### PR TITLE
Replace `docker-compose` with `docker compose`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,4 +9,4 @@ tasks:
   - name: Start Dev on Fresh Gitpod
     before: cp .env.example .env
     init: docker compose up mongo --detach && make mongorestore-nmdc-dev
-    command: make up-dev && docker-compose logs -f fastapi
+    command: make up-dev && docker compose logs -f fastapi

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ update-deps:
 update: update-deps init
 
 up-dev:
-	docker-compose up --build --force-recreate --detach --remove-orphans
+	docker compose up --build --force-recreate --detach --remove-orphans
 
 dev-reset-db:
 	docker compose \
 		exec mongo /bin/bash -c "./app_tests/mongorestore-nmdc-testdb.sh"
 
 up-test:
-	docker-compose --file docker-compose.test.yml \
+	docker compose --file docker-compose.test.yml \
 		up --build --force-recreate --detach --remove-orphans
 
 test-build:
@@ -49,13 +49,13 @@ lint:
 		--statistics --extend-exclude="./build/" --extend-ignore=F722
 
 down-dev:
-	docker-compose down
+	docker compose down
 
 down-test:
-	docker-compose --file docker-compose.test.yml down
+	docker compose --file docker-compose.test.yml down
 
 follow-fastapi:
-	docker-compose logs fastapi -f
+	docker compose logs fastapi -f
 
 fastapi-deploy-spin:
 	rancher kubectl rollout restart deployment/runtime-fastapi --namespace=nmdc-dev


### PR DESCRIPTION
I didn't think I should change anything beside `Makefile` and `.gitpod.yml`. In fact I'm not even sure about `.gitpod.yml`.

There were many appearances of `docker-compose` in files from the dependencies, and also in the context of the `docker-compose.yml` filename