### PR TITLE
feat: readsqc-in trigger

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,7 +13,7 @@ Use <https://en.wikipedia.org/wiki/ISO_8601> to express the current date and tim
 time offset for New York on standard time (EST). "−08:00" would be for California.
 
 ## Release Log
-
+* 2022-09-27T14:42:00-04:00 readsqc-in trigger
 * 2022-09-27T16:05:00-04:00 fix api endpoint for outputs
 * 2022-09-11T16:04:00-04:00 fix api endpoint for outputs
 * 2022-09-11T16:03:00-04:00 add workflow and infrastructure components

--- a/components/workflow/workflow/core.py
+++ b/components/workflow/workflow/core.py
@@ -17,9 +17,7 @@ class DataObjectService:
     ) -> None:
         self.__queries = data_object_queries
 
-    async def create_data_object(
-        self, data_object: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    async def create_data_object(self, data_object: Dict[str, Any]) -> Dict[str, Any]:
         """A function to create a new workflow job
 
         :param data_object: Dict[str, Any] dictionary of fields for data object creation
@@ -44,9 +42,7 @@ class ReadsQCSequencingActivityService:
     ) -> None:
         self.__queries = activity_queries
 
-    async def create_mgs_activity(
-        self, mgs_activity: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    async def create_mgs_activity(self, mgs_activity: Dict[str, Any]) -> Dict[str, Any]:
         new_activity = ReadsQCSequencingActivity.parse_obj(mgs_activity)
         result = await self.__queries.create_activity(new_activity)
         return result.dict()

--- a/nmdc_runtime/api/boot/object_types.py
+++ b/nmdc_runtime/api/boot/object_types.py
@@ -57,6 +57,12 @@ _raw = [
         "name": "metadata changesheet",
         "description": "Specification for changes to existing metadata",
     },
+    {
+        "id": "readsqc-in",
+        "created_at": datetime(2022, 9, 27, tzinfo=timezone.utc),
+        "name": "metadata needed for Reads QC Workflow",
+        "description": "metadata, in the form of a nmdc:Database, needed for Reads QC Workflow",
+    },
 ]
 
 _raw.extend(

--- a/nmdc_runtime/api/boot/triggers.py
+++ b/nmdc_runtime/api/boot/triggers.py
@@ -43,6 +43,11 @@ _raw = [
         "object_type_id": "metadata-changesheet",
         "workflow_id": "apply-changesheet-1.0.0",
     },
+    {
+        "created_at": datetime(2022, 9, 27, tzinfo=timezone.utc),
+        "object_type_id": "readsqc-in",
+        "workflow_id": "readsqc-1.0.1",
+    },
 ]
 
 

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -273,14 +273,11 @@ async def ensure_initial_resources_on_boot():
     collections = ["workflows", "capabilities", "object_types", "triggers"]
     for collection_name in collections:
         mdb[collection_name].create_index("id", unique=True)
-        collection_boot = import_module(
-            f"nmdc_runtime.api.boot.{collection_name}"
-        )
+        collection_boot = import_module(f"nmdc_runtime.api.boot.{collection_name}")
+
         for model in collection_boot.construct():
             doc = model.dict()
-            mdb[collection_name].replace_one(
-                {"id": doc["id"]}, doc, upsert=True
-            )
+            mdb[collection_name].replace_one({"id": doc["id"]}, doc, upsert=True)
 
     username = os.getenv("API_ADMIN_USER")
     admin_ok = mdb.users.count_documents(({"username": username})) > 0
@@ -340,9 +337,7 @@ async def ensure_indexes():
                     "only supports basic single-key ascending index specs at this time."
                 )
 
-            mdb[collection_name].create_index(
-                [(spec, 1)], name=spec, background=True
-            )
+            mdb[collection_name].create_index([(spec, 1)], name=spec, background=True)
 
 
 @app.on_event("startup")

--- a/nmdc_runtime/api/v1/router.py
+++ b/nmdc_runtime/api/v1/router.py
@@ -3,8 +3,6 @@ from fastapi import APIRouter
 # from . import users
 from . import outputs
 
-router_v1 = APIRouter(
-    prefix="/v1", responses={404: {"description": "Not found"}}
-)
+router_v1 = APIRouter(prefix="/v1", responses={404: {"description": "Not found"}})
 
 router_v1.include_router(outputs.router)


### PR DESCRIPTION
addded entries to api.boot.{object_types,triggers}. also reformatted files using black defaults.

examples used for dev:
- [readsqc-in-example.json](https://gist.github.com/dwinston/05a176b69744a3dfc52a1c8b07590867)
- [readsqc-in-example-drsobject.json](https://gist.github.com/dwinston/fac2cc17af2a281a06870981e0d7e63d)