### PR TITLE
Merge jupyter notebooks for 1) mongo validation and ref integrity check && 2) RDF gen 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# mongo-restore
+*.tar
+*.agz
+
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -54,6 +58,8 @@ coverage.xml
 # Translations
 *.mo
 *.pot
+
+
 
 # Django stuff:
 *.log
@@ -103,6 +109,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.localhost
 .venv
 env/
 venv/

--- a/metadata-translation/notebooks/ghissue_401_sparql.ipynb
+++ b/metadata-translation/notebooks/ghissue_401_sparql.ipynb
@@ -1,0 +1,623 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "51ea05af-7579-43ad-aa9c-3bf8b6da8fdb",
+   "metadata": {},
+   "source": [
+    "# Pipeline to transform the set of nmdc-schema-compliant mongodb collections to an RDF dataset amenable to SPARQL queries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae2673a5-560b-47b0-9608-656aa3854466",
+   "metadata": {},
+   "source": [
+    "Ensure that changes to the code will be import-able in this notebook without needing restart the kernel and thus lose state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a362b42f-7ae0-40cf-91d4-8f19ca1087cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b8b1fb7-2357-46ef-8d86-69cd1dce228d",
+   "metadata": {},
+   "source": [
+    "Connect to local dockerized dev environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "55932d03-802f-4efe-bceb-e1036cd35567",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MONGO_HOST=mongodb://localhost:27018\n"
+     ]
+    }
+   ],
+   "source": [
+    "!env | grep MONGO_HOST"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a146763-f03a-4d65-baa0-81ca15cba689",
+   "metadata": {},
+   "source": [
+    "Initialize a db connection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bc72113f-5044-4646-a273-0692d2e650ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "edb1bb42-005c-49ca-ba59-18c24833f93f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mongodb://localhost:27018\n",
+      "success\n"
+     ]
+    }
+   ],
+   "source": [
+    "from nmdc_runtime.api.db.mongo import get_mongo_db\n",
+    "print(os.getenv(\"MONGO_HOST\"))\n",
+    "# start 12:23\n",
+    "mdb = get_mongo_db()\n",
+    "print(\"success\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "114d9ffa-a22a-48de-9001-d04cbab175eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from unittest.mock import patch\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37dbc9a8-8cac-4798-8d4f-ccbd9c3560e9",
+   "metadata": {},
+   "source": [
+    "Get all populated nmdc-schema collections with entity `id`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a0dd489-74cc-47c4-b3e0-c97dd88f5b5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nmdc_runtime.util import schema_collection_names_with_id_field\n",
+    "\n",
+    "populated_collections = sorted([\n",
+    "    name for name in set(schema_collection_names_with_id_field()) & set(mdb.list_collection_names())\n",
+    "    if mdb[name].estimated_document_count() > 0\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9a45de7-ba27-4b18-8ff4-9ba44eeb1091",
+   "metadata": {},
+   "source": [
+    "Get a JSON-LD context for the NMDC Schema, to serialize documents to RDF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ed72826-b552-4429-8ab5-9f7126821822",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pprint import pprint\n",
+    "\n",
+    "from linkml.generators.jsonldcontextgen import ContextGenerator\n",
+    "from nmdc_schema.nmdc_data import get_nmdc_schema_definition\n",
+    "\n",
+    "context = ContextGenerator(get_nmdc_schema_definition())\n",
+    "context = json.loads(context.serialize())[\"@context\"]\n",
+    "\n",
+    "for k, v in list(context.items()):\n",
+    "    if isinstance(v, dict): #and v.get(\"@type\") == \"@id\":\n",
+    "        v.pop(\"@id\", None) # use nmdc uri, not e.g. MIXS uri"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0800c5b9-d09e-4be1-899d-62fcf40a2c0e",
+   "metadata": {},
+   "source": [
+    "Ensure `nmdc:type` has a `URIRef` range, i.e. `nmdc:type a owl:ObjectProperty`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62a68c07-0706-4300-a48d-0ab628af87b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context['type'] = {'@type': '@id'}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63fe4d54-0a41-4170-9310-45e5f47a6cb5",
+   "metadata": {},
+   "source": [
+    "Initialize an in-memory graph to store triples, prior to serializing to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "648b4f70-34d6-4c70-8d0a-ef76e7e5d96d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import Graph\n",
+    "\n",
+    "g = Graph()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05cb8fd0-b847-49fc-a472-a8df2426168a",
+   "metadata": {},
+   "source": [
+    "Define a helper function to speed up triplification process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d802017-2a7e-4614-b662-6a0cc027b8bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def split_chunk(seq, n: int):\n",
+    "    \"\"\"\n",
+    "    Split sequence into chunks of length n. Do not pad last chunk.\n",
+    "    \n",
+    "    >>> list(split_chunk(list(range(10)), 3))\n",
+    "    [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]\n",
+    "    \"\"\"\n",
+    "    for i in range(0, len(seq), n):\n",
+    "        yield seq[i : i + n]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfd91d37-b1c7-46ab-b30d-de80132ec091",
+   "metadata": {},
+   "source": [
+    "Use `rdflib` JSON-LD parsing to ingest mongo docs to in-memory graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86ff7261-e255-415d-a589-67637292dbdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nmdc_runtime.util import collection_name_to_class_names\n",
+    "\n",
+    "def ensure_type(doc, collection_name):\n",
+    "    if \"type\" in doc:\n",
+    "        return doc\n",
+    "\n",
+    "    class_names = collection_name_to_class_names[collection_name]\n",
+    "    if len(class_names) > 1:\n",
+    "        raise Exception(\"cannot unambiguously infer class of document\")\n",
+    "    return assoc(doc, \"type\", class_names[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4251e0b1-35dc-4f40-91e7-b9bc0d9d79e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from toolz import assoc, dissoc\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "chunk_size = 2_000\n",
+    "total = sum((1 + mdb[name].estimated_document_count() // 2_000) for name in populated_collections)\n",
+    "\n",
+    "pbar = tqdm(total=total)\n",
+    "\n",
+    "for collection_name in populated_collections:\n",
+    "    print(collection_name)\n",
+    "    docs = [dissoc(doc, \"_id\") for doc in mdb[collection_name].find()]\n",
+    "    chunks = list(split_chunk(docs, chunk_size))\n",
+    "    for chunk in chunks:\n",
+    "        typed_chunk = [ensure_type(doc, collection_name) for doc in chunk]\n",
+    "        doc_jsonld = {\"@context\": context, \"@graph\": chunk}\n",
+    "        g.parse(data=json.dumps(doc_jsonld), format='json-ld')\n",
+    "        pbar.update(1)\n",
+    "print(f\"{len(g):,} triples loaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7140ef42-f94c-45c5-a0c1-31b05718aa4f",
+   "metadata": {},
+   "source": [
+    "Correct crazy URIs that end with newlines, which messes up graph serialization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba832848-2cc9-4d1d-bf5f-966a73e26658",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import Namespace, RDF, Literal, URIRef\n",
+    "\n",
+    "NMDC = Namespace(\"https://w3id.org/nmdc/\")\n",
+    "\n",
+    "for s, p, o in tqdm(g, total=len(g)):\n",
+    "    s_str = str(s)\n",
+    "    if s_str.endswith(\"\\n\"):\n",
+    "        s_str_fixed = str(s_str)[:-2]\n",
+    "        g.remove((s,p,o))\n",
+    "        g.add((URIRef(s_str_fixed), p,o))\n",
+    "    if isinstance(o, URIRef):\n",
+    "        o_str = str(o)\n",
+    "        if o_str.endswith(\"\\n\"):\n",
+    "            o_str_fixed = str(o_str)[:-2]\n",
+    "            g.remove((s,p,o))\n",
+    "            g.add((s, p, URIRef(o_str_fixed)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71893efc-8e19-465e-a33d-3fe6ee475e05",
+   "metadata": {},
+   "source": [
+    "Given a schema-collection entity (i.e. one with an `id` and its own mongo document), we want to easily find all other schema-collection entities to which it connects, via any slot.\n",
+    "\n",
+    "To do this, we first gather all schema classes that are the type of a schema-collection entity, as well as these class' ancestors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "831cbf19-8331-4f2d-814c-89d86d060029",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from linkml_runtime.utils.schemaview import SchemaView\n",
+    "\n",
+    "from nmdc_runtime.util import nmdc_schema_view, nmdc_database_collection_instance_class_names\n",
+    "\n",
+    "schema_view = nmdc_schema_view()\n",
+    "toplevel_classes = set()\n",
+    "for name in nmdc_database_collection_instance_class_names():\n",
+    "    toplevel_classes |= set(schema_view.class_ancestors(name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acdc7a8c-a104-4ac4-b105-0daeaba598a4",
+   "metadata": {},
+   "source": [
+    "Next, we determine which slots have such a \"top-level\" class as its range."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d402b739-4ab8-4d93-b00f-76f677313c66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slots = schema_view.all_slots()\n",
+    "\n",
+    "toplevel_entity_connectors = set()\n",
+    "for k, v in context.items():\n",
+    "    if isinstance(v, dict) and \"@type\" in v and v[\"@type\"] == \"@id\":\n",
+    "        if slots[k].range in toplevel_classes and slots[k].domain != \"Database\":\n",
+    "            toplevel_entity_connectors.add(k)\n",
+    "print(toplevel_entity_connectors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40e58127-013e-40e2-a839-c9317e14c488",
+   "metadata": {},
+   "source": [
+    "Let's construct an entity-relationship diagram to visualize relationships."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c99cdd8d-5fd2-44eb-9090-af6f51770fbd",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# print(\"classDiagram\\n\")\n",
+    "# for slot_name in toplevel_entity_connectors:\n",
+    "#     slot = slots[slot_name]\n",
+    "#     domain = slot.domain or \"NamedThing\"\n",
+    "#     range = slot.range\n",
+    "#     print(f\"{domain} --> {range} : {slot_name}\")\n",
+    "\n",
+    "# print()\n",
+    "\n",
+    "# inheritance_links = set()\n",
+    "# for cls in toplevel_classes:\n",
+    "#     ancestors = schema_view.class_ancestors(cls)\n",
+    "#     for a in ancestors:\n",
+    "#         if a != cls:\n",
+    "#             inheritance_links.add(f\"{a} <|-- {cls}\")\n",
+    "\n",
+    "# for link in inheritance_links:\n",
+    "#     print(link)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63cb2cc8-ef99-4d5f-9ddf-9eb2949e9c06",
+   "metadata": {},
+   "source": [
+    "Now, let's assert a common `depends_on` relation for all entities connected by these slots so that we can traverse the graph of top-level entities without needing to specify any specific slot names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc830d77-5ac2-482e-a4f9-dc2eed3f2ef9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import PROV\n",
+    "\n",
+    "for s, p, o in tqdm(g, total=len(g)):\n",
+    "    if (connector := p.removeprefix(str(NMDC))) in toplevel_entity_connectors:\n",
+    "        if connector == \"has_output\":\n",
+    "            g.add((o, NMDC.depends_on, s))\n",
+    "        else:\n",
+    "            g.add((s, NMDC.depends_on, o))\n",
+    "\n",
+    "print(f\"{len(g):,} triples in total\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b3dd01c-0f20-40c6-9066-793c9d33b901",
+   "metadata": {},
+   "source": [
+    "Materialize superclass relations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75db4baf-369b-47af-974b-f5298470ad7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema_view = nmdc_schema_view()\n",
+    "toplevel_classes = set()\n",
+    "for name in nmdc_database_collection_instance_class_names():\n",
+    "    toplevel_classes |= set(getattr(NMDC, a) for a in schema_view.class_ancestors(name))\n",
+    "\n",
+    "for s, p, o in tqdm(g, total=len(g)):\n",
+    "    p_localname = p.removeprefix(str(NMDC))\n",
+    "    if p_localname != \"type\":\n",
+    "        continue\n",
+    "    if o not in toplevel_classes:\n",
+    "        continue\n",
+    "    for a in schema_view.class_ancestors(o.removeprefix(str(NMDC))):\n",
+    "        g.add((s, NMDC.type, getattr(NMDC,a)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "067a53a9-9220-4ee2-bcce-12d6007dab47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len([t for t in g.subjects(NMDC.type, NMDC.Activity)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91171cf6-f435-4815-970f-a67f51254997",
+   "metadata": {},
+   "source": [
+    "Serialize and store as gzipped N-Triples file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "125d2ad4-8433-45d8-86c4-d6a619ea5280",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gzip\n",
+    "\n",
+    "with gzip.open('data/nmdc-db.nt.gz', 'wb') as f:\n",
+    "    f.write(g.serialize(format='nt').encode())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d8c0a2-6f75-4dac-9bb9-ac48838ad2b8",
+   "metadata": {},
+   "source": [
+    "Wipe any existing persisted data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea0bdeee-6b3a-4074-bd73-cc9424569346",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker compose up fuseki -d\n",
+    "!docker exec fuseki rm -rf /fuseki-base/nmdc-db.tdb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79284de7-ef52-47c6-aeb1-1453bd4b5f59",
+   "metadata": {},
+   "source": [
+    "Ensure data is present to load."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9037026c-2653-43e3-bb92-2a0eea85b213",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker cp data/nmdc-db.nt.gz fuseki:/fuseki-base/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dca86f8-6752-4aba-8d3c-656810f3af3f",
+   "metadata": {},
+   "source": [
+    "Take server down in order to bulk-load data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16f0621c-cf98-4a27-9165-7a0a8711db77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker compose down fuseki"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa4f9843-d5c0-4f8d-bcaf-ad2cf50c0264",
+   "metadata": {},
+   "source": [
+    "Bulk-load data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a490caff-af8a-4537-8c0b-e4a4752645bc",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!docker compose run fuseki ./apache-jena-4.9.0/bin/tdbloader --loc /fuseki-base/nmdc-db.tdb /fuseki-base/nmdc-db.nt.gz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69d0e50c-102a-4a8e-9bcd-ef23600afd66",
+   "metadata": {},
+   "source": [
+    "Start up server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a0bfb4b-e694-40b1-88af-4446e3fcc888",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker compose up fuseki -d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e528d6a-76b1-4629-82a1-58793ad6a481",
+   "metadata": {},
+   "source": [
+    "Now go to <http://localhost:3030/#/dataset/nmdc/query> and SPARQL it up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8695001d-9722-48a0-98e8-9ac5000551ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2024-03-14T09:40 : took <4min to run all the above."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/metadata-translation/notebooks/repl_validation_referential_integrity-1715162638.ipynb
+++ b/metadata-translation/notebooks/repl_validation_referential_integrity-1715162638.ipynb
@@ -1,0 +1,491 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2a66b2dc",
+   "metadata": {},
+   "source": [
+    "# imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f1c8bdb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f7ff0664-1881-4eca-b018-4c5856dc2489",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from linkml_runtime.utils.schemaview import SchemaView\n",
+    "from toolz import dissoc, assoc\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "from nmdc_runtime.api.db.mongo import get_mongo_db, nmdc_schema_collection_names\n",
+    "from nmdc_runtime.util import collection_name_to_class_names, nmdc_schema_view, nmdc_database_collection_instance_class_names\n",
+    "from nmdc_schema.nmdc_schema_accepting_legacy_ids import Database as NMDCDatabase\n",
+    "from nmdc_schema.get_nmdc_view import ViewGetter\n",
+    "\n",
+    "mdb = get_mongo_db()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcb5802b-8205-49b7-8784-dc137baff1a0",
+   "metadata": {},
+   "source": [
+    "# \"pre-cleaning\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ecb1950-eaec-469c-b7ac-949650825093",
+   "metadata": {},
+   "source": [
+    "Only consider populated collections with `id` field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dde4c77e-5e06-4751-930a-95906cdf89c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_names = sorted(nmdc_schema_collection_names(mdb))\n",
+    "collection_names = [n for n in collection_names if mdb[n].find_one({\"id\": {\"$exists\": True}})]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cddaaa54-262d-4549-a9a9-4c280a6a6341",
+   "metadata": {},
+   "source": [
+    "Remove null-valued optional properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b71ba7d2-ebd2-487d-a5cc-2a85ee14cb95",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c9c772648214f1faec08df226b7b44b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/18 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "props = [\"used\", \"git_url\", \"was_associated_with\", \"was_generated_by\", \"compression_type\",]\n",
+    "\n",
+    "pbar = tqdm(total=len(collection_names))\n",
+    "for p in props:\n",
+    "    for coll_name in collection_names:\n",
+    "        pbar.set_description(f\"checking {coll_name}...\")\n",
+    "        docs_broken = list(mdb[coll_name].find({p: {\"$type\": 10}}, [\"id\"]))\n",
+    "        if docs_broken:\n",
+    "            print(f\"removing {len(docs_broken)} null-valued {p} values for {coll_name}...\")\n",
+    "            mdb[coll_name].update_many(\n",
+    "                {\"id\": {\"$in\": [d[\"id\"] for d in docs_broken]}},\n",
+    "                {\"$unset\": {p: None}}\n",
+    "            )\n",
+    "        pbar.update(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21c2f771-b8da-466a-90e8-2c17ac5e6388",
+   "metadata": {},
+   "source": [
+    "# materialize single-collection db view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56d6c224-ec80-4ac9-9dcf-bf04b33a61f9",
+   "metadata": {},
+   "source": [
+    "Check assumption that every populated collection currently has documents of one type only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "59176b24-2854-4387-891f-a6be2ceca4f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name in collection_names:\n",
+    "    assert len(collection_name_to_class_names[name]) == 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ed95ee0-03b7-4dff-80e7-92a2b24bccf4",
+   "metadata": {},
+   "source": [
+    "Define helper function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4470c52a-81e4-4511-b549-768c04c3b45d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def class_hierarchy_as_list(obj):\n",
+    "    rv = []\n",
+    "    current_class = obj.__class__\n",
+    "    \n",
+    "    def recurse_through_bases(cls):\n",
+    "        name = cls.__name__\n",
+    "        if name == \"YAMLRoot\":\n",
+    "            return rv\n",
+    "        rv.append(name)\n",
+    "        for base in cls.__bases__:\n",
+    "            recurse_through_bases(base)\n",
+    "        return rv\n",
+    "    \n",
+    "    return recurse_through_bases(current_class)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b962e3c8-a346-49c5-8470-915f3cf9eb07",
+   "metadata": {},
+   "source": [
+    "Materialize `alldocs` collection, associating all inherited classes with document via `type` field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ae8a6da2-6194-4aa5-aa36-8b21f5942b40",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_id': ObjectId('64b59413fe178b5f0339ca41'),\n",
+       " 'end_date': '2018-05-08',\n",
+       " 'has_input': ['nmdc:procsm-11-dha8mw20'],\n",
+       " 'has_output': ['nmdc:procsm-11-xb11xa62'],\n",
+       " 'id': 'nmdc:extrp-11-k5fecy41',\n",
+       " 'processing_institution': 'Battelle',\n",
+       " 'quality_control_report': {'status': 'pass'},\n",
+       " 'start_date': '2017-06-07T20:26Z',\n",
+       " 'extraction_target': 'DNA',\n",
+       " 'input_mass': {'has_numeric_value': 0.25, 'has_unit': 'g'}}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdb.extraction_set.estimated_document_count()\n",
+    "mdb.extraction_set.find_one()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b2e618f3-78b9-42b6-8ea9-63d080b1b0f6",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a55f9c6b3933449897439966b9e5b1b7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/171332 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "ValueError",
+     "evalue": " Unknown argument: quality_control_report = {'status': 'pass'}",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[9], line 10\u001b[0m\n\u001b[1;32m      8\u001b[0m pbar\u001b[38;5;241m.\u001b[39mset_description(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mprocessing \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcoll_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m...\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m# try:\u001b[39;00m\n\u001b[0;32m---> 10\u001b[0m nmdcdb \u001b[38;5;241m=\u001b[39m \u001b[43mNMDCDatabase\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43m{\u001b[49m\u001b[43mcoll_name\u001b[49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43mdissoc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmdb\u001b[49m\u001b[43m[\u001b[49m\u001b[43mcoll_name\u001b[49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfind_one\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m_id\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m]\u001b[49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m# except ValueError as e:\u001b[39;00m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;66;03m#     print(f\"no {coll_name}!\")\u001b[39;00m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m#     raise e\u001b[39;00m\n\u001b[1;32m     14\u001b[0m exemplar \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mgetattr\u001b[39m(nmdcdb, coll_name)[\u001b[38;5;241m0\u001b[39m]\n",
+      "File \u001b[0;32m<string>:28\u001b[0m, in \u001b[0;36m__init__\u001b[0;34m(self, planned_process_set, functional_annotation_agg, activity_set, biosample_set, collecting_biosamples_from_site_set, data_object_set, extraction_set, field_research_site_set, functional_annotation_set, genome_feature_set, library_preparation_set, mags_activity_set, metabolomics_analysis_activity_set, metagenome_annotation_activity_set, metagenome_assembly_set, metagenome_sequencing_activity_set, metaproteomics_analysis_activity_set, metatranscriptome_activity_set, nom_analysis_activity_set, omics_processing_set, pooling_set, processed_sample_set, read_based_taxonomy_analysis_activity_set, read_qc_analysis_activity_set, study_set, **_kwargs)\u001b[0m\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/nmdc_schema/nmdc_schema_accepting_legacy_ids.py:595\u001b[0m, in \u001b[0;36mDatabase.__post_init__\u001b[0;34m(self, *_, **kwargs)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_normalize_inlined_as_list(slot_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcollecting_biosamples_from_site_set\u001b[39m\u001b[38;5;124m\"\u001b[39m, slot_type\u001b[38;5;241m=\u001b[39mCollectingBiosamplesFromSite, key_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mid\u001b[39m\u001b[38;5;124m\"\u001b[39m, keyed\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[1;32m    593\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_normalize_inlined_as_list(slot_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdata_object_set\u001b[39m\u001b[38;5;124m\"\u001b[39m, slot_type\u001b[38;5;241m=\u001b[39mDataObject, key_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mid\u001b[39m\u001b[38;5;124m\"\u001b[39m, keyed\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[0;32m--> 595\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_normalize_inlined_as_list\u001b[49m\u001b[43m(\u001b[49m\u001b[43mslot_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mextraction_set\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mslot_type\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mExtraction\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkey_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mid\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkeyed\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m    597\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_normalize_inlined_as_list(slot_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfield_research_site_set\u001b[39m\u001b[38;5;124m\"\u001b[39m, slot_type\u001b[38;5;241m=\u001b[39mFieldResearchSite, key_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mid\u001b[39m\u001b[38;5;124m\"\u001b[39m, keyed\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[1;32m    599\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunctional_annotation_agg, \u001b[38;5;28mlist\u001b[39m):\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/linkml_runtime/utils/yamlutils.py:97\u001b[0m, in \u001b[0;36mYAMLRoot._normalize_inlined_as_list\u001b[0;34m(self, slot_name, slot_type, key_name, keyed)\u001b[0m\n\u001b[1;32m     96\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_normalize_inlined_as_list\u001b[39m(\u001b[38;5;28mself\u001b[39m, slot_name: \u001b[38;5;28mstr\u001b[39m, slot_type: Type, key_name: \u001b[38;5;28mstr\u001b[39m, keyed: \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m---> 97\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_normalize_inlined\u001b[49m\u001b[43m(\u001b[49m\u001b[43mslot_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mslot_type\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkey_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkeyed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/linkml_runtime/utils/yamlutils.py:182\u001b[0m, in \u001b[0;36mYAMLRoot._normalize_inlined\u001b[0;34m(self, slot_name, slot_type, key_name, keyed, is_list)\u001b[0m\n\u001b[1;32m    179\u001b[0m                 form_1(list_entry)\n\u001b[1;32m    180\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    181\u001b[0m         \u001b[38;5;66;03m# **kwargs\u001b[39;00m\n\u001b[0;32m--> 182\u001b[0m         cooked_obj \u001b[38;5;241m=\u001b[39m \u001b[43mslot_type\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mas_dict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlist_entry\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    183\u001b[0m         order_up(cooked_obj[key_name], cooked_obj)\n\u001b[1;32m    184\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(list_entry, \u001b[38;5;28mlist\u001b[39m):\n\u001b[1;32m    185\u001b[0m     \u001b[38;5;66;03m# *args\u001b[39;00m\n",
+      "File \u001b[0;32m<string>:23\u001b[0m, in \u001b[0;36m__init__\u001b[0;34m(self, id, name, description, alternative_identifiers, designated_class, end_date, has_input, has_output, processing_institution, protocol_link, start_date, instrument_name, qc_status, qc_comment, has_failure_categorization, extractant, extraction_method, extraction_target, input_mass, volume, **_kwargs)\u001b[0m\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/nmdc_schema/nmdc_schema_accepting_legacy_ids.py:3932\u001b[0m, in \u001b[0;36mExtraction.__post_init__\u001b[0;34m(self, *_, **kwargs)\u001b[0m\n\u001b[1;32m   3929\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvolume \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvolume, QuantityValue):\n\u001b[1;32m   3930\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvolume \u001b[38;5;241m=\u001b[39m QuantityValue(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mas_dict(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvolume))\n\u001b[0;32m-> 3932\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__post_init__\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   3933\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdesignated_class \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclass_class_curie)\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/nmdc_schema/nmdc_schema_accepting_legacy_ids.py:3849\u001b[0m, in \u001b[0;36mPlannedProcess.__post_init__\u001b[0;34m(self, *_, **kwargs)\u001b[0m\n\u001b[1;32m   3846\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhas_failure_categorization \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhas_failure_categorization] \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhas_failure_categorization \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m []\n\u001b[1;32m   3847\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhas_failure_categorization \u001b[38;5;241m=\u001b[39m [v \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(v, FailureCategorization) \u001b[38;5;28;01melse\u001b[39;00m FailureCategorization(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mas_dict(v)) \u001b[38;5;28;01mfor\u001b[39;00m v \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhas_failure_categorization]\n\u001b[0;32m-> 3849\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__post_init__\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   3850\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdesignated_class \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclass_class_curie)\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/nmdc_schema/nmdc_schema_accepting_legacy_ids.py:828\u001b[0m, in \u001b[0;36mNamedThing.__post_init__\u001b[0;34m(self, *_, **kwargs)\u001b[0m\n\u001b[1;32m    825\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39malternative_identifiers \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39malternative_identifiers] \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39malternative_identifiers \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m []\n\u001b[1;32m    826\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39malternative_identifiers \u001b[38;5;241m=\u001b[39m [v \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(v, URIorCURIE) \u001b[38;5;28;01melse\u001b[39;00m URIorCURIE(v) \u001b[38;5;28;01mfor\u001b[39;00m v \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39malternative_identifiers]\n\u001b[0;32m--> 828\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__post_init__\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/nmdc/nmdc-runtime/venv/lib/python3.10/site-packages/linkml_runtime/utils/yamlutils.py:48\u001b[0m, in \u001b[0;36mYAMLRoot.__post_init__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m     46\u001b[0m     v \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mrepr\u001b[39m(kwargs[k])[:\u001b[38;5;241m40\u001b[39m]\u001b[38;5;241m.\u001b[39mreplace(\u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\\\\u001b[39;00m\u001b[38;5;124mn\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     47\u001b[0m     messages\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mTypedNode\u001b[38;5;241m.\u001b[39myaml_loc(k)\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m Unknown argument: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mk\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m = \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mv\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m---> 48\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(messages))\n",
+      "\u001b[0;31mValueError\u001b[0m:  Unknown argument: quality_control_report = {'status': 'pass'}"
+     ]
+    }
+   ],
+   "source": [
+    "mdb.alldocs.drop()\n",
+    "\n",
+    "n_docs_total = sum(mdb[name].estimated_document_count() for name in collection_names)\n",
+    "pbar = tqdm(total=n_docs_total)\n",
+    "\n",
+    "#- for each collection name\n",
+    "for coll_name in collection_names:\n",
+    "    pbar.set_description(f\"processing {coll_name}...\")\n",
+    "    # try:\n",
+    "    nmdcdb = NMDCDatabase(**{coll_name: [dissoc(mdb[coll_name].find_one(), '_id')]})\n",
+    "    # except ValueError as e:\n",
+    "    #     print(f\"no {coll_name}!\")\n",
+    "    #     raise e\n",
+    "    exemplar = getattr(nmdcdb, coll_name)[0]\n",
+    "    newdoc_type = class_hierarchy_as_list(exemplar)\n",
+    "    # for each doc in collection\n",
+    "    mdb.alldocs.insert_many([assoc(dissoc(doc, 'type', '_id'), 'type', newdoc_type) for doc in mdb[coll_name].find()])\n",
+    "    pbar.update(mdb[coll_name].estimated_document_count())\n",
+    "\n",
+    "pbar.close()\n",
+    "mdb.alldocs.create_index(\"id\") # WTF... nmdc:0078a0f981ad3f92693c2bc3b6470791 prevents mdb.alldocs.create_index(\"id\", unique=True)\n",
+    "print(\"refreshed `alldocs` collection\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca194c0f-7417-41d2-bea8-a5a54392fee6",
+   "metadata": {},
+   "source": [
+    "# Validation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab859bb2-808c-48e2-8412-d8a3a79ca4e8",
+   "metadata": {},
+   "source": [
+    "Collect \"top level\" (nmdc:Database slot range) classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a2dbaf22-46e9-4de7-8288-05bc8cd2e5f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nmdc_view = nmdc_schema_view()\n",
+    "toplevel_classes = set()\n",
+    "for name in nmdc_database_collection_instance_class_names():\n",
+    "    toplevel_classes |= set(nmdc_view.class_ancestors(name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "969e13e0-25c0-4623-bcab-93097132924b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Activity',\n",
+       " 'Biosample',\n",
+       " 'BiosampleProcessing',\n",
+       " 'CollectingBiosamplesFromSite',\n",
+       " 'DataObject',\n",
+       " 'Extraction',\n",
+       " 'FieldResearchSite',\n",
+       " 'FunctionalAnnotation',\n",
+       " 'FunctionalAnnotationAggMember',\n",
+       " 'GenomeFeature',\n",
+       " 'LibraryPreparation',\n",
+       " 'MagsAnalysisActivity',\n",
+       " 'MaterialEntity',\n",
+       " 'MetabolomicsAnalysisActivity',\n",
+       " 'MetagenomeAnnotationActivity',\n",
+       " 'MetagenomeAssembly',\n",
+       " 'MetagenomeSequencingActivity',\n",
+       " 'MetaproteomicsAnalysisActivity',\n",
+       " 'MetatranscriptomeActivity',\n",
+       " 'NamedThing',\n",
+       " 'NomAnalysisActivity',\n",
+       " 'OmicsProcessing',\n",
+       " 'PlannedProcess',\n",
+       " 'Pooling',\n",
+       " 'ProcessedSample',\n",
+       " 'ReadBasedTaxonomyAnalysisActivity',\n",
+       " 'ReadQcAnalysisActivity',\n",
+       " 'Site',\n",
+       " 'Study',\n",
+       " 'WorkflowExecutionActivity'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toplevel_classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8645690e-7a9d-4f1e-8e62-0cbdde825890",
+   "metadata": {},
+   "source": [
+    "Referential integrity checking:\n",
+    "- \"naive\" errors collected in `not_found` list\n",
+    "- (hierarchy-aware) type errors (doc found, but of invalid type) collected in `invalid_type` list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "103d70b6-24ab-41bd-8b7f-d2faaa028bdf",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "errors = {\"not_found\": [], \"invalid_type\": []}\n",
+    "\n",
+    "n_docs_total = sum(mdb[name].estimated_document_count() for name in collection_names)\n",
+    "pbar = tqdm(total=n_docs_total)\n",
+    "\n",
+    "for name in sorted(collection_names):\n",
+    "    cls_name = collection_name_to_class_names[name][0]\n",
+    "    slot_map = {\n",
+    "        slot.name: slot\n",
+    "        for slot in nmdc_view.class_induced_slots(cls_name)\n",
+    "    }\n",
+    "    pbar.set_description(f\"processing {name}...\")\n",
+    "    for doc in mdb[name].find():\n",
+    "        doc = dissoc(doc, \"_id\")\n",
+    "        for field, value in doc.items():\n",
+    "            assert field in slot_map, f\"{name} doc {doc['id']}: field {field} not a valid slot\"\n",
+    "            slot_range = str(slot_map[field].range)\n",
+    "            assert slot_range, type(slot_range)\n",
+    "            if not slot_range in toplevel_classes:\n",
+    "                continue\n",
+    "            if not isinstance(value, list):\n",
+    "                value = [value]\n",
+    "            for v in value:\n",
+    "                if mdb.alldocs.find_one({\"id\": v}, [\"_id\"]) is None:\n",
+    "                    errors[\"not_found\"].append(f\"{name} doc {doc['id']}: field {field} referenced doc {v} not found\")\n",
+    "                elif mdb.alldocs.find_one({\"id\": v, \"type\": slot_range}, [\"_id\"]) is None:\n",
+    "                    errors[\"invalid_type\"].append(f\"{name} doc {doc['id']}: field {field} referenced doc {v} not of type {slot_range}\")\n",
+    "        pbar.update(1)\n",
+    "pbar.close()           "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e01450d1-3369-4fc5-80be-9787e00a6597",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(errors[\"not_found\"]), len(errors[\"invalid_type\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a25857f4-e26e-4896-9e5f-607e7b4bb07c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors[\"not_found\"][:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "855e232d-0e94-428e-96eb-0535c5135bee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdb.alldocs.find_one({\"id\": \"nmdc:mga0vx38\"}) is None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33516e3c-f10d-4c30-942b-0d01d06082f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors[\"invalid_type\"][:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29ec7e82-d079-4525-bd7b-d770fd69d788",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OmicsProcessing is not subclass of Activity (!)\n",
+    "mdb.alldocs.find_one({\"id\": \"emsl:570856\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "690ea8f8-05be-4d0a-aaa4-5c04aa4c640c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Description
This PR add two notebooks for prototyping validation solutions to the `nmdc-runtime` repo

Related to #318 

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Notebooks have been run locally




