### PR TITLE
Authenticate as workflow triggerer instead of as repo owner

### DIFF
--- a/.github/workflows/build-and-release-to-spin.yml
+++ b/.github/workflows/build-and-release-to-spin.yml
@@ -65,11 +65,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Reference: https://docs.docker.com/build/ci/github-actions/push-multi-registries/
+      # Reference: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push


### PR DESCRIPTION
This is an attempt to fix the HTTP 403 Forbidden error that occurred in this [GHA workflow run](https://github.com/microbiomedata/nmdc-runtime/actions/runs/9587845790/job/26438682126), which was triggered by the merging of PR https://github.com/microbiomedata/nmdc-runtime/pull/565.

```fortran
Error: buildx failed with: ERROR: failed to solve: failed to push ghcr.io/microbiomedata/nmdc-runtime-fastapi:main: failed commit on ref "manifest-sha256:***": unexpected status from PUT request to https://ghcr.io/v2/microbiomedata/nmdc-runtime-fastapi/manifests/sha256:***: 403 Forbidden
```

In this branch, I configured the GHA workflow step to authenticate with GHCR as the user triggering the workflow instead of as the repository owner. This makes it consistent with how it is done in [nmdc-server](https://github.com/microbiomedata/nmdc-server/blob/b0a10482a409167e2315c081706ecc35a8ba8816/.github/workflows/deploy.yml#L49) and [nmdc-edge](https://github.com/microbiomedata/nmdc-edge/blob/46139ee56ec05ae9898af5520522ce372c994725/.github/workflows/build-and-push-image.yml#L18) (it works in those repo)—instead of consistent with the [Docker documentation](https://docs.docker.com/build/ci/github-actions/push-multi-registries/) (which I had never tried before).