### PR TITLE
update changesheets documentation

### DIFF
--- a/docs/howto-guides/author-changesheets.md
+++ b/docs/howto-guides/author-changesheets.md
@@ -2,9 +2,18 @@
 
 ## Introduction
 
-Changesheets is a mechanism to perform CRUD, i.e., Create, Read, Update, Delete operations on the NMDC MongoDB database that is exposed via the [nmdc-runtime API](https://api.dev.microbiomedata.org/docs).
+Changesheets is a mechanism to update records (JSON documents) that have already been ingested into MongoDB. Meaning, you can *update* an already ingested document - you can *insert* new keys on a document, *delete/remove* certain keys on a document, or even update the value corresponding to a key in a document. But it is important to note that you cannot *create/delete* whole new JSON documents via changesheets.
 
-A changesheet, like the name tells us, is a sheet, more specifically, a TSV file with pre defined column names that a user can fill out appropriately and submit via the API.
+If you look at the changesheet workflow diagram below, you'll see that there are two main steps in the workflow - validation of the changesheet, and upon successful validation, submission of the changesheet.
+
+There are two endpoints in the NMDC runtime API infrastructure that you can use are:
+
+* validation: `/metadata/changesheets:validate`
+* submission: `/metadata/changesheets:submit`
+
+The Swagger UI, which is one of the ways in which you can interact with the suite of endpoints that the runtime API provides, and which also serves as the primary API documentation reference is accessible here: [https://api.microbiomedata.org/docs](https://api.microbiomedata.org/docs)
+
+Changesheets are typically specified as TSV files with pre-defined column names. There are four columns that need to be defined - *id*, *action*, *attribute* and *value*.
 
 ## Changesheet Workflow
 
@@ -12,30 +21,35 @@ The various steps that are involved in a typical changesheet workflow are as sum
 
 ```mermaid
 flowchart LR;
-    A[Create template changesheet] --> B[Fill changesheet];
+    A[Create changesheet template] --> B[Fill changesheet];
     B --> C[Validate changesheet];
     C --> D[Submit changesheet];
 ```
 
 1. The first step is to create a TSV file that follows the standard changesheet template. A changesheet has the following columns:
 
-    * `id`: The "id" field value of the JSON record in the database that is to be changed. It may be a biosample, study, project, etc.
-    * `action`: Action to be performed on the database. It may be one of the following: 
-        * `insert items`: Add new values to a multi-valued field of a particular record. Aliases: `insert`, `insert item`.
-        * `remove items`: Remove attributes from a particular record.  Aliases: `remove item`.
-        * `update`: Update field on a record with a new value. Aliases: `set`, `replace`, `replace items`.
-    * `attribute`: the field name of the NMDC JSON record that is to be modified. Reference: [NMDC JSON Schema](https://github.com/microbiomedata/nmdc-schema/blob/main/nmdc_schema/nmdc.schema.json).
+    * `id`: The *id* value corresponding to the *id* of every JSON document in the database. Specifying this will tell the changesheet what record in the database needs to be modified. There are no restrictions on the ids that can be modified. For example, tt can be a Biosample *id* (with typecode *bsm*), or a Study *id* (with typecode *sty*), and so forth.
+    * `action`: The action to be performed on the database. It may be one of the following: 
+        * `insert` / `insert item` / `insert items`: Add new values to a multivalued field, i.e., a field/key on a document which captures a list of values instead of single values.
+        * `remove item` / `remove items`: Remove attributes/keys on a document.
+        * `update` / `set` / `replace` / `replace items`: Update the value of a particular field/key on a document and replace it with a new value.
+    * `attribute`: the name of the field/key in the NMDC JSON document that is to be modified.
     * `value`: New value, which may be added (if it wasn't present already) to a multi-valued field for an `insert` action. For an `update` action, it will overwrite any current value.
 
 2. The second step is to fill our the columns in the above changesheet appropriately.
 
-    !!! note
-        For any property with some substructure, such as the [`doi`](https://microbiomedata.github.io/nmdc-schema/doi/) field, you can specify a symbolic name in the `value` column of the changesheet, say something like `v1`. Then you can specify a property on `v1`. For example, `doi` has a sub property called `has_raw_value` which can be specified in the `attribute` column of the changesheet, and then some value provided for that. [Example changesheet using symbolic names](https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/notebooks/data/changesheet-without-separator3.tsv).
+A couple of notes to keep in mind when you are modifying a key in your document, the value of which has some substructure to it:
 
-3. The third step is to use the validation endpoint from the nmdc-runtime API which you can find [here](https://api.dev.microbiomedata.org/docs#/metadata/validate_changesheet_metadata_changesheets_validate_post). Click on `Try it out`, and upload your TSV file. You should see a `200` successful response for proper validation.
+!!! info
+    If you are modifying/replacing the value of a key in a document which has a *dictionary* structure, and you want to modify individual keys/attributes in that dictionary, then changesheets employs a dot syntax to indicate those. For example, if you wanted to modify a field called [depth](https://microbiomedata.github.io/nmdc-schema/depth/) within the records in the `biosample_set` collection, and specifically the `has_numeric_value` portion that can be asserted on *depth* fields, then the `attribute` column would have a value like this `depth.has_numeric_value`. Another way in which you can rewrite the same syntax as above is by using symbolic names. Consider another field called [doi](https://microbiomedata.github.io/nmdc-schema/doi/) which is a key on documents in the `study_set` collection. You can specify a symbolic name in the `value` column of the changesheet, say something like `v1`. Then you can specify what attribute of the substructure you want to modify on another row for `v1` in the changesheet. Let's say you want to modify the `has_raw_value` component of the `doi`, then you would simply indicate `has_raw_value` in the *attribute* column of the changesheet (on the row corresponding to `v1`). You can find an example of a changesheet using symbolic names [here](https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/notebooks/data/changesheet-without-separator3.tsv).
 
-4. The fourth and final step in the protocol is to actually submit the changesheet using the submission endpoint from the nmdc-runtime API which you can find [here](https://api.dev.microbiomedata.org/docs#/metadata/submit_changesheet_metadata_changesheets_submit_post). For this, you must be logged in using your username/password (click on any lock icon) and authorized to submit changesheets. Click on `Try it out`, and upload your TSV file. Similar to the validation endpoint, you should see a `200` successful response on execution the request. For an example submission changesheet, see [here](https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/notebooks/data/changesheet-without-separator3.tsv).
+!!! info
+    If you are modifying/replacing the value of a key in a document which has a *list* structure, then specifying a single value in the *value* column of the changesheet will be interpreted as a single element list. If you wanted to replace it with a multi-element list, then you can specify the individual elements of that list value in a pipe (`|`) delimited fashion in the *value* column of the changesheet
+
+
+3. The third step is to use the validation endpoint from the runtime API which you can find [here](https://api.dev.microbiomedata.org/docs#/metadata/validate_changesheet_metadata_changesheets_validate_post). Click on *Try it out*, and upload your TSV file. You should see a `200` successful response for proper validation.
+
+4. The fourth and final step in the protocol is to actually submit the changesheet using the submission endpoint from the nmdc-runtime API which you can find [here](https://api.dev.microbiomedata.org/docs#/metadata/submit_changesheet_metadata_changesheets_submit_post). For this, you must be logged in using your username/password (click on any lock icon) and authorized to submit changesheets. Click on *Try it out*, and upload your TSV file. Similar to the validation endpoint, you should see a `200` successful response on execution the request. For an example submission changesheet, see [here](https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/notebooks/data/changesheet-without-separator3.tsv).
 
 !!! note
     The submission endpoint runs the validation endpoint prior to actually submitting the data.
-

--- a/docs/howto-guides/author-changesheets.md
+++ b/docs/howto-guides/author-changesheets.md
@@ -6,12 +6,12 @@ Changesheets is a mechanism to update records (JSON documents) that have already
 
 If you look at the changesheet workflow diagram below, you'll see that there are two main steps in the workflow - validation of the changesheet, and upon successful validation, submission of the changesheet.
 
-There are two endpoints in the NMDC runtime API infrastructure that you can use are:
+There are two endpoints in the NMDC runtime API infrastructure that you can use:
 
 * validation: `/metadata/changesheets:validate`
 * submission: `/metadata/changesheets:submit`
 
-The Swagger UI, which is one of the ways in which you can interact with the suite of endpoints that the runtime API provides, and which also serves as the primary API documentation reference is accessible here: [https://api.microbiomedata.org/docs](https://api.microbiomedata.org/docs)
+The Swagger UI, which is one of the ways in which you can interact with the suite of endpoints that the runtime API provides and which also serves as the primary API documentation reference, is accessible here: [https://api.microbiomedata.org/docs](https://api.microbiomedata.org/docs).
 
 Changesheets are typically specified as TSV files with pre-defined column names. There are four columns that need to be defined - *id*, *action*, *attribute* and *value*.
 
@@ -28,7 +28,7 @@ flowchart LR;
 
 1. The first step is to create a TSV file that follows the standard changesheet template. A changesheet has the following columns:
 
-    * `id`: The *id* value corresponding to the *id* of every JSON document in the database. Specifying this will tell the changesheet what record in the database needs to be modified. There are no restrictions on the ids that can be modified. For example, tt can be a Biosample *id* (with typecode *bsm*), or a Study *id* (with typecode *sty*), and so forth.
+    * `id`: The *id* value corresponding to the *id* of the JSON document in the database. Specifying this will tell the changesheet what record in the database needs to be modified. There are no restrictions on the ids that can be modified. For example, it can be a Biosample *id* (with typecode *bsm*), or a Study *id* (with typecode *sty*), or another class of *id*.
     * `action`: The action to be performed on the database. It may be one of the following: 
         * `insert` / `insert item` / `insert items`: Add new values to a multivalued field, i.e., a field/key on a document which captures a list of values instead of single values.
         * `remove item` / `remove items`: Remove attributes/keys on a document.
@@ -36,15 +36,13 @@ flowchart LR;
     * `attribute`: the name of the field/key in the NMDC JSON document that is to be modified.
     * `value`: New value, which may be added (if it wasn't present already) to a multi-valued field for an `insert` action. For an `update` action, it will overwrite any current value.
 
-2. The second step is to fill our the columns in the above changesheet appropriately.
+2. The second step is to fill out the rows of your changesheet appropriately as described above.
 
-A couple of notes to keep in mind when you are modifying a key in your document, the value of which has some substructure to it:
-
-!!! info
-    If you are modifying/replacing the value of a key in a document which has a *dictionary* structure, and you want to modify individual keys/attributes in that dictionary, then changesheets employs a dot syntax to indicate those. For example, if you wanted to modify a field called [depth](https://microbiomedata.github.io/nmdc-schema/depth/) within the records in the `biosample_set` collection, and specifically the `has_numeric_value` portion that can be asserted on *depth* fields, then the `attribute` column would have a value like this `depth.has_numeric_value`. Another way in which you can rewrite the same syntax as above is by using symbolic names. Consider another field called [doi](https://microbiomedata.github.io/nmdc-schema/doi/) which is a key on documents in the `study_set` collection. You can specify a symbolic name in the `value` column of the changesheet, say something like `v1`. Then you can specify what attribute of the substructure you want to modify on another row for `v1` in the changesheet. Let's say you want to modify the `has_raw_value` component of the `doi`, then you would simply indicate `has_raw_value` in the *attribute* column of the changesheet (on the row corresponding to `v1`). You can find an example of a changesheet using symbolic names [here](https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/notebooks/data/changesheet-without-separator3.tsv).
-
-!!! info
-    If you are modifying/replacing the value of a key in a document which has a *list* structure, then specifying a single value in the *value* column of the changesheet will be interpreted as a single element list. If you wanted to replace it with a multi-element list, then you can specify the individual elements of that list value in a pipe (`|`) delimited fashion in the *value* column of the changesheet
+    !!! note
+        A couple of notes to keep in mind when you are modifying a key in your document, the value of which has some substructure to it:
+    
+        * If you are modifying/replacing the value of a key in a document which has a *dictionary* structure, and you want to modify individual keys/attributes in that dictionary, then changesheets employs a dot syntax to indicate those. For example, if you wanted to modify a field called [depth](https://microbiomedata.github.io/nmdc-schema/depth/) within the records in the `biosample_set` collection, and specifically the `has_numeric_value` portion that can be asserted on *depth* fields, then the `attribute` column would have a value like this: `depth.has_numeric_value`. Another way in which you can rewrite the same syntax as above is by using symbolic names. Consider another field called [doi](https://microbiomedata.github.io/nmdc-schema/doi/) which is a key on documents in the `study_set` collection. You can specify a symbolic name in the `value` column of the changesheet, say something like `v1`. Then you can specify what attribute of the substructure you want to modify on another row for `v1` in the changesheet. Let's say you want to modify the `has_raw_value` component of the `doi`, then you would simply indicate `has_raw_value` in the *attribute* column of the changesheet (on the row corresponding to `v1`). You can find an example of a changesheet using symbolic names [here](https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/notebooks/data/changesheet-without-separator3.tsv).
+        * If you are modifying/replacing the value of a key in a document which has a *list* structure, then specifying a single value in the *value* column of the changesheet will be interpreted as a single element list. If you wanted to replace it with a multi-element list, then you can specify the individual elements of that list value in a pipe (`|`) delimited fashion in the *value* column of the changesheet
 
 
 3. The third step is to use the validation endpoint from the runtime API which you can find [here](https://api.dev.microbiomedata.org/docs#/metadata/validate_changesheet_metadata_changesheets_validate_post). Click on *Try it out*, and upload your TSV file. You should see a `200` successful response for proper validation.


### PR DESCRIPTION
Capture latest notes on how to update JSON document values that have substructure, i.e., lists, dicts, etc. using changesheets.