### PR TITLE
Misc. updates to `gold_translator.py`

### DIFF
--- a/nmdc_runtime/site/translation/gold_translator.py
+++ b/nmdc_runtime/site/translation/gold_translator.py
@@ -1,6 +1,6 @@
 import collections
 import re
-from typing import List, Union
+from typing import List, Tuple, Union
 from nmdc_schema import nmdc
 
 from nmdc_runtime.site.translation.translator import JSON_OBJECT, Translator
@@ -188,20 +188,19 @@ class GoldStudyTranslator(Translator):
     def _get_quantity_value(
         self,
         gold_entity: JSON_OBJECT,
-        gold_field: str,
+        gold_field: Union[str, Tuple[str, str]],
         unit: Union[str, None] = None,
     ) -> Union[nmdc.QuantityValue, None]:
         """Get any field of a GOLD entity object as a QuantityValue
 
         This method extracts any single field of a GOLD entity object (study, biosample, etc)
         and if it is not `None` returns it as an `nmdc:QuantityValue`. A has_numeric_value will
-        be inferred from the gold_field value in gold_entity. The inference is done only if the
-        unit is meters. Support for other units will be added incrementally. A unit can optionally
-        be provided, otherwise the unit will be `None`. If the value of the field is `None`,
-        `None` will be returned.
+        be inferred from the gold_field value in gold_entity if it is a simple string value. If
+        it is a tuple of two fields, a has_minimum_numeric_value and has_maximum_numeric_value
+        will be inferred from the gold_field values in gold_entity.
 
         :param gold_entity: GOLD entity object
-        :param gold_field: Name of the field to extract
+        :param gold_field: Name of the field to extract, or a tuple of two fields to extract a range
         :param unit: An optional unit as a string, defaults to None
         :return: QuantityValue object
         """
@@ -209,29 +208,28 @@ class GoldStudyTranslator(Translator):
         if field_value is None:
             return None
 
-        numeric_value = None
-        has_minimum_numeric_value = None
-        has_maximum_numeric_value = None
+        if isinstance(gold_field, tuple):
+            minimum_numeric_value = gold_entity.get(gold_field[0])
+            maximum_numeric_value = gold_entity.get(gold_field[1])
 
-        # TODO: in the future we will need better handling
-        # to parse out the numerical portion of the quantity value
-        # ex. temp might be 3 C, and we will need to parse out 3.0 from it
-        if unit == "meters":
-            numeric_value = nmdc.Double(field_value)
-            
-            has_maximum_numeric_value = gold_entity.get("depthInMeters2")
-            if has_maximum_numeric_value is not None:
-                has_minimum_numeric_value = nmdc.Double(field_value)
-
+            if minimum_numeric_value is None and maximum_numeric_value is None:
+                return None
+            elif minimum_numeric_value is not None and maximum_numeric_value is None:
                 return nmdc.QuantityValue(
-                    has_minimum_numeric_value=has_minimum_numeric_value,
-                    has_maximum_numeric_value=has_maximum_numeric_value,
+                    has_raw_value=field_value,
+                    has_numeric_value=nmdc.Double(minimum_numeric_value),
+                    has_unit=unit,
+                )
+            else:
+                return nmdc.QuantityValue(
+                    has_minimum_numeric_value=nmdc.Double(minimum_numeric_value),
+                    has_maximum_numeric_value=nmdc.Double(maximum_numeric_value),
                     has_unit=unit,
                 )
 
         return nmdc.QuantityValue(
             has_raw_value=field_value,
-            has_numeric_value=numeric_value,
+            has_numeric_value=nmdc.Double(field_value),
             has_unit=unit,
         )
 
@@ -440,7 +438,7 @@ class GoldStudyTranslator(Translator):
             collected_from=nmdc_field_site_id,
             collection_date=self._get_collection_date(gold_biosample),
             depth=self._get_quantity_value(
-                gold_biosample, "depthInMeters", unit="meters"
+                gold_biosample, ("depthInMeters", "depthInMeters2"), unit="meters"
             ),
             description=gold_biosample.get("description"),
             diss_oxygen=self._get_quantity_value(gold_biosample, "oxygenConcentration"),

--- a/nmdc_runtime/site/translation/gold_translator.py
+++ b/nmdc_runtime/site/translation/gold_translator.py
@@ -210,11 +210,24 @@ class GoldStudyTranslator(Translator):
             return None
 
         numeric_value = None
+        has_minimum_numeric_value = None
+        has_maximum_numeric_value = None
+
         # TODO: in the future we will need better handling
         # to parse out the numerical portion of the quantity value
         # ex. temp might be 3 C, and we will need to parse out 3.0 from it
         if unit == "meters":
             numeric_value = nmdc.Double(field_value)
