### PR TITLE
Bump migration notebooks' `pymongo` dependency to accommodate `nmdc-schema`

### DIFF
--- a/demo/metadata_migration/notebooks/requirements.txt
+++ b/demo/metadata_migration/notebooks/requirements.txt
@@ -1,5 +1,5 @@
 dictdiffer==0.9.0
 jsonschema==4.19.2
-pymongo==4.5.0
+pymongo==4.7.2
 python-dotenv==1.0.0
 PyYAML==6.0.1


### PR DESCRIPTION
In this branch, I committed code I meant to commit in PR branch https://github.com/microbiomedata/nmdc-runtime/pull/558. A full explanation is in the description of issue https://github.com/microbiomedata/nmdc-runtime/issues/561.

As a reminder, this `requirements.txt` file is only used by the migration notebooks and has no impact on the Runtime.