### PR TITLE
Implement API endpoint that returns name of collection containing document having a given `id`

### DIFF
--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -216,7 +216,7 @@ def get_class_name_and_collection_names_by_doc_id(
     containing_collection_name = None
     for collection_name in collection_names:
         collection = mdb.get_collection(name=collection_name)
-        if collection.count_documents(dict(id=hypothetical_doc_id)) > 0:
+        if collection.count_documents(dict(id=hypothetical_doc_id), limit=1) > 0:
             containing_collection_name = collection_name
             break
 

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -135,7 +135,7 @@ def get_by_id(
 
 
 @router.get("/nmdcschema/ids/{hypothetical_doc_id}/collection-and-class-name")
-def get_collection_name_and_class_name_by_doc_id(hypothetical_doc_id: str):
+def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
     r"""
     Gets the name of the Mongo collection that could contain a document having this `id`
     and the name of the NMDC Schema class whose instances could have this `id`.
@@ -161,7 +161,7 @@ def get_collection_name_and_class_name_by_doc_id(hypothetical_doc_id: str):
     # Determine the schema class, if any, of which the specified `id` could belong to an instance.
     schema_class_name = None
     for typecode in typecodes():
-        if typecode_portion == typecode:
+        if typecode_portion == typecode["name"]:
             schema_class_name_prefixed = typecode["schema_class"]
             schema_class_name = schema_class_name_prefixed.replace("nmdc:", "", 1)
             break
@@ -170,7 +170,7 @@ def get_collection_name_and_class_name_by_doc_id(hypothetical_doc_id: str):
         return None  # abort
 
     # Determine the Mongo collection in which instances of that schema class can reside.
-    collection_name = None
+    collection_names = []
     DATABASE_CLASS_NAME = "Database"
     schema_view = SchemaView(get_nmdc_schema_definition())
     for slot_name in schema_view.class_slots(DATABASE_CLASS_NAME):
@@ -186,15 +186,14 @@ def get_collection_name_and_class_name_by_doc_id(hypothetical_doc_id: str):
             name_of_eligible_class
         )
         if schema_class_name in names_of_eligible_classes:
-            collection_name = slot_name
-            break
+            collection_names.append(slot_name)
 
-    if collection_name is None:
+    if not collection_names:
         return None  # abort
 
     return {
         "id": hypothetical_doc_id,
-        "collection_name": collection_name,
+        "collection_names": collection_names,
         "class_name": schema_class_name,
     }
 

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -135,9 +135,7 @@ def get_by_id(
 
 
 @router.get("/nmdcschema/ids/{hypothetical_doc_id}/collection-and-class-name")
-def get_collection_name_and_class_name_by_doc_id(
-    hypothetical_doc_id: str
-):
+def get_collection_name_and_class_name_by_doc_id(hypothetical_doc_id: str):
     r"""
     Gets the name of the Mongo collection that could contain a document having this `id`
     and the name of the NMDC Schema class whose instances could have this `id`.
@@ -146,17 +144,17 @@ def get_collection_name_and_class_name_by_doc_id(
     #       not used here because that function (a) only processes collections whose
     #       names end with `_set` and (b) only works for `id` values that are in
     #       use in the database (as opposed to hypothetical `id` values).
-    
+
     # Extract the typecode portion, if any, of the specified `id`.
     #
-    # Examples: 
+    # Examples:
     # - "nmdc:foo-123-456" → "foo"
     # - "foo:nmdc-123-456" → `None`
     #
     pattern = re.compile(r"^nmdc:(\w+)?-")
     match = pattern.search(hypothetical_doc_id)
     typecode_portion = match.group(1) if match else None
-    
+
     if typecode_portion is None:
         return None  # abort
 
@@ -181,10 +179,12 @@ def get_collection_name_and_class_name_by_doc_id(
         # If this slot doesn't represent a Mongo collection, abort this iteration.
         if not (slot_definition.multivalued and slot_definition.inlined_as_list):
             continue
-        
+
         # Determine the names of the classes whose instances can be stored in this collection.
         name_of_eligible_class = slot_definition.range
-        names_of_eligible_classes = schema_view.class_descendants(name_of_eligible_class)
+        names_of_eligible_classes = schema_view.class_descendants(
+            name_of_eligible_class
+        )
         if schema_class_name in names_of_eligible_classes:
             collection_name = slot_name
             break

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -168,7 +168,7 @@ def get_collection_name_by_doc_id(
     if typecode_portion is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'No document having `id` "{doc_id}" was found.',
+            detail=f'The typecode portion of the specified `id` is invalid.',
         )
 
     # Determine the schema class, if any, of which the specified `id` could belong to an instance.
@@ -182,7 +182,7 @@ def get_collection_name_by_doc_id(
     if schema_class_name is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'No document having `id` "{doc_id}" was found.',
+            detail=f'The specified `id` is not compatible with any schema classes.',
         )
 
     # Determine the Mongo collection(s) in which instances of that schema class can reside.
@@ -207,7 +207,7 @@ def get_collection_name_by_doc_id(
     if len(collection_names) == 0:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'No document having `id` "{doc_id}" was found.',
+            detail=f'The specified `id` is not compatible with any database collections.',
         )
 
     # Use the Mongo database to determine which of those collections a document having that `id` actually
@@ -218,6 +218,12 @@ def get_collection_name_by_doc_id(
         if collection.count_documents(dict(id=doc_id), limit=1) > 0:
             containing_collection_name = collection_name
             break
+
+    if containing_collection_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'The specified `id` does not belong to any documents.',
+        )
 
     return {
         "id": doc_id,

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -134,8 +134,8 @@ def get_by_id(
     )
 
 
-@router.get("/nmdcschema/ids/{hypothetical_doc_id}/collection-and-class-name")
-def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
+@router.get("/nmdcschema/ids/{hypothetical_doc_id}/class-and-collection-names")
+def get_class_name_and_collection_names_by_doc_id(hypothetical_doc_id: str):
     r"""
     Gets the name of the Mongo collection(s) that could contain a document having this `id`
     and the name of the NMDC Schema class of which an instance could have this `id`.
@@ -206,8 +206,8 @@ def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
 
     return {
         "id": hypothetical_doc_id,
-        "collection_names": collection_names,
         "class_name": schema_class_name,
+        "collection_names": collection_names,
     }
 
 

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -142,6 +142,9 @@ def get_class_name_and_collection_names_by_doc_id(hypothetical_doc_id: str):
 
     Returns an HTTP 404 response if either (a) no associated collection names are found or
     (b) no associated class name is found.
+
+    Note: This endpoint does not use the Mongo database. The Mongo collection names it
+          returns are names of slots of the `Database` class in the NMDC Schema.
     """
     # Note: The `nmdc_runtime.api.core.metadata.map_id_to_collection` function is
     #       not used here because that function (a) only processes collections whose

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -168,7 +168,7 @@ def get_collection_name_by_doc_id(
     if typecode_portion is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'The typecode portion of the specified `id` is invalid.',
+            detail=f"The typecode portion of the specified `id` is invalid.",
         )
 
     # Determine the schema class, if any, of which the specified `id` could belong to an instance.
@@ -182,7 +182,7 @@ def get_collection_name_by_doc_id(
     if schema_class_name is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'The specified `id` is not compatible with any schema classes.',
+            detail=f"The specified `id` is not compatible with any schema classes.",
         )
 
     # Determine the Mongo collection(s) in which instances of that schema class can reside.
@@ -207,7 +207,7 @@ def get_collection_name_by_doc_id(
     if len(collection_names) == 0:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'The specified `id` is not compatible with any database collections.',
+            detail=f"The specified `id` is not compatible with any database collections.",
         )
 
     # Use the Mongo database to determine which of those collections a document having that `id` actually
@@ -222,7 +222,7 @@ def get_collection_name_by_doc_id(
     if containing_collection_name is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'The specified `id` does not belong to any documents.',
+            detail=f"The specified `id` does not belong to any documents.",
         )
 
     return {

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -137,8 +137,8 @@ def get_by_id(
 @router.get("/nmdcschema/ids/{hypothetical_doc_id}/collection-and-class-name")
 def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
     r"""
-    Gets the name of the Mongo collection that could contain a document having this `id`
-    and the name of the NMDC Schema class whose instances could have this `id`.
+    Gets the name of the Mongo collection(s) that could contain a document having this `id`
+    and the name of the NMDC Schema class of which an instance could have this `id`.
     """
     # Note: The `nmdc_runtime.api.core.metadata.map_id_to_collection` function is
     #       not used here because that function (a) only processes collections whose
@@ -169,7 +169,7 @@ def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
     if schema_class_name is None:
         return None  # abort
 
-    # Determine the Mongo collection in which instances of that schema class can reside.
+    # Determine the Mongo collection(s) in which instances of that schema class can reside.
     collection_names = []
     DATABASE_CLASS_NAME = "Database"
     schema_view = SchemaView(get_nmdc_schema_definition())
@@ -188,7 +188,7 @@ def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
         if schema_class_name in names_of_eligible_classes:
             collection_names.append(slot_name)
 
-    if not collection_names:
+    if len(collection_names) == 0:
         return None  # abort
 
     return {

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -166,7 +166,7 @@ def get_class_name_and_collection_names_by_doc_id(
     if typecode_portion is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No associated collection names or class name were found.",
+            detail=f"No compatible collection names or class name were found.",
         )
 
     # Determine the schema class, if any, of which the specified `id` could belong to an instance.
@@ -180,7 +180,7 @@ def get_class_name_and_collection_names_by_doc_id(
     if schema_class_name is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No associated class name was found.",
+            detail=f"No compatible class name was found.",
         )
 
     # Determine the Mongo collection(s) in which instances of that schema class can reside.
@@ -206,8 +206,8 @@ def get_class_name_and_collection_names_by_doc_id(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=(
-                f'An associated class name was found ("{schema_class_name}"), '
-                f"but no associated collection names were found."
+                f'A compatible class name was found ("{schema_class_name}"), '
+                f"but no compatible collection names were found."
             ),
         )
 
@@ -222,8 +222,8 @@ def get_class_name_and_collection_names_by_doc_id(
 
     return {
         "id": hypothetical_doc_id,
-        "class_name": schema_class_name,
-        "collection_names": collection_names,
+        "compatible_class_name": schema_class_name,
+        "compatible_collection_names": collection_names,
         "containing_collection_name": containing_collection_name,
     }
 

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -201,7 +201,7 @@ def get_collection_names_and_class_name_by_doc_id(hypothetical_doc_id: str):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f'An associated class name was found ("{schema_class_name}"), '
-                   f"but no associated collection names were found.",
+            f"but no associated collection names were found.",
         )
 
     return {

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -212,7 +212,7 @@ def get_class_name_and_collection_names_by_doc_id(
         )
 
     # Use the Mongo database to determine which of those collections a document having that `id` actually
-    # resides, if any. If multiple collections contains such a document, report only the first one.
+    # resides in, if any. If multiple collections contain such a document, report only the first one.
     containing_collection_name = None
     for collection_name in collection_names:
         collection = mdb.get_collection(name=collection_name)

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -282,11 +282,13 @@ def test_submit_workflow_activities(api_site_client):
 
 
 def test_get_class_name_and_collection_names_by_doc_id():
+    base_url = os.getenv("API_HOST")
+
     # Happy path.
     id_ = "nmdc:sty-1-foobar"
     response = requests.request(
         "GET",
-        f"/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
     )
     body = response.json()
     assert response.status_code == 200
@@ -298,6 +300,6 @@ def test_get_class_name_and_collection_names_by_doc_id():
     id_ = "fake:sty-1-foobar"
     response = requests.request(
         "GET",
-        f"/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
     )
     assert response.status_code == 404

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -298,8 +298,8 @@ def test_get_class_name_and_collection_names_by_doc_id():
     body = response.json()
     assert response.status_code == 200
     assert body["id"] == id_
-    assert body["class_name"] == "Study"
-    assert "study_set" in body["collection_names"]
+    assert body["compatible_class_name"] == "Study"
+    assert "study_set" in body["compatible_collection_names"]
     assert body["containing_collection_name"] == "study_set"
 
     # Valid id, but document does not exist in database.
@@ -311,8 +311,8 @@ def test_get_class_name_and_collection_names_by_doc_id():
     body = response.json()
     assert response.status_code == 200
     assert body["id"] == id_
-    assert body["class_name"] == "Study"
-    assert "study_set" in body["collection_names"]
+    assert body["compatible_class_name"] == "Study"
+    assert "study_set" in body["compatible_collection_names"]
     assert body["containing_collection_name"] is None
 
     # Invalid typecode.

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -286,7 +286,7 @@ def test_get_class_name_and_collection_names_by_doc_id():
 
     # Seed the database.
     mdb = get_mongo_db()
-    study_set_collection = mdb["nmdc"].get_collection("study_set")
+    study_set_collection = mdb.get_collection(name="study_set")
     study_set_collection.insert_one(dict(id="nmdc:sty-1-foobar"))
 
     # Valid id, and document exists in database.

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -286,7 +286,7 @@ def test_get_class_name_and_collection_names_by_doc_id():
     id_ = "nmdc:sty-1-foobar"
     response = requests.request(
         "GET",
-        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"/nmdcschema/ids/{id_}/class-and-collection-names"
     )
     body = response.json()
     assert response.status_code == 200
@@ -298,6 +298,6 @@ def test_get_class_name_and_collection_names_by_doc_id():
     id_ = "fake:sty-1-foobar"
     response = requests.request(
         "GET",
-        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"/nmdcschema/ids/{id_}/class-and-collection-names"
     )
     assert response.status_code == 404

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -279,3 +279,25 @@ def test_submit_workflow_activities(api_site_client):
     if doc_to_restore:
         mdb[test_collection].insert_one(doc_to_restore)
     assert "id" in rv.json() and "input_read_count" not in rv.json()
+
+
+def test_get_class_name_and_collection_names_by_doc_id():
+    # Happy path.
+    id_ = "nmdc:sty-1-foobar"
+    response = requests.request(
+        "GET",
+        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+    )
+    body = response.json()
+    assert response.status_code == 200
+    assert body["id"] == "nmdc:sty-1-foobar"
+    assert body["class_name"] == "Study"
+    assert "study_set" in body["collection_names"]
+
+    # Invalid typecode.
+    id_ = "fake:sty-1-foobar"
+    response = requests.request(
+        "GET",
+        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+    )
+    assert response.status_code == 404

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -293,7 +293,7 @@ def test_get_class_name_and_collection_names_by_doc_id():
     id_ = "nmdc:sty-1-foobar"
     response = requests.request(
         "GET",
-        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"{base_url}/nmdcschema/ids/{id_}/collection-name"
     )
     body = response.json()
     assert response.status_code == 200
@@ -304,7 +304,7 @@ def test_get_class_name_and_collection_names_by_doc_id():
     id_ = "nmdc:sty-1-bazqux"
     response = requests.request(
         "GET",
-        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"{base_url}/nmdcschema/ids/{id_}/collection-name"
     )
     assert response.status_code == 404
 
@@ -312,6 +312,6 @@ def test_get_class_name_and_collection_names_by_doc_id():
     id_ = "nmdc:foo-1-foobar"
     response = requests.request(
         "GET",
-        f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
+        f"{base_url}/nmdcschema/ids/{id_}/collection-name"
     )
     assert response.status_code == 404

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -289,7 +289,7 @@ def test_get_class_name_and_collection_names_by_doc_id():
     study_set_collection = mdb.get_collection(name="study_set")
     study_set_collection.insert_one(dict(id="nmdc:sty-1-foobar"))
 
-    # Valid id, and document exists in database.
+    # Valid `id`, and the document exists in database.
     id_ = "nmdc:sty-1-foobar"
     response = requests.request(
         "GET",
@@ -298,24 +298,17 @@ def test_get_class_name_and_collection_names_by_doc_id():
     body = response.json()
     assert response.status_code == 200
     assert body["id"] == id_
-    assert body["compatible_class_name"] == "Study"
-    assert "study_set" in body["compatible_collection_names"]
-    assert body["containing_collection_name"] == "study_set"
+    assert body["collection_name"] == "study_set"
 
-    # Valid id, but document does not exist in database.
+    # Valid `id`, but the document does not exist in database.
     id_ = "nmdc:sty-1-bazqux"
     response = requests.request(
         "GET",
         f"{base_url}/nmdcschema/ids/{id_}/class-and-collection-names"
     )
-    body = response.json()
-    assert response.status_code == 200
-    assert body["id"] == id_
-    assert body["compatible_class_name"] == "Study"
-    assert "study_set" in body["compatible_collection_names"]
-    assert body["containing_collection_name"] is None
+    assert response.status_code == 404
 
-    # Invalid typecode.
+    # Invalid `id` (because "foo" is an invalid typecode).
     id_ = "nmdc:foo-1-foobar"
     response = requests.request(
         "GET",


### PR DESCRIPTION
# Description

In this branch, I implemented a new API endpoint. Its behavior is described in its docstring, shown here:

```py
@router.get("/nmdcschema/ids/{doc_id}/collection-name")
def get_collection_name_by_doc_id(
    doc_id: str,
    mdb: MongoDatabase = Depends(get_mongo_db),
):
    r"""
    Returns the name of the collection, if any, containing the document having the specified `id`.

    This endpoint uses the NMDC Schema to determine the schema class of which an instance could have
    the specified value as its `id`; and then uses the NMDC Schema to determine the names of the
    `Database` slots (i.e. Mongo collection names) that could contain instances of that schema class.

    This endpoint then searches those Mongo collections for a document having that `id`.
    If it finds one, it responds with the name of the collection containing the document.
    If it does not find one, it response with an `HTTP 404 Not Found` response.
    """
```

Fixes https://github.com/microbiomedata/nmdc-runtime/issues/531

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [x] I implemented an automated test targeting the new functionality and that test ran/passed on GitHub Actions:
      ![image](https://github.com/microbiomedata/nmdc-runtime/assets/134325062/5af22995-3dbd-45ac-a02c-e18a21d2dbde)

**Configuration Details**: none

# Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)
  > I delegated this test running to GitHub Actions, which passes