### PR TITLE
Configure CORS to allow requests from clients hosted on GitHub Pages

### DIFF
--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -441,7 +441,8 @@ app.include_router(api_router)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=r"(http://localhost:\d+)|(https://.+?\.microbiomedata\.org)",
+    # Allow requests from client-side web apps hosted in local development environments, on microbiomedata.org, and on GitHub Pages.
+    allow_origin_regex=r"(http://localhost:\d+)|(https://.+?\.microbiomedata\.org)|(https://microbiomedata\.github\.io)",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
# Description

In this branch, I made it so the Runtime will respond to requests originating from `https://microbiomedata.github.io` (i.e. web clients hosted on GitHub Pages). That will enable team members to develop unofficial web clients that can streamline certain processes while similar functionality does not exist in the Runtime (maybe by design).

Fixes #508

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It has not been tested beyond observing that none of the GitHub Actions workflows fail with the change present.

# Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
      - GitHub Actions ran it for me
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)