### PR TITLE
Updates to submission portal-to-Mongo pipeline to support GLBRC data

### DIFF
--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -140,14 +140,24 @@ def translate_metadata_submission_to_nmdc_schema_database():
         submission_id,
         omics_processing_mapping_file_url,
         data_object_mapping_file_url,
+        biosample_extras_file_url,
+        biosample_extras_slot_mapping_file_url,
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
     omics_processing_mapping = get_csv_rows_from_url(omics_processing_mapping_file_url)
     data_object_mapping = get_csv_rows_from_url(data_object_mapping_file_url)
+    biosample_extras = get_csv_rows_from_url(biosample_extras_file_url)
+    biosample_extras_slot_mapping = get_csv_rows_from_url(
+        biosample_extras_slot_mapping_file_url
+    )
 
     database = translate_portal_submission_to_nmdc_schema_database(
-        metadata_submission, omics_processing_mapping, data_object_mapping
+        metadata_submission,
+        omics_processing_mapping,
+        data_object_mapping,
+        biosample_extras=biosample_extras,
+        biosample_extras_slot_mapping=biosample_extras_slot_mapping,
     )
 
     validate_metadata(database)
@@ -164,14 +174,24 @@ def ingest_metadata_submission():
         submission_id,
         omics_processing_mapping_file_url,
         data_object_mapping_file_url,
+        biosample_extras_file_url,
+        biosample_extras_slot_mapping_file_url,
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
     omics_processing_mapping = get_csv_rows_from_url(omics_processing_mapping_file_url)
     data_object_mapping = get_csv_rows_from_url(data_object_mapping_file_url)
+    biosample_extras = get_csv_rows_from_url(biosample_extras_file_url)
+    biosample_extras_slot_mapping = get_csv_rows_from_url(
+        biosample_extras_slot_mapping_file_url
+    )
 
     database = translate_portal_submission_to_nmdc_schema_database(
-        metadata_submission, omics_processing_mapping, data_object_mapping
+        metadata_submission,
+        omics_processing_mapping,
+        data_object_mapping,
+        biosample_extras=biosample_extras,
+        biosample_extras_slot_mapping=biosample_extras_slot_mapping,
     )
     run_id = submit_metadata_to_db(database)
     poll_for_run_completion(run_id)

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -643,24 +643,27 @@ def nmdc_schema_database_from_gold_study(
 
 
 @op(
-    config_schema={
-        "submission_id": str,
-        "omics_processing_mapping_file_url": str,
-        "data_object_mapping_file_url": str,
-    },
     out={
         "submission_id": Out(),
-        "omics_processing_mapping_file_url": Out(),
-        "data_object_mapping_file_url": Out(),
+        "omics_processing_mapping_file_url": Out(Optional[str]),
+        "data_object_mapping_file_url": Out(Optional[str]),
+        "biosample_extras_file_url": Out(Optional[str]),
+        "biosample_extras_slot_mapping_file_url": Out(Optional[str]),
     },
 )
 def get_submission_portal_pipeline_inputs(
-    context: OpExecutionContext,
-) -> Tuple[str, str, str]:
+    submission_id: str,
+    omics_processing_mapping_file_url: Optional[str],
+    data_object_mapping_file_url: Optional[str],
+    biosample_extras_file_url: Optional[str],
+    biosample_extras_slot_mapping_file_url: Optional[str],
+) -> Tuple[str, str | None, str | None, str | None, str | None]:
     return (
-        context.op_config["submission_id"],
-        context.op_config["omics_processing_mapping_file_url"],
-        context.op_config["data_object_mapping_file_url"],
+        submission_id,
+        omics_processing_mapping_file_url,
+        data_object_mapping_file_url,
+        biosample_extras_file_url,
+        biosample_extras_slot_mapping_file_url,
     )
 
 
@@ -685,6 +688,8 @@ def translate_portal_submission_to_nmdc_schema_database(
     study_doi_provider: Optional[str],
     study_funding_sources: Optional[List[str]],
     study_pi_image_url: Optional[str],
+    biosample_extras: Optional[list[dict]],
+    biosample_extras_slot_mapping: Optional[list[dict]],
 ) -> nmdc.Database:
     client: RuntimeApiSiteClient = context.resources.runtime_api_site_client
 
@@ -702,6 +707,8 @@ def translate_portal_submission_to_nmdc_schema_database(
         study_doi_provider=study_doi_provider,
         study_funding_sources=study_funding_sources,
         study_pi_image_url=study_pi_image_url,
+        biosample_extras=biosample_extras,
+        biosample_extras_slot_mapping=biosample_extras_slot_mapping,
     )
     database = translator.get_database()
     return database
