### PR TITLE
Allow Biosample.env_package to be populated from submission-level data

### DIFF
--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -503,7 +503,7 @@ class SubmissionPortalTranslator(Translator):
         sample_data: List[JSON_OBJECT],
         nmdc_biosample_id: str,
         nmdc_study_id: str,
-        submission_package_name: str,
+        default_env_package: str,
     ) -> nmdc.Biosample:
         """Translate sample data from portal submission into an `nmdc:Biosample` object.
 
@@ -518,6 +518,7 @@ class SubmissionPortalTranslator(Translator):
                             from each applicable submission portal tab
         :param nmdc_biosample_id: Minted nmdc:Biosample identifier for the translated object
         :param nmdc_study_id: Minted nmdc:Study identifier for the related Study
+        :param default_env_package: Default value for `env_package` slot
         :return: nmdc:Biosample
         """
         source_mat_id = sample_data[0].get("source_mat_id", "").strip()
@@ -525,7 +526,7 @@ class SubmissionPortalTranslator(Translator):
             "id": nmdc_biosample_id,
             "part_of": nmdc_study_id,
             "name": sample_data[0].get("samp_name", "").strip(),
-            "env_package": nmdc.TextValue(has_raw_value=submission_package_name),
+            "env_package": nmdc.TextValue(has_raw_value=default_env_package),
         }
         for tab in sample_data:
             transformed_tab = self._transform_dict_for_class(tab, "Biosample")
@@ -572,9 +573,9 @@ class SubmissionPortalTranslator(Translator):
         database.biosample_set = [
             self._translate_biosample(
                 sample_data,
-                sample_data_to_nmdc_biosample_ids[sample_data_id],
-                nmdc_study_id,
-                package_name,
+                nmdc_biosample_id=sample_data_to_nmdc_biosample_ids[sample_data_id],
+                nmdc_study_id=nmdc_study_id,
+                default_env_package=package_name,
             )
             for sample_data_id, sample_data in sample_data_by_id.items()
             if sample_data

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -499,12 +499,16 @@ class SubmissionPortalTranslator(Translator):
         return transformed_values
 
     def _translate_biosample(
-        self, sample_data: List[JSON_OBJECT], nmdc_biosample_id: str, nmdc_study_id: str
+        self,
+        sample_data: List[JSON_OBJECT],
+        nmdc_biosample_id: str,
+        nmdc_study_id: str,
+        submission_package_name: str,
     ) -> nmdc.Biosample:
         """Translate sample data from portal submission into an `nmdc:Biosample` object.
 
         sample_data is a list of objects where each object represents one row from a tab in
-        the submission portal. Each of the objects represent information about the same
+        the submission portal. Each of the objects represents information about the same
         underlying biosample. For each of the rows, each of the columns is iterated over.
         For each column, the corresponding slot from the nmdc:Biosample class is identified.
         The raw value from the submission portal is the transformed according to the range
@@ -521,6 +525,7 @@ class SubmissionPortalTranslator(Translator):
             "id": nmdc_biosample_id,
             "part_of": nmdc_study_id,
             "name": sample_data[0].get("samp_name", "").strip(),
+            "env_package": nmdc.TextValue(has_raw_value=submission_package_name),
         }
         for tab in sample_data:
             transformed_tab = self._transform_dict_for_class(tab, "Biosample")
@@ -557,6 +562,7 @@ class SubmissionPortalTranslator(Translator):
         ]
 
         sample_data = metadata_submission_data.get("sampleData", {})
+        package_name = metadata_submission_data["packageName"]
         sample_data_by_id = groupby("source_mat_id", concat(sample_data.values()))
         nmdc_biosample_ids = self._id_minter("nmdc:Biosample", len(sample_data_by_id))
         sample_data_to_nmdc_biosample_ids = dict(
@@ -568,6 +574,7 @@ class SubmissionPortalTranslator(Translator):
                 sample_data,
                 sample_data_to_nmdc_biosample_ids[sample_data_id],
                 nmdc_study_id,
+                package_name,
             )
             for sample_data_id, sample_data in sample_data_by_id.items()
             if sample_data

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -56,7 +56,7 @@ def test_get_doi():
     doi = translator._get_doi({"contextForm": {"datasetDoi": "1234"}})
     assert doi is not None
     assert doi == [
-        nmdc.Doi(doi_value="1234", doi_category=nmdc.DoiCategoryEnum.dataset_doi)
+        nmdc.Doi(doi_value="doi:1234", doi_category=nmdc.DoiCategoryEnum.dataset_doi)
     ]
 
     doi = translator._get_doi({"contextForm": {"datasetDoi": ""}})
@@ -72,7 +72,7 @@ def test_get_doi():
     assert doi is not None
     assert doi == [
         nmdc.Doi(
-            doi_value="5678",
+            doi_value="doi:5678",
             doi_provider=nmdc.DoiProviderEnum.kbase,
             doi_category=nmdc.DoiCategoryEnum.award_doi,
         )

--- a/tests/test_data/test_submission_portal_translator_data.yaml
+++ b/tests/test_data/test_submission_portal_translator_data.yaml
@@ -93,7 +93,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R1_MAIN_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -113,7 +112,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R2_MAIN_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -133,7 +131,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R3_MAIN_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -153,7 +150,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R4_MAIN_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -173,7 +169,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R1_NF_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -193,7 +188,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R2_NF_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -213,7 +207,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R3_NF_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -233,7 +226,6 @@ input:
           ecosystem: Environmental
           samp_name: "G5R4_NF_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -253,7 +245,6 @@ input:
           ecosystem: Environmental
           samp_name: "G6R1_MAIN_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -273,7 +264,6 @@ input:
           ecosystem: Environmental
           samp_name: "G6R2_MAIN_09MAY2016"
           env_medium: plant-associated biome [ENVO:01001001]
-          env_package: soil
           geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
           growth_facil: field
           analysis_type:
@@ -325,7 +315,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -374,7 +364,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -423,7 +413,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -472,7 +462,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -521,7 +511,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -570,7 +560,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -619,7 +609,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -668,7 +658,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -717,7 +707,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -766,7 +756,7 @@ output:
       has_numeric_value: 0.0
     elev: 286.0
     env_package:
-      has_raw_value: soil
+      has_raw_value: plant-associated
     geo_loc_name:
       has_raw_value: 'USA: Kellogg Biological Station, Michigan'
     lat_lon:
@@ -863,7 +853,6 @@ input:
             env_broad_scale: agricultural biome [ENVO:01001442]
             env_local_scale: phyllosphere biome [ENVO:01001442]
             env_medium: plant-associated biome [ENVO:01001001]
-            env_package: soil
             geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
             growth_facil: field
             lat_lon: 42.39 -85.37
@@ -936,7 +925,7 @@ output:
       ecosystem_type: Plant-associated
       elev: 286.0
       env_package:
-        has_raw_value: soil
+        has_raw_value: plant-associated
       geo_loc_name:
         has_raw_value: 'USA: Kellogg Biological Station, Michigan'
       growth_facil:


### PR DESCRIPTION
This is part 2 of https://github.com/microbiomedata/issues/issues/543.

The changes here update the `SubmissionPortalTranslator` class so so that when it is creating `Biosample` instances, the `env_package` slot is populated by default from the submission-level `packageName` field. Tests updated accordingly. 