### PR TITLE
Issue 44: fix ETL to use has minimum/maximum numeric value slots

### DIFF
--- a/metadata-translation/examples/biosample_test.json
+++ b/metadata-translation/examples/biosample_test.json
@@ -14,6 +14,9 @@
         "has_raw_value": "ENVO:01000017"
       },
       "type": "nmdc:Biosample",
+      "part_of": [
+        "gold:Gs0114663"
+      ],
       "collection_date": {
         "has_raw_value": "2014-09-23"
       },
@@ -47,10 +50,7 @@
       "location": "groundwater-surface water interaction zone in Washington, USA",
       "mod_date": "2021-06-17",
       "ncbi_taxonomy_name": "sediment metagenome",
-      "sample_collection_site": "sand microcosm",
-      "part of": [
-        "gold:Gs0114663"
-      ]
+      "sample_collection_site": "sand microcosm"
     },
     {
       "id": "gold:Gb0115218",
@@ -66,6 +66,9 @@
         "has_raw_value": "ENVO:01000017"
       },
       "type": "nmdc:Biosample",
+      "part_of": [
+        "gold:Gs0114663"
+      ],
       "collection_date": {
         "has_raw_value": "2014-11-25"
       },
@@ -99,10 +102,7 @@
       "location": "groundwater-surface water interaction zone in Washington, USA",
       "mod_date": "2021-06-17",
       "ncbi_taxonomy_name": "sediment metagenome",
-      "sample_collection_site": "sand microcosm",
-      "part of": [
-        "gold:Gs0114663"
-      ]
+      "sample_collection_site": "sand microcosm"
     },
     {
       "id": "gold:Gb0115219",
@@ -118,6 +118,9 @@
         "has_raw_value": "ENVO:01000017"
       },
       "type": "nmdc:Biosample",
+      "part_of": [
+        "gold:Gs0114663"
+      ],
       "collection_date": {
         "has_raw_value": "2014-04-30"
       },
@@ -151,10 +154,7 @@
       "location": "groundwater-surface water interaction zone in Washington, USA",
       "mod_date": "2021-06-17",
       "ncbi_taxonomy_name": "sediment metagenome",
-      "sample_collection_site": "sand microcosm",
-      "part of": [
-        "gold:Gs0114663"
-      ]
+      "sample_collection_site": "sand microcosm"
     }
   ]
 }

--- a/metadata-translation/examples/emsl_project_test.json
+++ b/metadata-translation/examples/emsl_project_test.json
@@ -10,13 +10,13 @@
       "has_output": [
         "emsl:output_446532"
       ],
-      "part_of": [
-        "gold:Gs0114675"
-      ],
       "instrument_name": "QExactP04",
       "omics_type": {
         "has_raw_value": "Proteomics"
       },
+      "part_of": [
+        "gold:Gs0114675"
+      ],
       "processing_institution": "Environmental Molecular Sciences Lab",
       "type": "nmdc:OmicsProcessing"
     },
@@ -30,13 +30,13 @@
       "has_output": [
         "emsl:output_446533"
       ],
-      "part_of": [
-        "gold:Gs0114675"
-      ],
       "instrument_name": "QExactP04",
       "omics_type": {
         "has_raw_value": "Proteomics"
       },
+      "part_of": [
+        "gold:Gs0114675"
+      ],
       "processing_institution": "Environmental Molecular Sciences Lab",
       "type": "nmdc:OmicsProcessing"
     },
@@ -50,13 +50,13 @@
       "has_output": [
         "emsl:output_446534"
       ],
-      "part_of": [
-        "gold:Gs0114675"
-      ],
       "instrument_name": "QExactP04",
       "omics_type": {
         "has_raw_value": "Proteomics"
       },
+      "part_of": [
+        "gold:Gs0114675"
+      ],
       "processing_institution": "Environmental Molecular Sciences Lab",
       "type": "nmdc:OmicsProcessing"
     }

--- a/metadata-translation/examples/gold_project_test.json
+++ b/metadata-translation/examples/gold_project_test.json
@@ -7,18 +7,18 @@
       "has_input": [
         "gold:Gb0115217"
       ],
+      "add_date": "2015-05-28",
+      "mod_date": "2021-06-15",
       "has_output": [
         "jgi:55d740280d8785342fcf7e39"
       ],
