### PR TITLE
Add PyPI and DockerHub links to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,18 @@ desired and does not break over time.
 [For hints on how to write tests for solids and pipelines in Dagster, see their documentation
 tutorial on Testing](https://docs.dagster.io/tutorial/testable).
 
+## Publish to PyPI
 
-## Release to PyPI
+This repository contains a GitHub Actions workflow that publishes a Python package to PyPI.
+
+You can also _manually_ publish the Python package to PyPI by issuing the following commands in the root directory of the repository:
 
 ```
 rm -rf dist
 python -m build
 twine upload dist/*
 ```
+
+Whether the Python package is published via the GitHub Actions workflow or manually, the published package will be available at: 
+
+https://pypi.org/project/nmdc-runtime/

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ tutorial on Testing](https://docs.dagster.io/tutorial/testable).
 
 ## Publish to PyPI
 
-This repository contains a GitHub Actions workflow that publishes a Python package to PyPI.
+This repository contains a GitHub Actions workflow that publishes a Python package to [PyPI](https://pypi.org/project/nmdc-runtime/).
 
 You can also _manually_ publish the Python package to PyPI by issuing the following commands in the root directory of the repository:
 
@@ -157,6 +157,11 @@ python -m build
 twine upload dist/*
 ```
 
-Whether the Python package is published via the GitHub Actions workflow or manually, the published package will be available at: 
+## Links
 
-https://pypi.org/project/nmdc-runtime/
+Here are links related to this repository:
+
+- Production API server: https://api.microbiomedata.org
+- PyPI package: https://pypi.org/project/nmdc-runtime
+- DockerHub image (API server): https://hub.docker.com/r/microbiomedata/nmdc-runtime-fastapi
+- DockerHub image (Dagster): https://hub.docker.com/r/microbiomedata/nmdc-runtime-dagster


### PR DESCRIPTION
### Changes

- I added the PyPI and DockerHub URLs to the README

### Background

I find it difficult to remember those URLs. In the case of the DockerHub ones, I also find it difficult to find them via Google.

One downside to documenting them statically like this is that clones of this repository will still have the same links. I think that is a common compromise people make when documenting links to deployments in READMEs. It is one I'm comfortable making.