### PR TITLE
fix: refresh minter.requesters collection on site creation

### DIFF
--- a/nmdc_runtime/api/endpoints/sites.py
+++ b/nmdc_runtime/api/endpoints/sites.py
@@ -40,6 +40,7 @@ from nmdc_runtime.api.models.site import (
 )
 from nmdc_runtime.api.models.user import get_current_active_user, User
 from nmdc_runtime.api.models.util import ListResponse, ListRequest
+from nmdc_runtime.minter.bootstrap import refresh_minter_requesters_from_sites
 
 router = APIRouter()
 
@@ -56,6 +57,7 @@ def create_site(
             detail=f"site with supplied id {site.id} already exists",
         )
     mdb.sites.insert_one(site.dict())
+    refresh_minter_requesters_from_sites()
     rv = mdb.users.update_one(
         {"username": user.username},
         {"$addToSet": {"site_admin": site.id}},

--- a/nmdc_runtime/minter/bootstrap.py
+++ b/nmdc_runtime/minter/bootstrap.py
@@ -16,6 +16,12 @@ def bootstrap():
             s.db["minter." + collection_name].replace_one(
                 {"id": d["id"]}, d, upsert=True
             )
+    refresh_minter_requesters_from_sites()
+
+
+def refresh_minter_requesters_from_sites():
+    mdb = config.get_mongo_db()
+    s = MongoIDStore(mdb)
     site_ids = [d["id"] for d in mdb.sites.find({}, {"id": 1})]
     for sid in site_ids:
         s.db["minter.requesters"].replace_one({"id": sid}, {"id": sid}, upsert=True)


### PR DESCRIPTION
The interface to modifying the sites collection is limited to a single endpoint, so I think it is fine to directly call a function to perform the operation.

I can envision moving to a more event-driven handler architecture once enough of these cases are present. I don't think it's worth the added complexity at this time.

fixes #317