-      "part_of": [
-        "gold:Gs0114663"
-      ],
-      "add_date": "2015-05-28",
-      "mod_date": "2021-06-15",
       "ncbi_project_name": "Sand microcosm microbial communities from a hyporheic zone in Columbia River, Washington, USA - GW-RW T2_23-Sept-14",
       "omics_type": {
         "has_raw_value": "Metagenome"
       },
+      "part_of": [
+        "gold:Gs0114663"
+      ],
       "principal_investigator": {
         "has_raw_value": "James Stegen"
       },
@@ -32,18 +32,18 @@
       "has_input": [
         "gold:Gb0115218"
       ],
+      "add_date": "2015-05-28",
+      "mod_date": "2021-06-15",
       "has_output": [
         "jgi:55d817f20d8785342fcf826c"
       ],
-      "part_of": [
-        "gold:Gs0114663"
-      ],
-      "add_date": "2015-05-28",
-      "mod_date": "2021-06-15",
       "ncbi_project_name": "Sand microcosm microbial communities from a hyporheic zone in Columbia River, Washington, USA - GW-RW T2_25-Nov-14",
       "omics_type": {
         "has_raw_value": "Metagenome"
       },
+      "part_of": [
+        "gold:Gs0114663"
+      ],
       "principal_investigator": {
         "has_raw_value": "James Stegen"
       },
@@ -57,18 +57,18 @@
       "has_input": [
         "gold:Gb0115219"
       ],
+      "add_date": "2015-05-28",
+      "mod_date": "2021-06-15",
       "has_output": [
         "jgi:55f23d820d8785306f964980"
       ],
-      "part_of": [
-        "gold:Gs0114663"
-      ],
-      "add_date": "2015-05-28",
-      "mod_date": "2021-06-15",
       "ncbi_project_name": "Sand microcosm microbial communities from a hyporheic zone in Columbia River, Washington, USA - GW-RW T2_30-Apr-14",
       "omics_type": {
         "has_raw_value": "Metagenome"
       },
+      "part_of": [
+        "gold:Gs0114663"
+      ],
       "principal_investigator": {
         "has_raw_value": "James Stegen"
       },

--- a/metadata-translation/src/bin/lib/nmdc_data_source.yaml
+++ b/metadata-translation/src/bin/lib/nmdc_data_source.yaml
@@ -224,11 +224,13 @@ classes:
         has_raw_value: lat_lon
         $class_type: GeolocationValue
     transforms:
-      pre:
-        - function: test_pre_transform
-          attributes:
-            - test_attribute
+      # perform functions on dataframes prior to transform
+      # pre: 
+      #   - function: test_pre_transform
+      #     attributes:
+      #       - test_attribute
       post:
+        # perform opertations on transformed data
         # note: attribute names must match names in nmdc.yaml
         - function: make_quantity_value
           attributes:
@@ -240,6 +242,10 @@ classes:
           attributes:
             - add_date
             - mod_date
+        - function: merge_value_range_fields
+          attributes:
+            - depth
+            - depth2
     attributes:
       - part_of: [study_gold_id]
       - add_date
@@ -326,7 +332,6 @@ classes:
       - soil_water_content_soil_meth:
           has_raw_value: soil_water_content_soil_meth
       - soluble_iron_micromol
-      - subsurface_depth2
       - tot_nitrogen:
           has_raw_value: tot_nitrogen # mixs:tot_nitro_content
       - tot_org_carbon:

--- a/metadata-translation/src/bin/lib/transform_nmdc_data.py
+++ b/metadata-translation/src/bin/lib/transform_nmdc_data.py
@@ -5,6 +5,8 @@
 import os, sys, git_root
 from datetime import datetime
 
+from pandas.core.reshape.merge import merge
+
 sys.path.append(os.path.abspath("."))
 sys.path.append(os.path.abspath("./lib"))
 sys.path.append(git_root.git_root("./schema"))
