### PR TITLE
Upgrade to nmdc-schema 10.1.2

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -24,7 +24,7 @@ mkdocs-jupyter
 mkdocs-material
 mkdocs-mermaid2-plugin
 motor
-nmdc-schema==10.1.1
+nmdc-schema==10.1.2
 openpyxl
 pandas
 passlib[bcrypt]

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -24,7 +24,7 @@ mkdocs-jupyter
 mkdocs-material
 mkdocs-mermaid2-plugin
 motor
-nmdc-schema==10.1.0
+nmdc-schema==10.1.1
 openpyxl
 pandas
 passlib[bcrypt]

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -460,7 +460,7 @@ nbformat==5.9.2
     #   nbconvert
 nest-asyncio==1.6.0
     # via ipykernel
-nmdc-schema==10.1.1
+nmdc-schema==10.1.2
     # via -r requirements/main.in
 notebook==7.1.1
     # via jupyter

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -24,6 +24,8 @@ anyio==4.3.0
     #   jupyter-server
     #   starlette
     #   watchfiles
+appnope==0.1.4
+    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -206,8 +208,6 @@ graphql-relay==3.2.0
     # via graphene
 graphviz==0.20.1
     # via linkml
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.62.0
     # via
     #   dagster
@@ -460,7 +460,7 @@ nbformat==5.9.2
     #   nbconvert
 nest-asyncio==1.6.0
     # via ipykernel
-nmdc-schema==10.1.0
+nmdc-schema==10.1.1
     # via -r requirements/main.in
 notebook==7.1.1
     # via jupyter


### PR DESCRIPTION
This upgrades the `nmdc-schema` dependency from 10.1.0 to 10.1.2. There _shouldn't_ be substantive schema changes between the two, except that both 10.1.0 and 10.1.1 were incorrectly built before release.

@aclum expressed interest in making an off-cycle release of `nmdc-runtime` once this change has been deployed to and tested (by workflows) on dev.