### PR TITLE
Implement migration notebook for `v10.3.0` to `v10.4.0`

### DIFF
--- a/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
@@ -12,6 +12,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "987824fa",
+   "metadata": {},
+   "source": [
+    "There is a migrator for the schema changes from `v10.3.0` to `v10.4.0`. That migrator was added to the `nmdc-schema` repo \"late\" (i.e. in version `v10.5.4`). There is no migrator for the schema changes, if any, from `v10.4.0` to `10.5.4`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f65ad4ab",
    "metadata": {},
    "source": [
@@ -132,7 +140,7 @@
    "source": [
     "%pip install --upgrade pip\n",
     "%pip install -r requirements.txt\n",
-    "%pip install nmdc-schema==10.4.0"
+    "%pip install nmdc-schema==10.5.4  # note: the 10.3.0-to-10.4.0 migrator was introduced in schema package version 10.5.4"
    ]
   },
   {
@@ -155,7 +163,7 @@
     "# Third-party packages:\n",
     "import pymongo\n",
     "from jsonschema import Draft7Validator\n",
-    "from nmdc_schema.nmdc_data import get_nmdc_jsonschema_dict, SchemaVariantIdentifier\n",
+    "from nmdc_schema.nmdc_data import get_nmdc_jsonschema_dict\n",
     "from nmdc_schema.migrators.adapters.mongo_adapter import MongoAdapter\n",
     "from nmdc_schema.migrators.migrator_from_10_3_0_to_10_4_0 import Migrator\n",
     "\n",
@@ -253,7 +261,7 @@
    },
    "outputs": [],
    "source": [
-    "nmdc_jsonschema: dict = get_nmdc_jsonschema_dict(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)\n",
+    "nmdc_jsonschema: dict = get_nmdc_jsonschema_dict()\n",
     "nmdc_jsonschema_validator = Draft7Validator(nmdc_jsonschema)\n",
     "\n",
     "# Perform sanity tests of the NMDC Schema dictionary and the JSON Schema validator.\n",

--- a/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
@@ -1,0 +1,647 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Migrate MongoDB database from `nmdc-schema` `v10.3.0` to `v10.4.0`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f65ad4ab",
+   "metadata": {},
+   "source": [
+    "## Prerequisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37d358ba",
+   "metadata": {},
+   "source": [
+    "### 1. Determine MongoDB collections involved.\n",
+    "\n",
+    "To determine this, we look at the migrator, itself. We make note of which collections are referenced by that migrator (whether for reading or for writing) and add them to the `COLLECTION_NAMES` list below.\n",
+    "\n",
+    "```py\n",
+    "# TODO: Consider separating them into two lists: `COLLECTIONS_TO_DUMP` and `COLLECTIONS_TO_RESTORE`.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5da29b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: `*arr` in Python is like `...arr` in JavaScript (it's a \"spread\" operator).\n",
+    "COLLECTION_NAMES: list[str] = [\n",
+    "    \"nom_analysis_activity_set\",\n",
+    "]\n",
+    "print(str(len(COLLECTION_NAMES)) + \" collection names\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09966b0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Eliminate duplicates.\n",
+    "COLLECTION_NAMES = list(set(COLLECTION_NAMES))\n",
+    "print(str(len(COLLECTION_NAMES)) + \" collection names (distinct)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17f351e8",
+   "metadata": {},
+   "source": [
+    "### 2. Coordinate with stakeholders.\n",
+    "\n",
+    "We will be enacting full Runtime and Database downtime for this migration. Ensure stakeholders are aware of that."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "233a35c3",
+   "metadata": {},
+   "source": [
+    "### 3. Set up environment.\n",
+    "\n",
+    "Here, you'll prepare an environment for running this notebook.\n",
+    "\n",
+    "1. Start a **MongoDB server** on your local machine (and ensure it does **not** already contain a database named `nmdc`).\n",
+    "    1. You can start a [Docker](https://hub.docker.com/_/mongo)-based MongoDB server at `localhost:27055` by running this command (this MongoDB server will be accessible without a username or password).\n",
+    "       ```shell\n",
+    "       docker run --rm --detach --name mongo-migration-transformer -p 27055:27017 mongo:6.0.4\n",
+    "       ```\n",
+    "2. Create and populate a **notebook configuration file** named `.notebook.env`.\n",
+    "    1. You can use `.notebook.env.example` as a template:\n",
+    "       ```shell\n",
+    "       $ cp .notebook.env.example .notebook.env\n",
+    "       ```\n",
+    "3. Create and populate the two **MongoDB configuration files** that this notebook will use to connect to the \"origin\" and \"transformer\" MongoDB servers. The \"origin\" MongoDB server is the one that contains the database you want to migrate; and the \"transformer\" MongoDB server is the one you want to use to perform the data transformations. In practice, the \"origin\" MongoDB server is typically a remote server, and the \"transformer\" MongoDB server is typically a local server.\n",
+    "    1. You can use `.mongo.yaml.example` as a template:\n",
+    "       ```shell\n",
+    "       $ cp .mongo.yaml.example .mongo.origin.yaml\n",
+    "       $ cp .mongo.yaml.example .mongo.transformer.yaml\n",
+    "       ```\n",
+    "       > When populating the file for the origin MongoDB server, use credentials that have **both read and write access** to the `nmdc` database.\n",
+    "\n",
+    "- TODO: Be more specific about the Mongo privileges necessary to perform a `mongodump` and a `mongorestore` that may involve creating/deleting collections."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69937b18",
+   "metadata": {},
+   "source": [
+    "## Procedure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe81196a",
+   "metadata": {},
+   "source": [
+    "### Install Python dependencies\n",
+    "\n",
+    "In this step, you'll [install](https://saturncloud.io/blog/what-is-the-difference-between-and-in-jupyter-notebooks/) the Python packages upon which this notebook depends.\n",
+    "\n",
+    "> Note: If the output of this cell says \"Note: you may need to restart the kernel to use updated packages\", restart the kernel (not the notebook cells) now.\n",
+    "\n",
+    "References: \n",
+    "- https://pypi.org/project/nmdc-schema/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e25a0af308c3185b",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade pip\n",
+    "%pip install -r requirements.txt\n",
+    "%pip install nmdc-schema==10.4.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a407c354",
+   "metadata": {},
+   "source": [
+    "### Import Python dependencies\n",
+    "\n",
+    "Import the Python objects upon which this notebook depends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbecd561",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Third-party packages:\n",
+    "import pymongo\n",
+    "from jsonschema import Draft7Validator\n",
+    "from nmdc_schema.nmdc_data import get_nmdc_jsonschema_dict, SchemaVariantIdentifier\n",
+    "from nmdc_schema.migrators.adapters.mongo_adapter import MongoAdapter\n",
+    "from nmdc_schema.migrators.migrator_from_10_3_0_to_10_4_0 import Migrator\n",
+    "\n",
+    "# First-party packages:\n",
+    "from helpers import Config\n",
+    "from bookkeeper import Bookkeeper, MigrationEvent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99b20ff4",
+   "metadata": {},
+   "source": [
+    "### Parse configuration files\n",
+    "\n",
+    "Parse the notebook and Mongo configuration files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1eac645a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg = Config()\n",
+    "\n",
+    "# Define some aliases we can use to make the shell commands in this notebook easier to read.\n",
+    "mongodump = cfg.mongodump_path\n",
+    "mongorestore = cfg.mongorestore_path\n",
+    "\n",
+    "# Perform a sanity test of the application paths.\n",
+    "!{mongodump} --version\n",
+    "!{mongorestore} --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68245d2b",
+   "metadata": {},
+   "source": [
+    "### Create MongoDB clients\n",
+    "\n",
+    "Create MongoDB clients you can use to access the \"origin\" and \"transformer\" MongoDB servers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e95f559",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mongo client for \"origin\" MongoDB server.\n",
+    "origin_mongo_client = pymongo.MongoClient(host=cfg.origin_mongo_server_uri, directConnection=True)\n",
+    "\n",
+    "# Mongo client for \"transformer\" MongoDB server.\n",
+    "transformer_mongo_client = pymongo.MongoClient(host=cfg.transformer_mongo_server_uri)\n",
+    "\n",
+    "# Perform sanity tests of those MongoDB clients' abilities to access their respective MongoDB servers.\n",
+    "with pymongo.timeout(3):\n",
+    "    # Display the MongoDB server version (running on the \"origin\" Mongo server).\n",
+    "    print(\"Origin Mongo server version:      \" + origin_mongo_client.server_info()[\"version\"])\n",
+    "\n",
+    "    # Sanity test: Ensure the origin database exists.\n",
+    "    assert \"nmdc\" in origin_mongo_client.list_database_names(), \"Origin database does not exist.\"\n",
+    "\n",
+    "    # Display the MongoDB server version (running on the \"transformer\" Mongo server).\n",
+    "    print(\"Transformer Mongo server version: \" + transformer_mongo_client.server_info()[\"version\"])\n",
+    "\n",
+    "    # Sanity test: Ensure the transformation database does not exist.\n",
+    "    assert \"nmdc\" not in transformer_mongo_client.list_database_names(), \"Transformation database already exists.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc387abc62686091",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Create JSON Schema validator\n",
+    "\n",
+    "In this step, you'll create a JSON Schema validator for the NMDC Schema.\n",
+    "\n",
+    "- TODO: Consider whether the JSON Schema validator version is consistent with the JSON Schema version (e.g. draft 7 versus draft 2019)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c982eb0c04e606d",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nmdc_jsonschema: dict = get_nmdc_jsonschema_dict(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)\n",
+    "nmdc_jsonschema_validator = Draft7Validator(nmdc_jsonschema)\n",
+    "\n",
+    "# Perform sanity tests of the NMDC Schema dictionary and the JSON Schema validator.\n",
+    "# Reference: https://python-jsonschema.readthedocs.io/en/latest/api/jsonschema/protocols/#jsonschema.protocols.Validator.check_schema\n",
+    "print(\"NMDC Schema title:   \" + nmdc_jsonschema[\"title\"])\n",
+    "print(\"NMDC Schema version: \" + nmdc_jsonschema[\"version\"])\n",
+    "\n",
+    "nmdc_jsonschema_validator.check_schema(nmdc_jsonschema)  # raises exception if schema is invalid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3975ac24",
+   "metadata": {},
+   "source": [
+    "### TODO: Revoke write access to the \"origin\" MongoDB server\n",
+    "\n",
+    "This is so people don't make changes to the original data while the migration is happening, given that the migration ends with an overwriting of the original data.\n",
+    "\n",
+    "Note: The migrator Mongo user may need additional permissions in order to manipulate Mongo user roles to the extent necessary to accomplish this step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd4994a0",
+   "metadata": {},
+   "source": [
+    "### Dump collections from the \"origin\" MongoDB server\n",
+    "\n",
+    "Use `mongodump` to dump the collections involved in this migration **from** the \"origin\" MongoDB server **into** a local directory.\n",
+    "\n",
+    "> Since `mongodump` doesn't provide a CLI option we can use to specify the collections we _want_ the dump to include, we use multiple occurrences of the `--excludeCollection` CLI option to exclude each collection we do _not_ want the dump to include. The end result is the same—there's just that extra step involved.\n",
+    "\n",
+    "- TODO: Consider ensuring that the local dump target folder is empty before doing this dump."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "831ac241",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build a string containing zero or more `--excludeCollection=\"...\"` options, which can be included in a `mongodump` command.\n",
+    "all_collection_names: list[str] = origin_mongo_client[\"nmdc\"].list_collection_names()\n",
+    "non_agenda_collection_names = [name for name in all_collection_names if name not in COLLECTION_NAMES]\n",
+    "exclusion_options = [f\"--excludeCollection='{name}'\" for name in non_agenda_collection_names]\n",
+    "exclusion_options_str = \" \".join(exclusion_options)  # separates each option with a space\n",
+    "print(exclusion_options_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf8fa1ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dump the not-excluded collections from the \"origin\" database.\n",
+    "!{mongodump} \\\n",
+    "  --config=\"{cfg.origin_mongo_config_file_path}\" \\\n",
+    "  --db=\"nmdc\" \\\n",
+    "  --gzip \\\n",
+    "  --out=\"{cfg.origin_dump_folder_path}\" \\\n",
+    "  {exclusion_options_str}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd4994a0",
+   "metadata": {},
+   "source": [
+    "### Load the dumped collections into the \"transformer\" MongoDB server\n",
+    "\n",
+    "Use `mongorestore` to load the dumped collections **from** the local directory **into** the \"transformer\" MongoDB server.\n",
+    "\n",
+    "> Since it's possible that the dump included extra collections (due to someone having created a collection between the time you generated the `--excludeCollection` CLI options and the time you ran `mongodump` above), we will use the `--nsInclude` CLI option to indicate which specific collections—from the dump—we want to load into the \"transformer\" database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4acae55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build a string containing zero or more `--nsInclude=\"...\"` options, which can be included in a `mongorestore` command.\n",
+    "inclusion_options = [f\"--nsInclude='nmdc.{name}'\" for name in COLLECTION_NAMES]\n",
+    "inclusion_options_str = \" \".join(inclusion_options)  # separates each option with a space\n",
+    "print(inclusion_options_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf8fa1ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Restore the dumped collections to the \"transformer\" MongoDB server.\n",
+    "!{mongorestore} \\\n",
+    "  --config=\"{cfg.transformer_mongo_config_file_path}\" \\\n",
+    "  --gzip \\\n",
+    "  --drop \\\n",
+    "  --preserveUUID \\\n",
+    "  --stopOnError \\\n",
+    "  --dir=\"{cfg.origin_dump_folder_path}\" \\\n",
+    "  {inclusion_options_str}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3e3c9c4",
+   "metadata": {},
+   "source": [
+    "### Transform the collections within the \"transformer\" MongoDB server\n",
+    "\n",
+    "Use the migrator to transform the collections in the \"transformer\" database.\n",
+    "\n",
+    "> Reminder: The database transformation functions are defined in the `nmdc-schema` Python package installed earlier.\n",
+    "\n",
+    "> Reminder: The \"origin\" database is **not** affected by this step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df8ee3da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "# Setup a logger that writes to a file.\n",
+    "# TODO: Move this logger stuff to `helpers.py`.`\n",
+    "LOG_FILE_PATH = \"./tmp.log\"\n",
+    "logger = logging.getLogger(name=\"migrator_logger\")\n",
+    "logger.setLevel(logging.DEBUG)\n",
+    "file_handler = logging.FileHandler(LOG_FILE_PATH)\n",
+    "formatter = logging.Formatter(fmt=\"[[%(asctime)s][%(name)s][%(levelname)s]] %(message)s\",\n",
+    "                              datefmt=\"%Y-%m-%d %H:%M:%S.%f\")\n",
+    "file_handler.setFormatter(formatter)\n",
+    "if logger.hasHandlers():\n",
+    "    logger.handlers.clear()  # avoid duplicate log entries\n",
+    "logger.addHandler(file_handler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05869340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate a MongoAdapter bound to the \"transformer\" database.\n",
+    "adapter = MongoAdapter(\n",
+    "    database=transformer_mongo_client[\"nmdc\"],\n",
+    "    on_collection_created=lambda name: print(f'Created collection \"{name}\"'),\n",
+    "    on_collection_renamed=lambda old_name, name: print(f'Renamed collection \"{old_name}\" to \"{name}\"'),\n",
+    "    on_collection_deleted=lambda name: print(f'Deleted collection \"{name}\"'),\n",
+    ")\n",
+    "\n",
+    "# Instantiate a Migrator bound to that adapter.\n",
+    "migrator = Migrator(adapter=adapter, logger=logger)\n",
+    "\n",
+    "# Execute the Migrator's `upgrade` method to perform the migration.\n",
+    "migrator.upgrade()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c090068",
+   "metadata": {},
+   "source": [
+    "### Validate the transformed documents\n",
+    "\n",
+    "Now that we have transformed the database, validate each document in each collection in the \"transformer\" MongoDB server.\n",
+    "\n",
+    "> Reference: https://github.com/microbiomedata/nmdc-runtime/blob/main/metadata-translation/src/bin/validate_json.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05869340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ensure that, if the (large) \"functional_annotation_agg\" collection is present in `COLLECTION_NAMES`,\n",
+    "# it goes at the end of the list we process. That way, we can find out about validation errors in\n",
+    "# other collections without having to wait for that (large) collection to be validated before them.\n",
+    "ordered_collection_names = sorted(COLLECTION_NAMES.copy())\n",
+    "large_collection_name = \"functional_annotation_agg\"\n",
+    "if large_collection_name in ordered_collection_names:\n",
+    "    ordered_collection_names = list(filter(lambda n: n != large_collection_name, ordered_collection_names))\n",
+    "    ordered_collection_names.append(large_collection_name)\n",
+    "\n",
+    "# TODO: Only validate documents in the collections that we will be restoring.\n",
+    "#       Note: If a collection listed in `COLLECTION_NAMES` doesn't exist in the transformation\n",
+    "#             database anymore, the inner `for` loop will just have zero iterations.\n",
+    "for collection_name in ordered_collection_names:\n",
+    "\n",
+    "    collection = transformer_mongo_client[\"nmdc\"][collection_name]\n",
+    "    num_documents_in_collection = collection.count_documents({})\n",
+    "    print(f\"Validating collection {collection_name} ({num_documents_in_collection} documents)\")\n",
+    "\n",
+    "    for document in collection.find():\n",
+    "        # Validate the transformed document.\n",
+    "        #\n",
+    "        # Reference: https://github.com/microbiomedata/nmdc-schema/blob/main/src/docs/schema-validation.md\n",
+    "        #\n",
+    "        # Note: Dictionaries originating as Mongo documents include a Mongo-generated key named `_id`. However,\n",
+    "        #       the NMDC Schema does not describe that key and, indeed, data validators consider dictionaries\n",
+    "        #       containing that key to be invalid with respect to the NMDC Schema. So, here, we validate a\n",
+    "        #       copy (i.e. a shallow copy) of the document that lacks that specific key.\n",
+    "        #\n",
+    "        # Note: `root_to_validate` is a dictionary having the shape: { \"some_collection_name\": [ some_document ] }\n",
+    "        #       Reference: https://docs.python.org/3/library/stdtypes.html#dict (see the \"type constructor\" section)\n",
+    "        #\n",
+    "        document_without_underscore_id_key = {key: value for key, value in document.items() if key != \"_id\"}\n",
+    "        root_to_validate = dict([(collection_name, [document_without_underscore_id_key])])\n",
+    "        nmdc_jsonschema_validator.validate(root_to_validate)  # raises exception if invalid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3edf77c7",
+   "metadata": {},
+   "source": [
+    "### Dump the collections from the \"transformer\" MongoDB server\n",
+    "\n",
+    "Now that the collections have been transformed and validated, dump them **from** the \"transformer\" MongoDB server **into** a local directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db6e432d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dump the database from the \"transformer\" MongoDB server.\n",
+    "!{mongodump} \\\n",
+    "  --config=\"{cfg.transformer_mongo_config_file_path}\" \\\n",
+    "  --db=\"nmdc\" \\\n",
+    "  --gzip \\\n",
+    "  --out=\"{cfg.transformer_dump_folder_path}\" \\\n",
+    "  {exclusion_options_str}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "997fcb281d9d3222",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Create a bookkeeper\n",
+    "\n",
+    "Create a `Bookkeeper` that can be used to document migration events in the \"origin\" server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbbe706d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bookkeeper = Bookkeeper(mongo_client=origin_mongo_client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e0c8891",
+   "metadata": {},
+   "source": [
+    "### Indicate — on the \"origin\" server — that the migration is underway\n",
+    "\n",
+    "Add an entry to the migration log collection to indicate that this migration has started."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca49f61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_STARTED)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c253e6f",
+   "metadata": {},
+   "source": [
+    "### TODO: Drop the original collections from the \"origin\" MongoDB server\n",
+    "\n",
+    "This is necessary for situations where collections were renamed or deleted. The `--drop` option of `mongorestore` only drops collections that exist in the dump. We may need `mongosh` for this."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84bdc11",
+   "metadata": {},
+   "source": [
+    "### Load the collections into the \"origin\" MongoDB server\n",
+    "\n",
+    "Load the transformed collections into the \"origin\" MongoDB server, **replacing** the collections there that have the same names.\n",
+    "\n",
+    "> Note: If the migration involved renaming or deleting a collection, the collection having the original name will continue to exist in the \"origin\" database until someone deletes it manually.\n",
+    "\n",
+    "- Consider using the `--preserveUUID` CLI option"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1dfbcf0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Replace the same-named collection(s) on the origin server, with the transformed one(s).\n",
+    "!{mongorestore} \\\n",
+    "  --config=\"{cfg.origin_mongo_config_file_path}\" \\\n",
+    "  --gzip \\\n",
+    "  --verbose \\\n",
+    "  --dir=\"{cfg.transformer_dump_folder_path}\" \\\n",
+    "  --drop \\\n",
+    "  --stopOnError \\\n",
+    "  {inclusion_options_str}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca5ee89a79148499",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Indicate that the migration is complete\n",
+    "\n",
+    "Add an entry to the migration log collection to indicate that this migration is complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1eaa6c92789c4f3",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_COMPLETED)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04c856a8",
+   "metadata": {},
+   "source": [
+    "### TODO: Reinstate write access to the MongoDB server\n",
+    "\n",
+    "This effectively un-does the access revocation that we did earlier."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Description

In this branch, I created a Python notebook that can be used to migrate a Mongo database from conforming to schema v10.3.0 to conforming to schema version v10.4.0. That migrator was introduced into the `nmdc-schema` repo "late" (i.e. in v10.5.4).

Fixes #556 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran locally and validated the migrated result.

**Configuration Details**: none

# Checklist:

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


