### PR TITLE
fix: include mongo-command writeErrors for http response code

### DIFF
--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -733,7 +733,10 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
     for result in results_of_updates:
         if len(result.get("validation_errors", [])) > 0:
             validation_errors.append(result["validation_errors"])
-        if len(write_errors := result.get("update_info", {}).get("writeErrors")) > 0:
+        if (
+            len(write_errors := result.get("update_info", {}).get("writeErrors", {}))
+            > 0
+        ):
             validation_errors.append(write_errors)
 
     if validation_errors:

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -733,6 +733,8 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
     for result in results_of_updates:
         if len(result.get("validation_errors", [])) > 0:
             validation_errors.append(result["validation_errors"])
+        if len(write_errors := result.get("update_info", {}).get("writeErrors")) > 0:
+            validation_errors.append(write_errors)
 
     if validation_errors:
         raise HTTPException(


### PR DESCRIPTION
 include mongo-command update_info writeErrors when determining HTTP response code

fixes #326