### PR TITLE
Configure GitHub Actions to push container image to GitHub Container Registry (in addition to Docker Hub)

### DIFF
--- a/.github/workflows/build-and-release-to-spin.yml
+++ b/.github/workflows/build-and-release-to-spin.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           images: |
             microbiomedata/nmdc-runtime-${{ matrix.image }}
+            ghcr.io/microbiomedata/nmdc-runtime-${{ matrix.image }}
           flavor: |
             latest=false
           tags: |
@@ -62,6 +63,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Reference: https://docs.docker.com/build/ci/github-actions/push-multi-registries/
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
# Description

In this branch, I updated a GitHub Actions workflow so that, when it builds a container image and pushes it to Docker Hub, it also pushes a copy to GitHub Container Registry. That will make `nmdc-runtime` work more similarly to other NMDC products/applications (i.e. `nmdc-server`, `nmdc-edge`, and `nmdc-aggregator`).

Fixes #564 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It has not been tested yet. The final test will be whether Runtime package(s) appear at https://github.com/orgs/microbiomedata/packages once this new GHA workflow runs.

**Configuration Details**: none

# Checklist:

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