@@ -863,18 +865,108 @@ def dataframe_to_dict(
     return nmdc_dicts
 
 
-def test_pre_transform(nmdc_df, tx_attributes, **kwargs):
+def test_pre_transform(nmdc_df: pds.DataFrame, tx_attributes: list, **kwargs):
     """
     Dummy function to test pre-transform declarations.
     """
-    print("*** test pre-transform ******")
+    print("*** test pre-transform ****")
     return nmdc_df
+
+
+def merge_value_range_fields(nmdc_objs: list, tx_attributes: list, **kwargs):
+    """
+    merge two value range fields
+    """
+
+    def has_range_fields(obj, field1, field2):
+        # check that keys exist
+        if type(obj) == type({}):
+            # check that keys have values
+            if field1 in obj.keys() and field2 in obj.keys():
+                # check if vals are None
+                if obj[field1] is not None and obj[field2] is not None:
+                    field_obj1 = obj[field1]
+                    field_obj2 = obj[field2]
+                    return (
+                        field_obj1["has_raw_value"] is not None
+                        and field_obj2["has_raw_value"]
+                    )
+            else:
+                return False
+        else:
+            # check that properties exist
+            if hasattr(obj, field1) and hasattr(obj, field2):
+                # get objects from fields and check if vals are None
+                field_obj1 = getattr(obj, field1)
+                field_obj2 = getattr(obj, field2)
+                return (
+                    getattr(field_obj1, "has_raw_value") is not None
+                    and getattr(field_obj2, "has_raw_value") is not None
+                )
+            else:
+                return False
+
+    def get_obj_field_values(obj, field1, field2):
+        if type(obj) == type({}):
+            return obj[field1], obj[field2]
+        else:
+            field_obj1 = getattr(obj, field1)
+            field_obj2 = getattr(obj, field2)
+            return getattr(field_obj1, "has_raw_value"), getattr(
+                field_obj2, "has_raw_value"
+            )
+
+    def format_val(val: str):
+        # if val is negative, put it in parens
+        return f"({val})" if val[0] == "-" else val
+
+    def add_min_max(obj, field, val1, val2):
+        # merge vals
+        merge_val = f"{format_val(val1)}-{format_val(val2)}"
+
+        if type(obj) == type({}):
+            pass
+        else:
+            # set value range and min/max numeric values
+            field_obj = getattr(obj, field)
+            setattr(field_obj, "has_raw_value", merge_val)  # e.g., {va1}-{val2}
+            setattr(field_obj, "has_minimum_numeric_value", float(val1))
+            setattr(field_obj, "has_maximum_numeric_value", float(val2))
+
+            # remove simple number value
+            if hasattr(field_obj, "has_numeric_value"):
+                delattr(field_obj, "has_numeric_value")
+
+        return obj
+
+    if len(tx_attributes) != 2:
+        raise Exception("This function only accepts two arguments.")
+
+    # get fields to be merged
+    field1 = tx_attributes[0]
+    field2 = tx_attributes[1]
+
+    for obj in nmdc_objs:
+        # test if fields exist
+        if has_range_fields(obj, field1, field2):
+            # get values from fields and merge
+            val1, val2 = get_obj_field_values(obj, field1, field2)
+
+            # modify obj's field1 to hold min/max ranges
+            obj = add_min_max(obj, field1, val1, val2)
+
+            # remove field2, no long needed
+            if type(obj) == type({}):
+                obj.pop(field2, None)
+            else:
+                delattr(obj, field2)
+
+    return nmdc_objs
 
 
 def make_quantity_value(nmdc_objs: list, tx_attributes: list, **kwargs) -> list:
     """
-    Takes each nmdc object (either a dict or class instance) and
-    and adds has_numeric_value and has_unit information.
+    Takes each nmdc object (either a dict or class instance) and adds has_numeric_value and has_unit information.
 
 
     Args:
@@ -890,7 +982,7 @@ def make_quantity_value(nmdc_objs: list, tx_attributes: list, **kwargs) -> list:
             if has_raw_value(obj, attribute):
 
                 val = getattr(obj, attribute)
-                # print("*** pre ***", val)
+                # print("*** pre make_quantity_value ***", val)
 
                 ## split raw value after first space
                 if type(val) == type({}):
@@ -917,7 +1009,7 @@ def make_quantity_value(nmdc_objs: list, tx_attributes: list, **kwargs) -> list:
                     else:
                         val.has_unit = value_list[1].strip()
 
-                # print("*** post ***", val)
+                # print("*** post make_quantity_value ***", val)
 
     return nmdc_objs
 


### PR DESCRIPTION
Fixes #44 

Modify code in `metadata-translation/src` directories. So far, things look good. Need to modify the dagaster operations in `nmdc_runtime/site/translation` next.