### PR TITLE
Revert to using env context for variables

### DIFF
--- a/.github/workflows/build-and-release-to-spin.yml
+++ b/.github/workflows/build-and-release-to-spin.yml
@@ -13,19 +13,12 @@ on:
       - '**.py'
       - 'requirements/main.txt'
 
+env:
+  IS_PROD_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  RANCHER_NAMESPACE: ${{ startsWith(github.ref, 'refs/tags/v') && 'nmdc' || 'nmdc-dev' }}
+
 jobs:
-  setup-variables:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set variables
-        run: |
-          echo "IS_PROD_RELEASE=${{ startsWith(github.ref, 'refs/tags/v') }}" >> "$GITHUB_ENV"
-          echo "RANCHER_NAMESPACE=${{ startsWith(github.ref, 'refs/tags/v') && 'nmdc' || 'nmdc-dev' }}" >> "$GITHUB_ENV"
-
   build:
-    needs:
-      - setup-variables
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -72,9 +65,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   release:
-    needs:
-      - setup-variables
-      - build
+    needs: build
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Follow up to #390.

I thought I understood the GitHub workflows environment file thing, but oops not quite. I think those values are only sent to the runners so they can't be used for things like `enable=${{ env.IS_PROD_RELEASE }}` outside of `run` in a `step`. So, back to using a workflow-level `env` block.