### PR TITLE
Clean up job adding service for activities

### DIFF
--- a/components/nmdc_runtime/workflow_execution_activity/spec.py
+++ b/components/nmdc_runtime/workflow_execution_activity/spec.py
@@ -1,19 +1,18 @@
 " " "Beans." ""
 from abc import ABC, abstractmethod
-from pydantic.dataclasses import dataclass
-from datetime import datetime
-from typing import Literal, Type
-from typing_extensions import TypedDict
 
+from components.nmdc_runtime.workflow.spec import Workflow
 from nmdc_schema.nmdc import (
-    DataObject,
-    DataObjectId,
     WorkflowExecutionActivity,
-    WorkflowExecutionActivityId,
     Database,
 )
-from pydantic import BaseModel, HttpUrl
-from typing_extensions import NotRequired
+from pydantic import BaseModel
+
+
+class ActivityTree(BaseModel):
+    children: list["ActivityTree"] = []
+    data: WorkflowExecutionActivity
+    spec: Workflow
 
 
 class ActivityQueriesABC(ABC):


### PR DESCRIPTION
Create jobs for correct workflows

Rewrote the `create_jobs` function to only create new workflows if they do not have an activity already associated with them in the incoming workflow execution activity sets. This method creates a mapping of nodes and their children and then iterates through them to see if their children account for all of the workflow execution activities that should have been created already. If something is missing a new job will be created for it.