### PR TITLE
allow mongodb update command via POST /query:run

### DIFF
--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -65,7 +65,7 @@ def run_query(
 
     {
         "update": "biosample_set",
-        "updates": [{"q": {"id": "nmdc:bsm-11-002vgm56"}, "u": {"$set": {"name": "BEAL_048-O-6.5-19.5-20160725"}}}]
+        "updates": [{"q": {"id": "YOUR_BIOSAMPLE_ID"}, "u": {"$set": {"name": "A_NEW_NAME"}}}]
     }
     ```
     """

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -62,6 +62,11 @@ def run_query(
       "delete": "biosample_set",
       "deletes": [{"q": {"id": "NOT_A_REAL_ID"}, "limit": 1}]
     }
+
+    {
+        "update": "biosample_set",
+        "updates": [{"q": {"id": "nmdc:bsm-11-002vgm56"}, "u": {"$set": {"name": "BEAL_048-O-6.5-19.5-20160725"}}}]
+    }
     ```
     """
     if isinstance(query_cmd, (DeleteCommand, UpdateCommand)):

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -120,10 +120,10 @@ def _run_query(query, mdb) -> CommandResponse:
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="Can only delete documents in nmdc-schema collections.",
             )
-        find_specs = [
-            {"filter": dcd.q, "limit": dcd.limit} for dcd in query.cmd.deletes
+        delete_specs = [
+            {"filter": del_statement.q, "limit": del_statement.limit} for del_statement in query.cmd.deletes
         ]
-        for spec in find_specs:
+        for spec in delete_specs:
             docs = list(mdb[collection_name].find(**spec))
             if not docs:
                 continue
@@ -135,6 +135,7 @@ def _run_query(query, mdb) -> CommandResponse:
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail="Failed to back up to-be-deleted documents. operation aborted.",
                 )
+
     elif q_type is UpdateCommand:
         collection_name = query.cmd.update
         if collection_name not in nmdc_schema_collection_names(mdb):
@@ -143,7 +144,7 @@ def _run_query(query, mdb) -> CommandResponse:
                 detail="Can only update documents in nmdc-schema collections.",
             )
         update_specs = [
-            {"filter": us.q, "limit": 0 if us.multi else 1} for us in query.cmd.updates
+            {"filter": up_statement.q, "limit": 0 if up_statement.multi else 1} for up_statement in query.cmd.updates
         ]
         for spec in update_specs:
             docs = list(mdb[collection_name].find(**spec))

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -34,8 +34,7 @@ def check_can_update_and_delete(user: User):
     if not permitted(user.username, "/queries:run(query_cmd:DeleteCommand)"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(f"Only specific users " 
-                    "are allowed to issue update and delete commands.",),
+            detail="Only specific users are allowed to issue update and delete commands."
         )
 
 

--- a/nmdc_runtime/api/models/query.py
+++ b/nmdc_runtime/api/models/query.py
@@ -112,7 +112,7 @@ class UpdateCommandResponse(CommandResponse):
     ok: OneOrZero
     n: NonNegativeInt
     nModified: NonNegativeInt
-    upserted: List[DocumentUpserted]
+    upserted: Optional[List[DocumentUpserted]] = None
     writeErrors: Optional[List[Document]] = None
 
 
@@ -134,7 +134,12 @@ class GetMoreCommandResponse(CommandResponse):
 
 
 QueryCmd = Union[
-    CollStatsCommand, CountCommand, FindCommand, GetMoreCommand, DeleteCommand
+    CollStatsCommand,
+    CountCommand,
+    FindCommand,
+    GetMoreCommand,
+    DeleteCommand,
+    UpdateCommand,
 ]
 
 QueryResponseOptions = Union[
@@ -143,6 +148,7 @@ QueryResponseOptions = Union[
     FindCommandResponse,
     GetMoreCommandResponse,
     DeleteCommandResponse,
+    UpdateCommandResponse,
 ]
 
 
@@ -153,6 +159,7 @@ def command_response_for(type_):
         FindCommand: FindCommandResponse,
         GetMoreCommand: GetMoreCommandResponse,
         DeleteCommand: DeleteCommandResponse,
+        UpdateCommand: UpdateCommandResponse,
     }
     return d.get(type_)
 

--- a/nmdc_runtime/api/models/query.py
+++ b/nmdc_runtime/api/models/query.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import Optional, Any, Dict, List, Union
 
+from bson import ObjectId
 from pydantic import (
     model_validator,
     Field,
@@ -86,6 +87,32 @@ class DeleteCommand(CommandBase):
 class DeleteCommandResponse(CommandResponse):
     ok: OneOrZero
     n: NonNegativeInt
+    writeErrors: Optional[List[Document]] = None
+
+
+class UpdateStatement(BaseModel):
+    q: Document
+    u: Document
+    upsert: bool = False
+    multi: bool = False
+    hint: Optional[Dict[str, OneOrMinusOne]] = None
+
+
+class UpdateCommand(CommandBase):
+    update: str
+    updates: List[UpdateStatement]
+
+
+class DocumentUpserted(BaseModel):
+    index: NonNegativeInt
+    _id: ObjectId
+
+
+class UpdateCommandResponse(CommandResponse):
+    ok: OneOrZero
+    n: NonNegativeInt
+    nModified: NonNegativeInt
+    upserted: List[DocumentUpserted]
     writeErrors: Optional[List[Document]] = None
 
 

--- a/nmdc_runtime/api/models/query.py
+++ b/nmdc_runtime/api/models/query.py
@@ -90,6 +90,8 @@ class DeleteCommandResponse(CommandResponse):
     writeErrors: Optional[List[Document]] = None
 
 
+# If `multi==True` all documents that meet the query criteria will be updated.
+# Else only a single document that meets the query criteria will be updated.
 class UpdateStatement(BaseModel):
     q: Document
     u: Document

--- a/nmdc_runtime/api/models/query.py
+++ b/nmdc_runtime/api/models/query.py
@@ -73,7 +73,7 @@ class FindCommandResponse(CommandResponse):
     cursor: FindCommandResponseCursor
 
 
-class DeleteCommandDelete(BaseModel):
+class DeleteStatement(BaseModel):
     q: Document
     limit: OneOrZero
     hint: Optional[Dict[str, OneOrMinusOne]] = None
@@ -81,7 +81,7 @@ class DeleteCommandDelete(BaseModel):
 
 class DeleteCommand(CommandBase):
     delete: str
-    deletes: List[DeleteCommandDelete]
+    deletes: List[DeleteStatement]
 
 
 class DeleteCommandResponse(CommandResponse):


### PR DESCRIPTION
closes #356

#### A successful `update` query run 
- sends a 200
![image](https://github.com/microbiomedata/nmdc-runtime/assets/26777878/6ad5fe2b-78eb-428e-9c9e-a5ced4bf1b67)
- updates the document
![image](https://github.com/microbiomedata/nmdc-runtime/assets/26777878/0ff11ffc-aa4d-412c-aeb3-c9d243e020a0)

#### A poorly formatted `update` query run
- Throws an error if no records found
![image](https://github.com/microbiomedata/nmdc-runtime/assets/26777878/47278206-c67f-48a5-a53a-3a525000eb43)

- Throws an error if query is poorly formatted
![image](https://github.com/microbiomedata/nmdc-runtime/assets/26777878/601c3e9d-9106-42cf-8451-1f8f80778280)
