### PR TITLE
Migrations: Fix invalid example notebook

### DIFF
--- a/demo/metadata_migration/notebooks/migrate_A_B_C_to_X_Y_Z.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_A_B_C_to_X_Y_Z.ipynb
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "dbecd561",
    "metadata": {
     "ExecuteTime": {
@@ -225,26 +225,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bc387abc62686091",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Create a bookkeeper\n",
     "\n",
     "Create a `Bookkeeper` that can be used to document migration events in the \"origin\" server."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "bc387abc62686091"
+   ]
   },
   {
    "cell_type": "code",
-   "outputs": [],
-   "source": [
-    "bookkeeper = Bookkeeper(mongo_client=origin_mongo_client)"
-   ],
+   "execution_count": null,
+   "id": "5c982eb0c04e606d",
    "metadata": {
     "collapsed": false
    },
-   "id": "5c982eb0c04e606d"
+   "outputs": [],
+   "source": [
+    "bookkeeper = Bookkeeper(mongo_client=origin_mongo_client)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -420,26 +421,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "997fcb281d9d3222",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Indicate that the migration is underway\n",
     "\n",
     "Add an entry to the migration log collection to indicate that this migration has started."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "997fcb281d9d3222"
+   ]
   },
   {
    "cell_type": "code",
-   "outputs": [],
-   "source": [
-    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_STARTED)"
-   ],
+   "execution_count": null,
+   "id": "fcafd862e1becb98",
    "metadata": {
     "collapsed": false
    },
-   "id": "fcafd862e1becb98"
+   "outputs": [],
+   "source": [
+    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_STARTED)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -499,26 +501,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ca5ee89a79148499",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Indicate that the migration is complete\n",
     "\n",
     "Add an entry to the migration log collection to indicate that this migration is complete."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "ca5ee89a79148499"
+   ]
   },
   {
    "cell_type": "code",
-   "outputs": [],
-   "source": [
-    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_COMPLETED)"
-   ],
+   "execution_count": null,
+   "id": "d1eaa6c92789c4f3",
    "metadata": {
     "collapsed": false
    },
-   "id": "d1eaa6c92789c4f3"
+   "outputs": [],
+   "source": [
+    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_COMPLETED)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
# Description

In PR https://github.com/microbiomedata/nmdc-runtime/pull/487, I committed a Jupyter notebook that I didn't know was not formatted in a valid way.

In this PR, I am committing the same notebook in a valid way.

The invalid one was saved using PyCharm and the valid one was saved using VS Code. The PyCharm GUI has been buggy when it comes to Python notebooks, and—based on this issue—I think the under-the-hood piece of PyCharm that deals with Python notebook is buggy, too. I'm going to switch back to using VS Code for notebooks for now.

Fixes #490 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [x] I confirmed GitHub renders the notebook instead of displaying an error page

**Configuration Details**: none

# Checklist:

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)