### PR TITLE
fix: actual errors yield a more informative error code

### DIFF
--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -182,6 +182,11 @@ def _run_query(query, mdb) -> CommandResponse:
         if cmd_response.ok
         else QueryRun(qid=query.id, ran_at=ran_at, error=cmd_response)
     )
+    if cmd_response.writeErrors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=cmd_response.writeErrors,
+        )
     if q_type in (DeleteCommand, UpdateCommand) and cmd_response.n == 0:
         raise HTTPException(
             status_code=status.HTTP_418_IM_A_TEAPOT,


### PR DESCRIPTION
# Description

Invalid `/queries:run` calls (that is, calls with semantically invalid mongodb commands) return a 422 error with info, rather than the more generic 418.

Closes #523

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] `test_queries_run_invalid_update` (status: draft that needs work)

**Configuration Details**: none

# Checklist:

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


