### PR TITLE
Update `NmdcPortalApiClient` with new authentication scheme

### DIFF
--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -513,8 +513,8 @@ def biosample_submission_ingest():
                         "nmdc_portal_api_client": {
                             "config": {
                                 "base_url": {"env": "NMDC_PORTAL_API_BASE_URL"},
-                                "session_cookie": {
-                                    "env": "NMDC_PORTAL_API_SESSION_COOKIE"
+                                "refresh_token": {
+                                    "env": "NMDC_PORTAL_API_REFRESH_TOKEN"
                                 },
                             }
                         }
@@ -553,8 +553,8 @@ def biosample_submission_ingest():
                         "nmdc_portal_api_client": {
                             "config": {
                                 "base_url": {"env": "NMDC_PORTAL_API_BASE_URL"},
-                                "session_cookie": {
-                                    "env": "NMDC_PORTAL_API_SESSION_COOKIE"
+                                "refresh_token": {
+                                    "env": "NMDC_PORTAL_API_REFRESH_TOKEN"
                                 },
                             }
                         }

--- a/nmdc_runtime/site/resources.py
+++ b/nmdc_runtime/site/resources.py
@@ -386,7 +386,7 @@ class NmdcPortalApiClient:
             refresh_response.raise_for_status()
             refresh_body = refresh_response.json()
             self.access_token_expires_at = datetime.now() + timedelta(
-                seconds=refresh_body["expires"]
+                seconds=refresh_body["expires_in"]
             )
             self.access_token = refresh_body["access_token"]
 

--- a/nmdc_runtime/site/resources.py
+++ b/nmdc_runtime/site/resources.py
@@ -392,7 +392,9 @@ class NmdcPortalApiClient:
 
         headers = kwargs.get("headers", {})
         headers["Authorization"] = f"Bearer {self.access_token}"
-        return requests.request(method, f"{self.base_url}{endpoint}", **kwargs, headers=headers)
+        return requests.request(
+            method, f"{self.base_url}{endpoint}", **kwargs, headers=headers
+        )
 
     def fetch_metadata_submission(self, id: str) -> Dict[str, Any]:
         response = self._request("GET", f"/api/metadata_submission/{id}")

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -101,7 +101,9 @@ class SubmissionPortalTranslator(Translator):
         self.study_pi_image_url = study_pi_image_url
         self.study_funding_sources = study_funding_sources
 
-        self.biosample_extras = group_dicts_by_key(BIOSAMPLE_UNIQUE_KEY_SLOT, biosample_extras)
+        self.biosample_extras = group_dicts_by_key(
+            BIOSAMPLE_UNIQUE_KEY_SLOT, biosample_extras
+        )
         self.biosample_extras_slot_mapping = group_dicts_by_key(
             "subject_id", biosample_extras_slot_mapping
         )
@@ -567,7 +569,9 @@ class SubmissionPortalTranslator(Translator):
 
         sample_data = metadata_submission_data.get("sampleData", {})
         package_name = metadata_submission_data["packageName"]
-        sample_data_by_id = groupby(BIOSAMPLE_UNIQUE_KEY_SLOT, concat(sample_data.values()))
+        sample_data_by_id = groupby(
+            BIOSAMPLE_UNIQUE_KEY_SLOT, concat(sample_data.values())
+        )
         nmdc_biosample_ids = self._id_minter("nmdc:Biosample", len(sample_data_by_id))
         sample_data_to_nmdc_biosample_ids = dict(
             zip(sample_data_by_id.keys(), nmdc_biosample_ids)

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -59,6 +59,9 @@ def ensure_test_resources(mdb):
     mdb.jobs.replace_one(
         {"id": job_id}, job.model_dump(exclude_unset=True), upsert=True
     )
+    mdb["minter.requesters"].replace_one(
+        {"id": site_id}, {"id": site_id}, upsert=True
+    )
     return {
         "site_client": {
             "site_id": site_id,

--- a/tests/test_data/test_submission_portal_translator_data.yaml
+++ b/tests/test_data/test_submission_portal_translator_data.yaml
@@ -882,12 +882,12 @@ input:
       templates:
         - plant-associated
   omics_processing_mapping:
-    - __biosample_source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
+    - __biosample_samp_name: G5R1_MAIN_09MAY2016
       processing_institution: JGI
       instrument_name: Some fancy expensive thing
       omics_type: Metagenome
   data_object_mapping:
-    - __biosample_source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
+    - __biosample_samp_name: G5R1_MAIN_09MAY2016
       data_object_type: Metagenome Raw Reads
       url: http://example.com/data.fastq.gz
       name: Metagenome Raw Reads

--- a/tests/test_graphs/test_submission_portal_graphs.py
+++ b/tests/test_graphs/test_submission_portal_graphs.py
@@ -141,7 +141,7 @@ def test_translate_metadata_submission_to_nmdc_schema_database():
     with requests_mock.mock(real_http=True) as mock:
         mock.post(f"{MOCK_PORTAL_API_BASE}/auth/refresh", json={
             "access_token": "abcde",
-            "expires": 86400,
+            "expires_in": 86400,
         })
         mock.get(
             f"{MOCK_PORTAL_API_BASE}/api/metadata_submission/{MOCK_PORTAL_SUBMISSION_ID}",

--- a/tests/test_ops/test_data_api_ops.py
+++ b/tests/test_ops/test_data_api_ops.py
@@ -7,9 +7,13 @@ from nmdc_runtime.site.resources import nmdc_portal_api_client_resource
 from nmdc_runtime.site.ops import fetch_nmdc_portal_submission_by_id
 
 
+MOCK_BASE_URL = "http://example.com/nmdc_portal"
+MOCK_SUBMISSION_ID = "353d751f-cff0-4558-9051-25a87ba00d3f"
+
+
 @pytest.fixture
 def client_config():
-    return {"base_url": "http://example.com/nmdc_portal", "session_cookie": "12345"}
+    return {"base_url": MOCK_BASE_URL, "refresh_token": "12345"}
 
 
 @pytest.fixture
@@ -25,13 +29,26 @@ def op_context(client_config):
 
 def test_metadata_submission(op_context):
     with requests_mock.mock() as mock:
+        mock.post(f"{MOCK_BASE_URL}/auth/refresh", json={
+            "access_token": "abcde",
+            "expires": 86400,
+        })
         mock.get(
-            "http://example.com/nmdc_portal/api/metadata_submission/353d751f-cff0-4558-9051-25a87ba00d3f",
-            json={"id": "353d751f-cff0-4558-9051-25a87ba00d3f"},
+            f"{MOCK_BASE_URL}/api/metadata_submission/{MOCK_SUBMISSION_ID}",
+            json={"id": MOCK_SUBMISSION_ID},
         )
 
+        # The first request should initiate an access token refresh and then fetch the submission
+        fetch_nmdc_portal_submission_by_id(
+            op_context, MOCK_SUBMISSION_ID
+        )
+        assert len(mock.request_history) == 2
+        assert mock.request_history[0].url == f"{MOCK_BASE_URL}/auth/refresh"
+        assert mock.request_history[1].url == f"{MOCK_BASE_URL}/api/metadata_submission/{MOCK_SUBMISSION_ID}"
+
+        # The second request should not need to refresh the access token
         fetch_nmdc_portal_submission_by_id(
             op_context, "353d751f-cff0-4558-9051-25a87ba00d3f"
         )
-
-        assert len(mock.request_history) == 1
+        assert len(mock.request_history) == 3
+        assert mock.request_history[2].url == f"{MOCK_BASE_URL}/api/metadata_submission/{MOCK_SUBMISSION_ID}"

--- a/tests/test_ops/test_data_api_ops.py
+++ b/tests/test_ops/test_data_api_ops.py
@@ -31,7 +31,7 @@ def test_metadata_submission(op_context):
     with requests_mock.mock() as mock:
         mock.post(f"{MOCK_BASE_URL}/auth/refresh", json={
             "access_token": "abcde",
-            "expires": 86400,
+            "expires_in": 86400,
         })
         mock.get(
             f"{MOCK_BASE_URL}/api/metadata_submission/{MOCK_SUBMISSION_ID}",


### PR DESCRIPTION
# Description

The Portal API has replaced session cookie-based authentication with Bearer token authentication. These changes update `NmdcPortalApiClient` to reflect that.

In testing I also found that the `SubmissionPortalTranslator` has drifted away from the Portal a bit. In particular, `samp_name` is now the unique key slot on `Biosample` instances instead of `source_mat_id`. These changes also correct that.

Fixes #571 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit test suite 
  - These changes update `tests/test_ops/test_data_api_ops.py` to reflect the new behavior of `NmdcPortalApiClient`.
  - These changes fix the test configuration of `tests/test_graphs/test_submission_portal_graphs.py` and remove the `xfail` mark.
- [x] Manually ran the `translate_metadata_submission_to_nmdc_schema_database` job in the Dagit interface

**Configuration Details**: none

# Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


