### PR TITLE
Issue 35: add SPRUCE data

### DIFF
--- a/metadata-translation/src/bin/lib/nmdc_data_source.yaml
+++ b/metadata-translation/src/bin/lib/nmdc_data_source.yaml
@@ -151,7 +151,6 @@ classes:
       description: description
       part_of: [study_gold_id]
       has_input: [biosample_gold_id]
-      has_output: [output_file_ids]
     transforms:
       post:
         # note: attribute names must match names in nmdc.yaml
@@ -160,6 +159,7 @@ classes:
             - add_date
             - mod_date
     attributes:
+      - has_output: [output_file_ids]
       - add_date 
       - mod_date
       - completion_date 

--- a/metadata-translation/src/bin/lib/nmdc_dataframes.py
+++ b/metadata-translation/src/bin/lib/nmdc_dataframes.py
@@ -404,11 +404,11 @@ def make_project_dataframe(
         output_files.rename(columns={"file_id": "output_file_ids"}, inplace=True)
         output_files["output_file_ids"] = output_files["output_file_ids"].astype(str)
 
-        ## require output files for projects (i.e., inner join)
+        ## left join output files for projects
         temp2_df = pds.merge(
             temp2_df,
             output_files,
-            how="inner",
+            how="left",
             left_on="gold_id",
             right_on="gold_project_id",
         )

--- a/metadata-translation/src/bin/lib/transform_nmdc_data.py
+++ b/metadata-translation/src/bin/lib/transform_nmdc_data.py
@@ -788,7 +788,7 @@ def dataframe_to_dict(
 
         Args:
             nmdc_record (namedtuple): the records that holds the data
-            nmdc_class ([type]): the class tha the object will instantiate
+            nmdc_class ([type]): the class that the object will instantiate
 
         Returns:
             an object of the type specified by class_type

--- a/nmdc_runtime/lib/nmdc_data_source.yaml
+++ b/nmdc_runtime/lib/nmdc_data_source.yaml
@@ -151,7 +151,6 @@ classes:
       description: description
       part_of: [study_gold_id]
       has_input: [biosample_gold_id]
-      has_output: [output_file_ids]
     transforms:
       post:
         # note: attribute names must match names in nmdc.yaml
@@ -160,6 +159,7 @@ classes:
             - add_date
             - mod_date
     attributes:
+      - has_output: [output_file_ids]
       - add_date 
       - mod_date
       - completion_date 

--- a/nmdc_runtime/lib/nmdc_dataframes.py
+++ b/nmdc_runtime/lib/nmdc_dataframes.py
@@ -396,11 +396,11 @@ def make_project_dataframe(
         output_files.rename(columns={"file_id": "output_file_ids"}, inplace=True)
         output_files["output_file_ids"] = output_files["output_file_ids"].astype(str)
 
-        ## require output files for projects (i.e., inner join)
+        ## left join output files for projects
         temp2_df = pds.merge(
             temp2_df,
             output_files,
-            how="inner",
+            how="left",
             left_on="gold_id",
             right_on="gold_project_id",
         )

--- a/nmdc_runtime/lib/transform_nmdc_data.py
+++ b/nmdc_runtime/lib/transform_nmdc_data.py
@@ -780,7 +780,7 @@ def dataframe_to_dict(
 
         Args:
             nmdc_record (namedtuple): the records that holds the data
-            nmdc_class ([type]): the class tha the object will instantiate
+            nmdc_class ([type]): the class that the object will instantiate
 
         Returns:
             an object of the type specified by class_type


### PR DESCRIPTION
@dwinston @dehays  
I have made the necessary changes to include projects that don't have outputs. However, I am not confident in the counts.

In my gold dump, there are a total 889 projects. Of these:
- 168 have data objects as outputs.
- There are 123 projects in SPRUCE study

This leaves 598 projects in the exported data that do not have outputs and are not in the SPRUCE study. Do we still want to include those projects?