@@ -819,7 +826,7 @@ def nmdc_schema_database_export_filename_neon() -> str:
 
 
 @op
-def get_csv_rows_from_url(url: str) -> List[Dict]:
+def get_csv_rows_from_url(url: Optional[str]) -> List[Dict]:
     """Download and parse a CSV file from a remote URL.
 
     This method fetches data from the given URL and parses that data as CSV. The parsed data

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -680,6 +680,11 @@ def translate_portal_submission_to_nmdc_schema_database(
     metadata_submission: Dict[str, Any],
     omics_processing_mapping: List,
     data_object_mapping: List,
+    study_category: Optional[str],
+    study_doi_category: Optional[str],
+    study_doi_provider: Optional[str],
+    study_funding_sources: Optional[List[str]],
+    study_pi_image_url: Optional[str],
 ) -> nmdc.Database:
     client: RuntimeApiSiteClient = context.resources.runtime_api_site_client
 
@@ -692,6 +697,11 @@ def translate_portal_submission_to_nmdc_schema_database(
         omics_processing_mapping,
         data_object_mapping,
         id_minter=id_minter,
+        study_category=study_category,
+        study_doi_category=study_doi_category,
+        study_doi_provider=study_doi_provider,
+        study_funding_sources=study_funding_sources,
+        study_pi_image_url=study_pi_image_url,
     )
     database = translator.get_database()
     return database

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -525,6 +525,15 @@ def biosample_submission_ingest():
                             "data_object_mapping_file_url": "",
                         }
                     },
+                    "translate_portal_submission_to_nmdc_schema_database": {
+                        "inputs": {
+                            "study_category": None,
+                            "study_doi_category": None,
+                            "study_doi_provider": None,
+                            "study_funding_sources": None,
+                            "study_pi_image_url": None,
+                        }
+                    }
                 },
             },
         ),
@@ -553,6 +562,15 @@ def biosample_submission_ingest():
                             "data_object_mapping_file_url": "",
                         }
                     },
+                    "translate_portal_submission_to_nmdc_schema_database": {
+                        "inputs": {
+                            "study_category": None,
+                            "study_doi_category": None,
+                            "study_doi_provider": None,
+                            "study_funding_sources": None,
+                            "study_pi_image_url": None,
+                        }
+                    }
                 },
             },
         ),

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -519,10 +519,12 @@ def biosample_submission_ingest():
                 "ops": {
                     "export_json_to_drs": {"config": {"username": "..."}},
                     "get_submission_portal_pipeline_inputs": {
-                        "config": {
+                        "inputs": {
                             "submission_id": "",
-                            "omics_processing_mapping_file_url": "",
-                            "data_object_mapping_file_url": "",
+                            "omics_processing_mapping_file_url": None,
+                            "data_object_mapping_file_url": None,
+                            "biosample_extras_file_url": None,
+                            "biosample_extras_slot_mapping_file_url": None,
                         }
                     },
                     "translate_portal_submission_to_nmdc_schema_database": {
@@ -533,7 +535,7 @@ def biosample_submission_ingest():
                             "study_funding_sources": None,
                             "study_pi_image_url": None,
                         }
-                    }
+                    },
                 },
             },
         ),
@@ -556,10 +558,12 @@ def biosample_submission_ingest():
                 ),
                 "ops": {
                     "get_submission_portal_pipeline_inputs": {
-                        "config": {
+                        "inputs": {
                             "submission_id": "",
-                            "omics_processing_mapping_file_url": "",
-                            "data_object_mapping_file_url": "",
+                            "omics_processing_mapping_file_url": None,
+                            "data_object_mapping_file_url": None,
+                            "biosample_extras_file_url": None,
+                            "biosample_extras_slot_mapping_file_url": None,
                         }
                     },
                     "translate_portal_submission_to_nmdc_schema_database": {
@@ -570,7 +574,7 @@ def biosample_submission_ingest():
                             "study_funding_sources": None,
                             "study_pi_image_url": None,
                         }
-                    }
+                    },
                 },
             },
         ),

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -36,7 +36,8 @@ class SubmissionPortalTranslator(Translator):
         omics_processing_mapping: Optional[list] = None,
         data_object_mapping: Optional[list] = None,
         *args,
-        study_dataset_doi_provider: Optional[str] = None,
+        study_doi_category: Optional[str] = None,
+        study_doi_provider: Optional[str] = None,
         study_category: Optional[str] = None,
         study_pi_image_url: Optional[str] = None,
         study_funding_sources: Optional[list[str]] = None,
@@ -48,10 +49,13 @@ class SubmissionPortalTranslator(Translator):
         self.omics_processing_mapping = omics_processing_mapping
         self.data_object_mapping = data_object_mapping
 
-        self.study_dataset_doi_provider = (
-            nmdc.DoiProviderEnum(study_dataset_doi_provider)
-            if study_dataset_doi_provider
-            else None
+        self.study_doi_category = (
+            nmdc.DoiCategoryEnum(study_doi_category)
+            if study_doi_category
+            else nmdc.DoiCategoryEnum.dataset_doi
+        )
+        self.study_doi_provider = (
+            nmdc.DoiProviderEnum(study_doi_provider) if study_doi_provider else None
         )
         self.study_category = (
             nmdc.StudyCategoryEnum(study_category) if study_category else None
@@ -93,8 +97,8 @@ class SubmissionPortalTranslator(Translator):
         return [
             nmdc.Doi(
                 doi_value=dataset_doi,
-                doi_provider=self.study_dataset_doi_provider,
-                doi_category=nmdc.DoiCategoryEnum.dataset_doi,
+                doi_provider=self.study_doi_provider,
+                doi_category=self.study_doi_category,
             )
         ]
 

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -94,6 +94,9 @@ class SubmissionPortalTranslator(Translator):
         if not dataset_doi:
             return None
 
+        if not dataset_doi.startswith('doi:'):
+            dataset_doi = f"doi:{dataset_doi}"
+
         return [
             nmdc.Doi(
                 doi_value=dataset_doi,
@@ -457,7 +460,7 @@ class SubmissionPortalTranslator(Translator):
         slots = {
             "id": nmdc_biosample_id,
             "part_of": nmdc_study_id,
-            "name": sample_data[0].get("samp_name"),
+            "name": sample_data[0].get("samp_name").strip(),
         }
         for tab in sample_data:
             transformed_tab = self._transform_dict_for_class(tab, "Biosample")

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -21,6 +21,34 @@ def _get_schema_view():
     )
 
 
+def group_dicts_by_key(key: str, seq: Optional[list[dict]]) -> Optional[dict]:
+    """Transform a sequence of dicts into a single dict based on values of `key` in each dict.
+
+    Unlike toolz.groupby: 1) this method only applies to sequences of dicts, 2) it only keeps one
+    value for each key, 3) it removes the key from the original dict.
+
+    Example:
+        >>> seq = [{'a': 'one', 'b': 1}, {'a': 'two', 'b': 2}, {'a': 'two', 'b': 3}]
+        >>> group_dicts_by_key('a', seq)
+        {'one': {'b': 1}, 'two': {'b': 3}}
+    """
+    if seq is None:
+        return None
+
+    grouped = {}
+    for idx, item in enumerate(seq):
+        key_value = item.pop(key)
+        if not key_value:
+            logging.warning(f"No key value found in index {idx}")
+            continue
+        if key_value in grouped:
+            logging.warning(
+                f"Duplicate key value {key_value}. Previous value will be overwritten."
+            )
+        grouped[key_value] = item
+    return grouped
+
+
 class SubmissionPortalTranslator(Translator):
     """A Translator subclass for handling submission portal entries
 
