### PR TITLE
Fix typo in `RELEASES.md`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
-When this file is changed and pushed to the `main` branch on Git1,
+When this file is changed and pushed to the `main` branch on GitHub,
 
-Hub. the Docker images for the API and Runtime are rebuild and pushed [via this GitHub
+1. the Docker images for the API and Runtime are rebuild and pushed [via this GitHub
    Action](https://github.com/microbiomedata/nmdc-runtime/blob/main/.github/workflows/build-and-push-docker-images.yml)), and
 
 2. if the previous action is successful, the deployment on NERSC Spin is refreshed ([via a GitHub


### PR DESCRIPTION
While reading `RELEASES.md`, I noticed the strings `Hub` and `1` were swapped from where I thought they belonged. I re-swapped them in this branch.

### Before:

![image](https://github.com/microbiomedata/nmdc-runtime/assets/134325062/41f1a528-3af2-4001-93b4-047db17aa617)

Source: https://github.com/microbiomedata/nmdc-runtime/blob/main/RELEASES.md

### After:

![image](https://github.com/microbiomedata/nmdc-runtime/assets/134325062/f389c842-a7b8-44b6-ae39-b23858266387)

Source: https://github.com/microbiomedata/nmdc-runtime/blob/fix/fix-typo-in-RELEASES.md/RELEASES.md