### PR TITLE
Remove username lists from error messages in HTTP responses

### DIFF
--- a/nmdc_runtime/api/endpoints/metadata.py
+++ b/nmdc_runtime/api/endpoints/metadata.py
@@ -20,7 +20,6 @@ from nmdc_runtime.api.endpoints.util import (
     _request_dagster_run,
     permitted,
     persist_content_and_get_drs_object,
-    users_allowed,
 )
 from nmdc_runtime.api.models.job import Job
 from nmdc_runtime.api.models.metadata import ChangesheetIn
@@ -87,7 +86,7 @@ async def submit_changesheet(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
-                f"Only users {users_allowed('/metadata/changesheets:submit')} "
+                f"Only specific users "
                 "are allowed to apply changesheets at this time."
             ),
         )

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -8,7 +8,7 @@ from pymongo.database import Database as MongoDatabase
 from nmdc_runtime.api.core.idgen import generate_one_id
 from nmdc_runtime.api.core.util import now, raise404_if_none
 from nmdc_runtime.api.db.mongo import get_mongo_db
-from nmdc_runtime.api.endpoints.util import permitted, users_allowed
+from nmdc_runtime.api.endpoints.util import permitted
 from nmdc_runtime.api.models.query import (
     Query,
     QueryResponseOptions,
@@ -33,7 +33,7 @@ def check_can_delete(user: User):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
-                f"only users {users_allowed('/queries:run(query_cmd:DeleteCommand)')} "
+                f"Only specific users "
                 "are allowed to issue delete commands.",
             ),
         )


### PR DESCRIPTION
### Changes

- I updated two HTTP responses so they no longer contain lists of usernames, which people could use to learn about API user accounts

Fixes https://github.com/microbiomedata/nmdc-runtime/issues/399