### PR TITLE
Fix inaccurate comment in migration instructions

### DIFF
--- a/demo/metadata_migration/notebooks/migrate_9_3_2_to_10_0_0.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_9_3_2_to_10_0_0.ipynb
@@ -93,7 +93,7 @@
     "       # Run in the same directory as this notebook:\n",
     "       $ cp .notebook.env.example .notebook.env\n",
     "       ```\n",
-    "3. Create and populate **MongoDB configuration files** for connecting to the origin (typically, local) and transformer (typically, remote) MongoDB servers.\n",
+    "3. Create and populate **MongoDB configuration files** for connecting to the origin (typically, remote) and transformer (typically, local) MongoDB servers.\n",
     "    1. You can use the `.mongo.yaml.example` file as a template:\n",
     "       ```shell\n",
     "       # Run in the same directory as this notebook:\n",


### PR DESCRIPTION
### Summary of changes

- Updated a statement that incorrectly said the origin server was typically local (not true) and the transformer server is typically remote (not true); to say the opposite.