### PR TITLE
Update `nmdc-schema` package from `9.0.4` to `9.1.0`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,7 @@ Use <https://en.wikipedia.org/wiki/ISO_8601> to express the current date and tim
 time offset for New York on standard time (EST). "−08:00" would be for California.
 
 ## Release Log
+* 2023-11-07T19:45:00-08:00 update nmdc-schema package from 9.0.4 to 9.1.0
 * 2023-11-07T19:30:00-08:00 update nmdc-schema package from 8.1.2 to 9.0.4
 * 2023-11-07T17:30:00-08:00 update nmdc-schema package from 8.0.0 to 8.1.2
 * (missing entries)

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -24,7 +24,7 @@ mkdocs-jupyter
 mkdocs-material
 mkdocs-mermaid2-plugin
 motor
-nmdc-schema==9.0.4
+nmdc-schema==9.1.0
 openpyxl
 pandas
 passlib[bcrypt]

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -452,7 +452,7 @@ nbformat==5.9.2
     #   nbconvert
 nest-asyncio==1.5.8
     # via ipykernel
-nmdc-schema==9.0.4
+nmdc-schema==9.1.0
     # via -r requirements/main.in
 notebook==7.0.6
     # via jupyter


### PR DESCRIPTION
There is no data migration associated with (or necessary for / written for) this schema change.