@@ -36,11 +64,18 @@ class SubmissionPortalTranslator(Translator):
         omics_processing_mapping: Optional[list] = None,
         data_object_mapping: Optional[list] = None,
         *args,
+        # Additional study-level metadata not captured by the submission portal currently
+        # See: https://github.com/microbiomedata/submission-schema/issues/162
         study_doi_category: Optional[str] = None,
         study_doi_provider: Optional[str] = None,
         study_category: Optional[str] = None,
         study_pi_image_url: Optional[str] = None,
         study_funding_sources: Optional[list[str]] = None,
+        # Additional biosample-level metadata with optional column mapping information not captured
+        # by the submission portal currently.
+        # See: https://github.com/microbiomedata/submission-schema/issues/162
+        biosample_extras: Optional[list[dict]] = None,
+        biosample_extras_slot_mapping: Optional[list[dict]] = None,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -62,6 +97,11 @@ class SubmissionPortalTranslator(Translator):
         )
         self.study_pi_image_url = study_pi_image_url
         self.study_funding_sources = study_funding_sources
+
+        self.biosample_extras = group_dicts_by_key("source_mat_id", biosample_extras)
+        self.biosample_extras_slot_mapping = group_dicts_by_key(
+            "subject_id", biosample_extras_slot_mapping
+        )
 
         self.schema_view: SchemaView = _get_schema_view()
 
