### PR TITLE
Update analytics middleware to log requests lacking a `user-agent` header

### DIFF
--- a/nmdc_runtime/api/analytics.py
+++ b/nmdc_runtime/api/analytics.py
@@ -49,17 +49,17 @@ class Analytics(BaseHTTPMiddleware):
         start = time()
         response = await call_next(request)
 
-        # Allow requests to lack a "user-agent" header (case-insensitive).
-        # Reference: https://www.starlette.io/requests/#headers
-        user_agent = None
-        if "user-agent" in request.headers:
-            user_agent = request.headers["user-agent"]
-
+        # Build a dictionary that describes the incoming request.
+        #
+        # Note: `request.headers` is an instance of `MultiDict`. References:
+        #       - https://www.starlette.io/requests/#headers
+        #       - https://multidict.aio-libs.org/en/stable/multidict/
+        #
         request_data = {
             "hostname": request.url.hostname,
             "ip_address": request.client.host,
             "path": request.url.path,
-            "user_agent": user_agent,
+            "user_agent": request.headers.get("user-agent"),
             "method": request.method,
             "status": response.status_code,
             "response_time": int((time() - start) * 1000),

--- a/nmdc_runtime/api/analytics.py
+++ b/nmdc_runtime/api/analytics.py
@@ -49,11 +49,17 @@ class Analytics(BaseHTTPMiddleware):
         start = time()
         response = await call_next(request)
 
+        # Allow requests to lack a "user-agent" header (case-insensitive).
+        # Reference: https://www.starlette.io/requests/#headers
+        user_agent = None
+        if "user-agent" in request.headers:
+            user_agent = request.headers["user-agent"]
+
         request_data = {
             "hostname": request.url.hostname,
             "ip_address": request.client.host,
             "path": request.url.path,
-            "user_agent": request.headers["user-agent"],
+            "user_agent": user_agent,
             "method": request.method,
             "status": response.status_code,
             "response_time": int((time() - start) * 1000),


### PR DESCRIPTION
# Description

The changes on this branch make it so the analytics middleware no longer raises a `KeyError` when the incoming request lacks a `user-agent` (case-insensitive) header.

If someone wants the runtime to deny those requests, I propose that be done elsewhere (and explicitly documented).

Fixes #515.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I confirmed, locally (shown [here](https://github.com/microbiomedata/nmdc-runtime/pull/516#issuecomment-2096659783)), that requests that lack a `User-Agent` header are now logged by the analytics middleware. I also confirmed that requests that _have_ the header are also logged (as they were before).

**Configuration Details**: none

# Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)