### PR TITLE
Switch to `mongo` image without replica set, for test stack

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -74,7 +74,7 @@ services:
       - .:/code
 
   mongo:
-    image: bitnami/mongodb:6.0.4
+    image: mongo:6.0.4
     container_name: mongo
     ports:
       - "27018:27017"
@@ -84,11 +84,8 @@ services:
       - ./tests/mongorestore-nmdc-testdb.sh:/mongorestore-nmdc-testdb.sh:ro
     restart: unless-stopped
     environment:
-      MONGODB_ROOT_USER: admin
-      MONGODB_ROOT_PASSWORD: root
-      MONGODB_REPLICA_SET_MODE: primary
-      MONGODB_ADVERTISED_HOSTNAME: mongodb-primary
-      MONGODB_REPLICA_SET_KEY: replicasetkey123
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: root
 
   test:
     build:


### PR DESCRIPTION
In this branch, I updated the Docker Compose file for the test stack, to use the `mongo` Docker image (instead of the Bitnami one), and to **not** configure the MongoDB server to run in replica set mode. This fixes an issue I ran into when running `$ make up-test`.

Closes #299 