@@ -94,7 +134,7 @@ class SubmissionPortalTranslator(Translator):
         if not dataset_doi:
             return None
 
-        if not dataset_doi.startswith('doi:'):
+        if not dataset_doi.startswith("doi:"):
             dataset_doi = f"doi:{dataset_doi}"
 
         return [
@@ -383,12 +423,14 @@ class SubmissionPortalTranslator(Translator):
             ),
         )
 
-    def _transform_value_for_slot(self, value: Any, slot: SlotDefinition):
+    def _transform_value_for_slot(
+        self, value: Any, slot: SlotDefinition, unit: Optional[str] = None
+    ):
         transformed_value = None
         if slot.range == "TextValue":
             transformed_value = nmdc.TextValue(has_raw_value=value)
         elif slot.range == "QuantityValue":
-            transformed_value = self._get_quantity_value(value)
+            transformed_value = self._get_quantity_value(value, unit=unit)
         elif slot.range == "ControlledIdentifiedTermValue":
             transformed_value = self._get_controlled_identified_term_value(value)
         elif slot.range == "ControlledTermValue":
@@ -406,7 +448,9 @@ class SubmissionPortalTranslator(Translator):
 
         return transformed_value
 
-    def _transform_dict_for_class(self, raw_values: dict, class_name: str) -> dict:
+    def _transform_dict_for_class(
+        self, raw_values: dict, class_name: str, slot_mappings: Optional[dict] = None
+    ) -> dict:
         """Transform a dict of values according to class slots.
 
         raw_values is a dict where the keys are slot names and the values are plain strings.
@@ -414,29 +458,44 @@ class SubmissionPortalTranslator(Translator):
         method. If the slot is multivalued each individual value will be transformed. If the
         slot is multivalued and the value is a string it will be split at pipe characters
         before transforming.
+
+        If slot_mappings is provided it should be a dict where each key is a potential non-NMDC
+        column name and corresponding value is a dict with keys for `object_id` (representing
+        the NMDC slot being mapped to; the name `object_id` is to overlap with the SSSOM standard
+        https://github.com/mapping-commons/sssom) and for `subject_unit` (useful for when the column
+        maps to a QuantityValue slot and the source metadata itself does not include the unit)
         """
         slot_names = self.schema_view.class_slots(class_name)
         transformed_values = {}
         for column, value in raw_values.items():
-            if column not in slot_names:
-                logging.warning(f"No slot '{column}' on class '{class_name}'")
+            slot_name = column
+            unit = None
+            if slot_mappings and column in slot_mappings:
+                mapped_column_name = slot_mappings[column].get("object_id")
+                if mapped_column_name and mapped_column_name.startswith("nmdc:"):
+                    slot_name = mapped_column_name.replace("nmdc:", "")
+
+                unit = slot_mappings[column].get("subject_unit")
+
+            if slot_name not in slot_names:
+                logging.warning(f"No slot '{slot_name}' on class '{class_name}'")
                 continue
 
-            slot_definition = self.schema_view.induced_slot(column, class_name)
+            slot_definition = self.schema_view.induced_slot(slot_name, class_name)
             if slot_definition.multivalued:
                 value_list = value
                 if isinstance(value, str):
                     value_list = [v.strip() for v in value.split("|")]
                 transformed_value = [
-                    self._transform_value_for_slot(item, slot_definition)
+                    self._transform_value_for_slot(item, slot_definition, unit)
                     for item in value_list
                 ]
             else:
                 transformed_value = self._transform_value_for_slot(
-                    value, slot_definition
+                    value, slot_definition, unit
                 )
 