+            
+            has_maximum_numeric_value = gold_entity.get("depthInMeters2")
+            if has_maximum_numeric_value is not None:
+                has_minimum_numeric_value = nmdc.Double(field_value)
+
+                return nmdc.QuantityValue(
+                    has_minimum_numeric_value=has_minimum_numeric_value,
+                    has_maximum_numeric_value=has_maximum_numeric_value,
+                    has_unit=unit,
+                )
 
         return nmdc.QuantityValue(
             has_raw_value=field_value,
@@ -390,7 +403,7 @@ class GoldStudyTranslator(Translator):
         """
         return nmdc.Study(
             description=gold_study.get("description"),
-            gold_study_identifiers=self._get_curie("GOLD", gold_study["studyGoldId"]),
+            gold_study_identifiers=self._get_curie("gold", gold_study["studyGoldId"]),
             id=nmdc_study_id,
             name=gold_study.get("studyName"),
             principal_investigator=self._get_pi(gold_study),
@@ -440,7 +453,7 @@ class GoldStudyTranslator(Translator):
             env_local_scale=self._get_env_term_value(gold_biosample, "envoLocalScale"),
             env_medium=self._get_env_term_value(gold_biosample, "envoMedium"),
             geo_loc_name=self._get_text_value(gold_biosample, "geoLocation"),
-            gold_biosample_identifiers=self._get_curie("GOLD", gold_biosample_id),
+            gold_biosample_identifiers=self._get_curie("gold", gold_biosample_id),
             habitat=gold_biosample.get("habitat"),
             host_name=gold_biosample.get("hostName"),
             host_taxid=self._get_text_value(gold_biosample, "hostNcbiTaxid"),
@@ -498,7 +511,7 @@ class GoldStudyTranslator(Translator):
             id=nmdc_omics_processing_id,
             name=gold_project.get("projectName"),
             gold_sequencing_project_identifiers=self._get_curie(
-                "GOLD", gold_project_id
+                "gold", gold_project_id
             ),
             ncbi_project_name=gold_project.get("projectName"),
             type="nmdc:OmicsProcessing",

--- a/nmdc_runtime/site/translation/gold_translator.py
+++ b/nmdc_runtime/site/translation/gold_translator.py
@@ -204,10 +204,6 @@ class GoldStudyTranslator(Translator):
         :param unit: An optional unit as a string, defaults to None
         :return: QuantityValue object
         """
-        field_value = gold_entity.get(gold_field)
-        if field_value is None:
-            return None
-
         if isinstance(gold_field, tuple):
             minimum_numeric_value = gold_entity.get(gold_field[0])
             maximum_numeric_value = gold_entity.get(gold_field[1])
@@ -226,6 +222,10 @@ class GoldStudyTranslator(Translator):
                     has_maximum_numeric_value=nmdc.Double(maximum_numeric_value),
                     has_unit=unit,
                 )
+        
+        field_value = gold_entity.get(gold_field)
+        if field_value is None:
+            return None
 
         return nmdc.QuantityValue(
             has_raw_value=field_value,

--- a/tests/test_data/test_gold_translator.py
+++ b/tests/test_data/test_gold_translator.py
@@ -219,7 +219,7 @@ def test_get_quantity_value():
     value = translator._get_quantity_value(entity, "arbitraryField")
     assert value is not None
     assert value.has_raw_value == "7"
-    assert value.has_numeric_value is None
+    assert value.has_numeric_value == 7.0
     assert value.has_unit is None
 
     entity = {"arbitraryField": 0}
@@ -239,6 +239,15 @@ def test_get_quantity_value():
     entity = {"arbitraryField": None}
     value = translator._get_quantity_value(entity, "arbitraryField", unit="meters")
     assert value is None
+
+    entity = {"arbitraryField1": 1, "arbitraryField2": 10}
+    value = translator._get_quantity_value(entity, ("arbitraryField1", "arbitraryField2"), unit="meters")
+    assert value is not None
+    assert value.has_minimum_numeric_value == 1.0
+    assert value.has_maximum_numeric_value == 10.0
+    assert value.has_raw_value is None
+    assert value.has_numeric_value is None
+    assert value.has_unit == "meters"
 
 
 def test_get_text_value():


### PR DESCRIPTION
As a result of the discussion on https://github.com/microbiomedata/issues/issues/527 a couple of trivial edits needed to be made to the GOLD-to-Mongo ingest pipeline:
* Use lowercase `gold` while making CURIEs for GOLD entities
* Modification to the logic in `_get_quantity_value()` to accommodate special handling of _depth_ data

> NMDC depth.has_minimum_numeric_value — GOLD depthInMeters
> NMDC depth.has_maximum_numeric_value — GOLD depthInMeters2

> depthInMeters2 may or may not be present in GOLD, so in the cases where it’s not provided:
> NMDC depth.has_numeric_value — GOLD depthInMeters