-            transformed_values[column] = transformed_value
+            transformed_values[slot_name] = transformed_value
         return transformed_values
 
     def _translate_biosample(
@@ -457,14 +516,23 @@ class SubmissionPortalTranslator(Translator):
         :param nmdc_study_id: Minted nmdc:Study identifier for the related Study
         :return: nmdc:Biosample
         """
+        source_mat_id = sample_data[0].get("source_mat_id", "").strip()
         slots = {
             "id": nmdc_biosample_id,
             "part_of": nmdc_study_id,
-            "name": sample_data[0].get("samp_name").strip(),
+            "name": sample_data[0].get("samp_name", "").strip(),
         }
         for tab in sample_data:
             transformed_tab = self._transform_dict_for_class(tab, "Biosample")
             slots.update(transformed_tab)
+
+        if self.biosample_extras:
+            raw_extras = self.biosample_extras.get(source_mat_id)
+            if raw_extras:
+                transformed_extras = self._transform_dict_for_class(
+                    raw_extras, "Biosample", self.biosample_extras_slot_mapping
+                )
+                slots.update(transformed_extras)
 
         return nmdc.Biosample(**slots)
 
@@ -472,7 +540,7 @@ class SubmissionPortalTranslator(Translator):
         """Translate the submission portal entry to an nmdc:Database
 
         This method translates the submission portal entry into one nmdc:Study and a set
-        of nmdc:Biosample objects. THese are wrapped into an nmdc:Database. NMDC identifiers
+        of nmdc:Biosample objects. These are wrapped into an nmdc:Database. NMDC identifiers
         are minted for each new object.
 
         :return: nmdc:Database object

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -65,14 +65,16 @@ def test_get_doi():
     doi = translator._get_doi({"contextForm": {}})
     assert doi is None
 
-    translator = SubmissionPortalTranslator(study_dataset_doi_provider="kbase")
+    translator = SubmissionPortalTranslator(
+        study_doi_provider="kbase", study_doi_category="award_doi"
+    )
     doi = translator._get_doi({"contextForm": {"datasetDoi": "5678"}})
     assert doi is not None
     assert doi == [
         nmdc.Doi(
             doi_value="5678",
             doi_provider=nmdc.DoiProviderEnum.kbase,
-            doi_category=nmdc.DoiCategoryEnum.dataset_doi,
+            doi_category=nmdc.DoiCategoryEnum.award_doi,
         )
     ]
 
@@ -301,7 +303,7 @@ def test_get_dataset(test_minter, monkeypatch):
                 **test_data["input"],
                 id_minter=test_minter,
                 study_category="research_study",
-                study_dataset_doi_provider="jgi",
+                study_doi_provider="jgi",
                 study_funding_sources=["Some award ABC", "Another award XYZ"]
             )
 

--- a/tests/test_data/test_submission_portal_translator_data.yaml
+++ b/tests/test_data/test_submission_portal_translator_data.yaml
@@ -810,8 +810,14 @@ output:
       orcid: 0000-0002-7189-3067
       email: shade.ashley@gmail.com
       name: Ashley Shade
-    dataset_dois:
-    - doi:10.46936/10.25585/60000818
+    associated_dois:
+    - doi_value: doi:10.46936/10.25585/60000818
+      doi_provider: jgi
+      doi_category: dataset_doi
+    funding_sources:
+      - Some award ABC
+      - Another award XYZ
+    study_category: research_study
     title: Seasonal activities of the phyllosphere microbiome of perennial crops
     websites:
     - https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9950430/
@@ -974,8 +980,13 @@ output:
     - id: nmdc:sty-00-y0cq65zt
       name: A test submission
       description: This is a test submission
-      dataset_dois:
-        - doi:10.12345/10.12345/00000000
+      associated_dois:
+        - doi_value: doi:10.12345/10.12345/00000000
+          doi_provider: jgi
+          doi_category: dataset_doi
+      funding_sources:
+        - Some award ABC
+        - Another award XYZ
       has_credit_associations:
         - applies_to_person:
             orcid: 0000-0000-0000-0000
@@ -986,6 +997,7 @@ output:
         orcid: 0000-0000-0000-0000
         email: test.testerson@example.com
         name: Test Testerson
+      study_category: research_study
       title: A test submission
       websites:
         - http://www.example.com/submission-test


### PR DESCRIPTION
Re: https://github.com/microbiomedata/submission-schema/issues/162

These changes are all around support for bringing data from a GLBRC submission into Mongo. Summary of changes:

* In the latest version of the schema `dataset_dois` has been replaced by `associated_dois` on the `Study` class. The range of `associated_dois` is a `Doi` class which has two required slots and one conditionally required slot. These changes update the `SubmissionPortalTranslator` to adhere to that. However since the submission portal does not yet collect some of the newly required information, it is being piped in via Dagster `op` inputs instead. So, _for now_ the person running this pipeline will be responsible for filling in these values. 
* Similarly, `study_category` is now required on the `Study` class, but has no corresponding form field in the submission portal. These changes allow passing it in while running the pipeline.
* The study/PI image and study funding sources aren't new or updated in the schema. This is just something that has been overlooked by the submission portal for a while. Again, allowing those to be injected into the pipeline run.
* The GLBRC has provided data that's split between _two_ environment packages. That means they can't input it all in the submission portal. But it all ends up on `Biosample` in Mongo anyway. So these changes allow for injecting extra `Biosample` data via a remote CSV file along with a file mapping their column headers to NMDC slot names along with units.