### PR TITLE
Update notebook to use revised migrator (via newer `nmdc-schema` PyPI package)

### DIFF
--- a/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
@@ -42,18 +42,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1c5da29b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 collection names\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Note: `*arr` in Python is like `...arr` in JavaScript (it's a \"spread\" operator).\n",
     "COLLECTION_NAMES: list[str] = [\n",
@@ -65,18 +57,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "09966b0d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 collection names (distinct)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Eliminate duplicates.\n",
     "COLLECTION_NAMES = list(set(COLLECTION_NAMES))\n",
@@ -148,143 +132,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "e25a0af308c3185b",
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: pip in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (24.1)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n",
-      "Requirement already satisfied: dictdiffer==0.9.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 1)) (0.9.0)\n",
-      "Requirement already satisfied: jsonschema==4.19.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 2)) (4.19.2)\n",
-      "Requirement already satisfied: pymongo==4.7.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 3)) (4.7.2)\n",
-      "Requirement already satisfied: python-dotenv==1.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 4)) (1.0.0)\n",
-      "Requirement already satisfied: PyYAML==6.0.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 5)) (6.0.1)\n",
-      "Requirement already satisfied: attrs>=22.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (23.2.0)\n",
-      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (2023.12.1)\n",
-      "Requirement already satisfied: referencing>=0.28.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (0.35.1)\n",
-      "Requirement already satisfied: rpds-py>=0.7.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (0.18.1)\n",
-      "Requirement already satisfied: dnspython<3.0.0,>=1.16.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pymongo==4.7.2->-r requirements.txt (line 3)) (2.6.1)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n",
-      "Collecting nmdc-schema==10.5.6\n",
-      "  Downloading nmdc_schema-10.5.6-py3-none-any.whl.metadata (5.6 kB)\n",
-      "Requirement already satisfied: linkml<2.0.0,>=1.6.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.7.10)\n",
-      "Requirement already satisfied: linkml-runtime<2.0.0,>=1.6.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.7.5)\n",
-      "Requirement already satisfied: mkdocs<2.0.0,>=1.4.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.6.0)\n",
-      "Requirement already satisfied: mkdocs-mermaid2-plugin<0.7.0,>=0.6.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (0.6.0)\n",
-      "Requirement already satisfied: mkdocs-redirects<2.0.0,>=1.2.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.2.1)\n",
-      "Requirement already satisfied: pymongo<5.0.0,>=4.7.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (4.7.2)\n",
-      "Requirement already satisfied: antlr4-python3-runtime<4.10,>=4.9.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.9.3)\n",
-      "Requirement already satisfied: click>=7.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (8.1.7)\n",
-      "Requirement already satisfied: graphviz>=0.10.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.20.3)\n",
-      "Requirement already satisfied: hbreader in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.9.1)\n",
-      "Requirement already satisfied: isodate>=0.6.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.6.1)\n",
-      "Requirement already satisfied: jinja2>=3.1.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.1.4)\n",
-      "Requirement already satisfied: jsonasobj2<2.0.0,>=1.0.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.0.4)\n",
-      "Requirement already satisfied: jsonschema>=4.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.19.2)\n",
-      "Requirement already satisfied: linkml-dataops in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.1.0)\n",
-      "Requirement already satisfied: openpyxl in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.1.3)\n",
-      "Requirement already satisfied: parse in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.20.1)\n",
-      "Requirement already satisfied: prefixcommons>=0.1.7 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.1.12)\n",
-      "Requirement already satisfied: prefixmaps>=0.2.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.2.4)\n",
-      "Requirement already satisfied: pydantic<3.0.0,>=1.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.7.2)\n",
-      "Requirement already satisfied: pyjsg>=0.11.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.11.10)\n",
-      "Requirement already satisfied: pyshex>=0.7.20 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.8.1)\n",
-      "Requirement already satisfied: pyshexc>=0.8.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.9.1)\n",
-      "Requirement already satisfied: python-dateutil in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.9.0.post0)\n",
-      "Requirement already satisfied: pyyaml in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (6.0.1)\n",
-      "Requirement already satisfied: rdflib>=6.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (7.0.0)\n",
-      "Requirement already satisfied: requests>=2.22 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.32.3)\n",
-      "Requirement already satisfied: sqlalchemy>=1.4.31 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.30)\n",
-      "Requirement already satisfied: watchdog>=0.9.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.0.1)\n",
-      "Requirement already satisfied: curies>=0.5.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (0.7.9)\n",
-      "Requirement already satisfied: deprecated in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (1.2.14)\n",
-      "Requirement already satisfied: json-flattener>=0.1.9 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (0.1.9)\n",
-      "Requirement already satisfied: ghp-import>=1.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (2.1.0)\n",
-      "Requirement already satisfied: markdown>=3.3.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (3.6)\n",
-      "Requirement already satisfied: markupsafe>=2.0.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (2.1.5)\n",
-      "Requirement already satisfied: mergedeep>=1.3.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (1.3.4)\n",
-      "Requirement already satisfied: mkdocs-get-deps>=0.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (0.2.0)\n",
-      "Requirement already satisfied: packaging>=20.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (24.0)\n",
-      "Requirement already satisfied: pathspec>=0.11.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (0.12.1)\n",
-      "Requirement already satisfied: pyyaml-env-tag>=0.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (0.1)\n",
-      "Requirement already satisfied: setuptools>=18.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (70.0.0)\n",
-      "Requirement already satisfied: beautifulsoup4>=4.6.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (4.12.3)\n",
-      "Requirement already satisfied: jsbeautifier in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (1.15.1)\n",
-      "Requirement already satisfied: mkdocs-material in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (9.5.25)\n",
-      "Requirement already satisfied: pymdown-extensions>=8.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (10.8.1)\n",
-      "Requirement already satisfied: dnspython<3.0.0,>=1.16.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pymongo<5.0.0,>=4.7.2->nmdc-schema==10.5.6) (2.6.1)\n",
-      "Requirement already satisfied: soupsieve>1.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from beautifulsoup4>=4.6.3->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2.5)\n",
-      "Requirement already satisfied: pytrie in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from curies>=0.5.4->linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (0.4.0)\n",
-      "Requirement already satisfied: six in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from isodate>=0.6.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.16.0)\n",
-      "Requirement already satisfied: attrs>=22.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (23.2.0)\n",
-      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2023.12.1)\n",
-      "Requirement already satisfied: referencing>=0.28.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.35.1)\n",
-      "Requirement already satisfied: rpds-py>=0.7.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.18.1)\n",
-      "Requirement already satisfied: fqdn in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.5.1)\n",
-      "Requirement already satisfied: idna in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.7)\n",
-      "Requirement already satisfied: isoduration in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (20.11.0)\n",
-      "Requirement already satisfied: jsonpointer>1.13 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.4)\n",
-      "Requirement already satisfied: rfc3339-validator in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.1.4)\n",
-      "Requirement already satisfied: rfc3987 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.8)\n",
-      "Requirement already satisfied: uri-template in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.0)\n",
-      "Requirement already satisfied: webcolors>=1.11 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.13)\n",
-      "Requirement already satisfied: platformdirs>=2.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-get-deps>=0.2.0->mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (4.2.2)\n",
-      "Requirement already satisfied: pytest-logging<2016.0.0,>=2015.11.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2015.11.4)\n",
-      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pydantic<3.0.0,>=1.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.18.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pydantic<3.0.0,>=1.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.18.3)\n",
-      "Requirement already satisfied: typing-extensions>=4.6.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pydantic<3.0.0,>=1.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.12.0)\n",
-      "Requirement already satisfied: jsonasobj>=1.2.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyjsg>=0.11.6->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.1)\n",
-      "Requirement already satisfied: cfgraph>=0.2.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.2.1)\n",
-      "Requirement already satisfied: chardet in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (5.2.0)\n",
-      "Requirement already satisfied: rdflib-shim in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.0.3)\n",
-      "Requirement already satisfied: shexjsg>=0.8.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.8.2)\n",
-      "Requirement already satisfied: sparqlslurper>=0.5.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.5.1)\n",
-      "Requirement already satisfied: sparqlwrapper>=1.8.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.0)\n",
-      "Requirement already satisfied: urllib3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.2.1)\n",
-      "Requirement already satisfied: pyparsing<4,>=2.1.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from rdflib>=6.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.1.2)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from requests>=2.22->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.3.2)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from requests>=2.22->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2024.2.2)\n",
-      "Requirement already satisfied: wrapt<2,>=1.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from deprecated->linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (1.16.0)\n",
-      "Requirement already satisfied: editorconfig>=0.12.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsbeautifier->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (0.12.4)\n",
-      "Requirement already satisfied: jsonpatch in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.33)\n",
-      "Requirement already satisfied: jsonpath-ng in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.6.1)\n",
-      "Requirement already satisfied: ruamel.yaml in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.18.6)\n",
-      "Requirement already satisfied: babel~=2.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2.15.0)\n",
-      "Requirement already satisfied: colorama~=0.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (0.4.6)\n",
-      "Requirement already satisfied: mkdocs-material-extensions~=1.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (1.3.1)\n",
-      "Requirement already satisfied: paginate~=0.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (0.5.6)\n",
-      "Requirement already satisfied: pygments~=2.16 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2.18.0)\n",
-      "Requirement already satisfied: regex>=2022.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2024.5.15)\n",
-      "Requirement already satisfied: et-xmlfile in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from openpyxl->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.1.0)\n",
-      "Requirement already satisfied: pytest>=2.8.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (8.2.1)\n",
-      "Requirement already satisfied: arrow>=0.15.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from isoduration->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.0)\n",
-      "Requirement already satisfied: ply in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonpath-ng->linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.11)\n",
-      "Requirement already satisfied: sortedcontainers in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytrie->curies>=0.5.4->linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (2.4.0)\n",
-      "Requirement already satisfied: rdflib-jsonld==0.6.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from rdflib-shim->pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.6.1)\n",
-      "Requirement already satisfied: ruamel.yaml.clib>=0.2.7 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from ruamel.yaml->linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.2.8)\n",
-      "Requirement already satisfied: types-python-dateutil>=2.8.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from arrow>=0.15.0->isoduration->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.9.0.20240316)\n",
-      "Requirement already satisfied: iniconfig in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.0)\n",
-      "Requirement already satisfied: pluggy<2.0,>=1.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.5.0)\n",
-      "Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.2.1)\n",
-      "Requirement already satisfied: tomli>=1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.1)\n",
-      "Downloading nmdc_schema-10.5.6-py3-none-any.whl (475 kB)\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m475.0/475.0 kB\u001b[0m \u001b[31m5.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hInstalling collected packages: nmdc-schema\n",
-      "  Attempting uninstall: nmdc-schema\n",
-      "    Found existing installation: nmdc_schema 11.0.0rc16\n",
-      "    Uninstalling nmdc_schema-11.0.0rc16:\n",
-      "      Successfully uninstalled nmdc_schema-11.0.0rc16\n",
-      "Successfully installed nmdc-schema-10.5.6\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install --upgrade pip\n",
     "%pip install -r requirements.txt\n",
@@ -303,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "dbecd561",
    "metadata": {},
    "outputs": [],
@@ -332,29 +185,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "1eac645a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "mongodump version: 100.7.4\n",
-      "git version: fb74684da15f56d40231ab04ded86c71c1d8f37c\n",
-      "Go version: go1.19.11\n",
-      "   os: darwin\n",
-      "   arch: arm64\n",
-      "   compiler: gc\n",
-      "mongorestore version: 100.7.4\n",
-      "git version: fb74684da15f56d40231ab04ded86c71c1d8f37c\n",
-      "Go version: go1.19.11\n",
-      "   os: darwin\n",
-      "   arch: arm64\n",
-      "   compiler: gc\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cfg = Config()\n",
     "\n",
@@ -379,19 +213,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "8e95f559",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Origin Mongo server version:      6.0.4\n",
-      "Transformer Mongo server version: 6.0.4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Mongo client for \"origin\" MongoDB server.\n",
     "origin_mongo_client = pymongo.MongoClient(host=cfg.origin_mongo_server_uri, directConnection=True)\n",
@@ -430,21 +255,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "5c982eb0c04e606d",
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NMDC Schema title:   NMDC\n",
-      "NMDC Schema version: 10.5.6\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "nmdc_jsonschema: dict = get_nmdc_jsonschema_dict()\n",
     "nmdc_jsonschema_validator = Draft7Validator(nmdc_jsonschema)\n",
@@ -485,18 +301,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "831ac241",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--excludeCollection='mags_activity_set' --excludeCollection='sites' --excludeCollection='read_based_taxonomy_analysis_activity_set' --excludeCollection='_runtime.api.allow' --excludeCollection='notes' --excludeCollection='study_set' --excludeCollection='ids_nmdc_mga0' --excludeCollection='extraction_set' --excludeCollection='typecodes' --excludeCollection='minter.services' --excludeCollection='metatranscriptome_activity_set' --excludeCollection='query_runs' --excludeCollection='object_types' --excludeCollection='minter.id_records' --excludeCollection='collecting_biosamples_from_site_set' --excludeCollection='metagenome_assembly_set' --excludeCollection='queries' --excludeCollection='metagenome_annotation_activity_set' --excludeCollection='processed_sample_set' --excludeCollection='services' --excludeCollection='minter.requesters' --excludeCollection='operations' --excludeCollection='requesters' --excludeCollection='triggers' --excludeCollection='_tmp__get_file_size_bytes' --excludeCollection='schema_classes' --excludeCollection='capabilities' --excludeCollection='system.views' --excludeCollection='_runtime.analytics' --excludeCollection='planned_process_set' --excludeCollection='ids' --excludeCollection='fs.chunks' --excludeCollection='jobs' --excludeCollection='txn_log' --excludeCollection='read_qc_analysis_activity_set' --excludeCollection='etl_software_version' --excludeCollection='ids_nmdc_gfs0' --excludeCollection='file_type_enum' --excludeCollection='_runtime.healthcheck' --excludeCollection='metabolomics_analysis_activity_set' --excludeCollection='run_events' --excludeCollection='_migration_events' --excludeCollection='objects' --excludeCollection='date_created' --excludeCollection='workflows' --excludeCollection='field_research_site_set' --excludeCollection='metaproteomics_analysis_activity_set' --excludeCollection='material_sample_set' --excludeCollection='minter.typecodes' --excludeCollection='ids_nmdc_mta0' --excludeCollection='shoulders' --excludeCollection='id_records' --excludeCollection='fs.files' --excludeCollection='biosample_set' --excludeCollection='page_tokens' --excludeCollection='ids_nmdc_fk4' --excludeCollection='minter.schema_classes' --excludeCollection='users' --excludeCollection='ids_nmdc_sys0' --excludeCollection='ids_nmdc_fk0' --excludeCollection='activity_set' --excludeCollection='nmdc_schema_version' --excludeCollection='minter.shoulders' --excludeCollection='library_preparation_set' --excludeCollection='functional_annotation_agg' --excludeCollection='pooling_set' --excludeCollection='omics_processing_set' --excludeCollection='metagenome_sequencing_activity_set' --excludeCollection='metap_gene_function_aggregation' --excludeCollection='_migration_latest_schema_version' --excludeCollection='EMP_soil_project_run_counts'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Build a string containing zero or more `--excludeCollection=\"...\"` options, which can be included in a `mongodump` command.\n",
     "all_collection_names: list[str] = origin_mongo_client[\"nmdc\"].list_collection_names()\n",
@@ -508,23 +316,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "cf8fa1ca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2024-06-25T15:12:58.736-0700\twriting nmdc.data_object_set to mongodump.origin.out/nmdc/data_object_set.bson.gz\n",
-      "2024-06-25T15:12:58.766-0700\twriting nmdc.nom_analysis_activity_set to mongodump.origin.out/nmdc/nom_analysis_activity_set.bson.gz\n",
-      "2024-06-25T15:12:58.967-0700\tdone dumping nmdc.nom_analysis_activity_set (2549 documents)\n",
-      "2024-06-25T15:13:01.346-0700\t[################........]  nmdc.data_object_set  70281/104296  (67.4%)\n",
-      "2024-06-25T15:13:01.830-0700\t[########################]  nmdc.data_object_set  104296/104296  (100.0%)\n",
-      "2024-06-25T15:13:01.831-0700\tdone dumping nmdc.data_object_set (104296 documents)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Dump the not-excluded collections from the \"origin\" database.\n",
     "!{mongodump} \\\n",
@@ -549,18 +344,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "c4acae55",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--nsInclude='nmdc.nom_analysis_activity_set' --nsInclude='nmdc.data_object_set'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Build a string containing zero or more `--nsInclude=\"...\"` options, which can be included in a `mongorestore` command.\n",
     "inclusion_options = [f\"--nsInclude='nmdc.{name}'\" for name in COLLECTION_NAMES]\n",
@@ -570,33 +357,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "cf8fa1ca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2024-06-25T15:13:53.551-0700\tpreparing collections to restore from\n",
-      "2024-06-25T15:13:53.551-0700\treading metadata for nmdc.data_object_set from mongodump.origin.out/nmdc/data_object_set.metadata.json.gz\n",
-      "2024-06-25T15:13:53.552-0700\treading metadata for nmdc.nom_analysis_activity_set from mongodump.origin.out/nmdc/nom_analysis_activity_set.metadata.json.gz\n",
-      "2024-06-25T15:13:53.571-0700\trestoring nmdc.data_object_set from mongodump.origin.out/nmdc/data_object_set.bson.gz\n",
-      "2024-06-25T15:13:53.580-0700\trestoring nmdc.nom_analysis_activity_set from mongodump.origin.out/nmdc/nom_analysis_activity_set.bson.gz\n",
-      "2024-06-25T15:13:53.774-0700\tfinished restoring nmdc.nom_analysis_activity_set (2549 documents, 0 failures)\n",
-      "2024-06-25T15:13:55.827-0700\tfinished restoring nmdc.data_object_set (104296 documents, 0 failures)\n",
-      "2024-06-25T15:13:55.827-0700\trestoring indexes for collection nmdc.nom_analysis_activity_set from metadata\n",
-      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:13:55.827-0700\trestoring indexes for collection nmdc.data_object_set from metadata\n",
-      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"file_size_bytes\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"file_size_bytes\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"url\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"url\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"data_object_type\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"data_object_type\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:13:55.828-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"md5_checksum\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"md5_checksum\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:13:56.664-0700\t106845 document(s) restored successfully. 0 document(s) failed to restore.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Restore the dumped collections to the \"transformer\" MongoDB server.\n",
     "!{mongorestore} \\\n",
@@ -625,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "df8ee3da",
    "metadata": {},
    "outputs": [],
@@ -647,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "05869340",
    "metadata": {},
    "outputs": [],
@@ -681,19 +445,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "05869340",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validating collection data_object_set (104296 documents)\n",
-      "Validating collection nom_analysis_activity_set (2549 documents)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Ensure that, if the (large) \"functional_annotation_agg\" collection is present in `COLLECTION_NAMES`,\n",
     "# it goes at the end of the list we process. That way, we can find out about validation errors in\n",
@@ -743,21 +498,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "db6e432d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2024-06-25T15:17:48.984-0700\twriting nmdc.data_object_set to mongodump.transformer.out/nmdc/data_object_set.bson.gz\n",
-      "2024-06-25T15:17:48.988-0700\twriting nmdc.nom_analysis_activity_set to mongodump.transformer.out/nmdc/nom_analysis_activity_set.bson.gz\n",
-      "2024-06-25T15:17:49.007-0700\tdone dumping nmdc.nom_analysis_activity_set (2549 documents)\n",
-      "2024-06-25T15:17:49.825-0700\tdone dumping nmdc.data_object_set (104296 documents)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Dump the database from the \"transformer\" MongoDB server.\n",
     "!{mongodump} \\\n",
@@ -782,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "dbbe706d",
    "metadata": {},
    "outputs": [],
@@ -802,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "ca49f61a",
    "metadata": {},
    "outputs": [],
@@ -836,52 +580,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "1dfbcf0a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2024-06-25T15:18:01.284-0700\tusing --dir flag instead of arguments\n",
-      "2024-06-25T15:18:01.285-0700\tusing write concern: &{majority false 0}\n",
-      "2024-06-25T15:18:01.538-0700\tpreparing collections to restore from\n",
-      "2024-06-25T15:18:01.538-0700\tfound collection nmdc.data_object_set bson to restore to nmdc.data_object_set\n",
-      "2024-06-25T15:18:01.538-0700\tfound collection metadata from nmdc.data_object_set to restore to nmdc.data_object_set\n",
-      "2024-06-25T15:18:01.538-0700\tfound collection nmdc.nom_analysis_activity_set bson to restore to nmdc.nom_analysis_activity_set\n",
-      "2024-06-25T15:18:01.538-0700\tfound collection metadata from nmdc.nom_analysis_activity_set to restore to nmdc.nom_analysis_activity_set\n",
-      "2024-06-25T15:18:01.538-0700\treading metadata for nmdc.data_object_set from mongodump.transformer.out/nmdc/data_object_set.metadata.json.gz\n",
-      "2024-06-25T15:18:01.539-0700\treading metadata for nmdc.nom_analysis_activity_set from mongodump.transformer.out/nmdc/nom_analysis_activity_set.metadata.json.gz\n",
-      "2024-06-25T15:18:01.565-0700\tdropping collection nmdc.data_object_set before restoring\n",
-      "2024-06-25T15:18:01.565-0700\tdropping collection nmdc.nom_analysis_activity_set before restoring\n",
-      "2024-06-25T15:18:01.589-0700\tcreating collection nmdc.data_object_set with no metadata\n",
-      "2024-06-25T15:18:01.616-0700\tcreating collection nmdc.nom_analysis_activity_set with no metadata\n",
-      "2024-06-25T15:18:01.654-0700\trestoring nmdc.data_object_set from mongodump.transformer.out/nmdc/data_object_set.bson.gz\n",
-      "2024-06-25T15:18:01.670-0700\trestoring nmdc.nom_analysis_activity_set from mongodump.transformer.out/nmdc/nom_analysis_activity_set.bson.gz\n",
-      "2024-06-25T15:18:02.543-0700\tfinished restoring nmdc.nom_analysis_activity_set (2549 documents, 0 failures)\n",
-      "2024-06-25T15:18:04.472-0700\t[###.....................]  nmdc.data_object_set  736KB/5.56MB  (12.9%)\n",
-      "2024-06-25T15:18:07.472-0700\t[#####...................]  nmdc.data_object_set  1.30MB/5.56MB  (23.4%)\n",
-      "2024-06-25T15:18:10.472-0700\t[#########...............]  nmdc.data_object_set  2.14MB/5.56MB  (38.6%)\n",
-      "2024-06-25T15:18:13.472-0700\t[#############...........]  nmdc.data_object_set  3.07MB/5.56MB  (55.3%)\n",
-      "2024-06-25T15:18:16.471-0700\t[#################.......]  nmdc.data_object_set  3.94MB/5.56MB  (70.9%)\n",
-      "2024-06-25T15:18:19.472-0700\t[####################....]  nmdc.data_object_set  4.84MB/5.56MB  (87.0%)\n",
-      "2024-06-25T15:18:21.723-0700\t[########################]  nmdc.data_object_set  5.56MB/5.56MB  (100.0%)\n",
-      "2024-06-25T15:18:21.723-0700\tfinished restoring nmdc.data_object_set (104296 documents, 0 failures)\n",
-      "2024-06-25T15:18:21.723-0700\trestoring indexes for collection nmdc.data_object_set from metadata\n",
-      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"file_size_bytes\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"file_size_bytes\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"url\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"url\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"data_object_type\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"data_object_type\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"md5_checksum\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"md5_checksum\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:18:21.724-0700\t\trun create Index command for indexes: file_size_bytes, url, data_object_type, id_1, md5_checksum\n",
-      "2024-06-25T15:18:21.724-0700\trestoring indexes for collection nmdc.nom_analysis_activity_set from metadata\n",
-      "2024-06-25T15:18:21.724-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
-      "2024-06-25T15:18:21.724-0700\t\trun create Index command for indexes: id_1\n",
-      "2024-06-25T15:18:22.799-0700\t106845 document(s) restored successfully. 0 document(s) failed to restore.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Replace the same-named collection(s) on the origin server, with the transformed one(s).\n",
     "!{mongorestore} \\\n",
@@ -908,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "d1eaa6c92789c4f3",
    "metadata": {
     "collapsed": false

--- a/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_10_3_0_to_10_4_0.ipynb
@@ -15,7 +15,7 @@
    "id": "987824fa",
    "metadata": {},
    "source": [
-    "There is a migrator for the schema changes from `v10.3.0` to `v10.4.0`. That migrator was added to the `nmdc-schema` repo \"late\" (i.e. in version `v10.5.4`). There is no migrator for the schema changes, if any, from `v10.4.0` to `10.5.4`. "
+    "There is a migrator for the schema changes from `v10.3.0` to `v10.4.0`. That migrator was added to the `nmdc-schema` repo \"late\" (i.e. in version `v10.5.4`). There is no migrator for the schema changes, if any, from `v10.4.0` to `10.5.6`. "
    ]
   },
   {
@@ -42,24 +42,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1c5da29b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 collection names\n"
+     ]
+    }
+   ],
    "source": [
     "# Note: `*arr` in Python is like `...arr` in JavaScript (it's a \"spread\" operator).\n",
     "COLLECTION_NAMES: list[str] = [\n",
     "    \"nom_analysis_activity_set\",\n",
+    "    \"data_object_set\",\n",
     "]\n",
     "print(str(len(COLLECTION_NAMES)) + \" collection names\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "09966b0d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 collection names (distinct)\n"
+     ]
+    }
+   ],
    "source": [
     "# Eliminate duplicates.\n",
     "COLLECTION_NAMES = list(set(COLLECTION_NAMES))\n",
@@ -131,16 +148,147 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "e25a0af308c3185b",
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: pip in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (24.1)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "Requirement already satisfied: dictdiffer==0.9.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 1)) (0.9.0)\n",
+      "Requirement already satisfied: jsonschema==4.19.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 2)) (4.19.2)\n",
+      "Requirement already satisfied: pymongo==4.7.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 3)) (4.7.2)\n",
+      "Requirement already satisfied: python-dotenv==1.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 4)) (1.0.0)\n",
+      "Requirement already satisfied: PyYAML==6.0.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 5)) (6.0.1)\n",
+      "Requirement already satisfied: attrs>=22.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (23.2.0)\n",
+      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (2023.12.1)\n",
+      "Requirement already satisfied: referencing>=0.28.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (0.35.1)\n",
+      "Requirement already satisfied: rpds-py>=0.7.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema==4.19.2->-r requirements.txt (line 2)) (0.18.1)\n",
+      "Requirement already satisfied: dnspython<3.0.0,>=1.16.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pymongo==4.7.2->-r requirements.txt (line 3)) (2.6.1)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "Collecting nmdc-schema==10.5.6\n",
+      "  Downloading nmdc_schema-10.5.6-py3-none-any.whl.metadata (5.6 kB)\n",
+      "Requirement already satisfied: linkml<2.0.0,>=1.6.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.7.10)\n",
+      "Requirement already satisfied: linkml-runtime<2.0.0,>=1.6.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.7.5)\n",
+      "Requirement already satisfied: mkdocs<2.0.0,>=1.4.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.6.0)\n",
+      "Requirement already satisfied: mkdocs-mermaid2-plugin<0.7.0,>=0.6.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (0.6.0)\n",
+      "Requirement already satisfied: mkdocs-redirects<2.0.0,>=1.2.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (1.2.1)\n",
+      "Requirement already satisfied: pymongo<5.0.0,>=4.7.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from nmdc-schema==10.5.6) (4.7.2)\n",
+      "Requirement already satisfied: antlr4-python3-runtime<4.10,>=4.9.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.9.3)\n",
+      "Requirement already satisfied: click>=7.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (8.1.7)\n",
+      "Requirement already satisfied: graphviz>=0.10.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.20.3)\n",
+      "Requirement already satisfied: hbreader in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.9.1)\n",
+      "Requirement already satisfied: isodate>=0.6.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.6.1)\n",
+      "Requirement already satisfied: jinja2>=3.1.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.1.4)\n",
+      "Requirement already satisfied: jsonasobj2<2.0.0,>=1.0.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.0.4)\n",
+      "Requirement already satisfied: jsonschema>=4.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.19.2)\n",
+      "Requirement already satisfied: linkml-dataops in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.1.0)\n",
+      "Requirement already satisfied: openpyxl in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.1.3)\n",
+      "Requirement already satisfied: parse in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.20.1)\n",
+      "Requirement already satisfied: prefixcommons>=0.1.7 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.1.12)\n",
+      "Requirement already satisfied: prefixmaps>=0.2.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.2.4)\n",
+      "Requirement already satisfied: pydantic<3.0.0,>=1.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.7.2)\n",
+      "Requirement already satisfied: pyjsg>=0.11.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.11.10)\n",
+      "Requirement already satisfied: pyshex>=0.7.20 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.8.1)\n",
+      "Requirement already satisfied: pyshexc>=0.8.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.9.1)\n",
+      "Requirement already satisfied: python-dateutil in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.9.0.post0)\n",
+      "Requirement already satisfied: pyyaml in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (6.0.1)\n",
+      "Requirement already satisfied: rdflib>=6.0.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (7.0.0)\n",
+      "Requirement already satisfied: requests>=2.22 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.32.3)\n",
+      "Requirement already satisfied: sqlalchemy>=1.4.31 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.30)\n",
+      "Requirement already satisfied: watchdog>=0.9.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.0.1)\n",
+      "Requirement already satisfied: curies>=0.5.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (0.7.9)\n",
+      "Requirement already satisfied: deprecated in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (1.2.14)\n",
+      "Requirement already satisfied: json-flattener>=0.1.9 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (0.1.9)\n",
+      "Requirement already satisfied: ghp-import>=1.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (2.1.0)\n",
+      "Requirement already satisfied: markdown>=3.3.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (3.6)\n",
+      "Requirement already satisfied: markupsafe>=2.0.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (2.1.5)\n",
+      "Requirement already satisfied: mergedeep>=1.3.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (1.3.4)\n",
+      "Requirement already satisfied: mkdocs-get-deps>=0.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (0.2.0)\n",
+      "Requirement already satisfied: packaging>=20.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (24.0)\n",
+      "Requirement already satisfied: pathspec>=0.11.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (0.12.1)\n",
+      "Requirement already satisfied: pyyaml-env-tag>=0.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (0.1)\n",
+      "Requirement already satisfied: setuptools>=18.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (70.0.0)\n",
+      "Requirement already satisfied: beautifulsoup4>=4.6.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (4.12.3)\n",
+      "Requirement already satisfied: jsbeautifier in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (1.15.1)\n",
+      "Requirement already satisfied: mkdocs-material in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (9.5.25)\n",
+      "Requirement already satisfied: pymdown-extensions>=8.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (10.8.1)\n",
+      "Requirement already satisfied: dnspython<3.0.0,>=1.16.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pymongo<5.0.0,>=4.7.2->nmdc-schema==10.5.6) (2.6.1)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from beautifulsoup4>=4.6.3->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2.5)\n",
+      "Requirement already satisfied: pytrie in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from curies>=0.5.4->linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (0.4.0)\n",
+      "Requirement already satisfied: six in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from isodate>=0.6.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.16.0)\n",
+      "Requirement already satisfied: attrs>=22.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (23.2.0)\n",
+      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2023.12.1)\n",
+      "Requirement already satisfied: referencing>=0.28.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.35.1)\n",
+      "Requirement already satisfied: rpds-py>=0.7.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema>=4.0.0->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.18.1)\n",
+      "Requirement already satisfied: fqdn in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.5.1)\n",
+      "Requirement already satisfied: idna in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.7)\n",
+      "Requirement already satisfied: isoduration in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (20.11.0)\n",
+      "Requirement already satisfied: jsonpointer>1.13 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.4)\n",
+      "Requirement already satisfied: rfc3339-validator in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.1.4)\n",
+      "Requirement already satisfied: rfc3987 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.8)\n",
+      "Requirement already satisfied: uri-template in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.0)\n",
+      "Requirement already satisfied: webcolors>=1.11 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.13)\n",
+      "Requirement already satisfied: platformdirs>=2.2.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-get-deps>=0.2.0->mkdocs<2.0.0,>=1.4.2->nmdc-schema==10.5.6) (4.2.2)\n",
+      "Requirement already satisfied: pytest-logging<2016.0.0,>=2015.11.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2015.11.4)\n",
+      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pydantic<3.0.0,>=1.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.18.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pydantic<3.0.0,>=1.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.18.3)\n",
+      "Requirement already satisfied: typing-extensions>=4.6.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pydantic<3.0.0,>=1.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (4.12.0)\n",
+      "Requirement already satisfied: jsonasobj>=1.2.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyjsg>=0.11.6->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.1)\n",
+      "Requirement already satisfied: cfgraph>=0.2.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.2.1)\n",
+      "Requirement already satisfied: chardet in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (5.2.0)\n",
+      "Requirement already satisfied: rdflib-shim in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.0.3)\n",
+      "Requirement already satisfied: shexjsg>=0.8.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.8.2)\n",
+      "Requirement already satisfied: sparqlslurper>=0.5.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.5.1)\n",
+      "Requirement already satisfied: sparqlwrapper>=1.8.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.0)\n",
+      "Requirement already satisfied: urllib3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.2.1)\n",
+      "Requirement already satisfied: pyparsing<4,>=2.1.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from rdflib>=6.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.1.2)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from requests>=2.22->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.3.2)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from requests>=2.22->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2024.2.2)\n",
+      "Requirement already satisfied: wrapt<2,>=1.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from deprecated->linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (1.16.0)\n",
+      "Requirement already satisfied: editorconfig>=0.12.2 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsbeautifier->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (0.12.4)\n",
+      "Requirement already satisfied: jsonpatch in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.33)\n",
+      "Requirement already satisfied: jsonpath-ng in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.6.1)\n",
+      "Requirement already satisfied: ruamel.yaml in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.18.6)\n",
+      "Requirement already satisfied: babel~=2.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2.15.0)\n",
+      "Requirement already satisfied: colorama~=0.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (0.4.6)\n",
+      "Requirement already satisfied: mkdocs-material-extensions~=1.3 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (1.3.1)\n",
+      "Requirement already satisfied: paginate~=0.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (0.5.6)\n",
+      "Requirement already satisfied: pygments~=2.16 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2.18.0)\n",
+      "Requirement already satisfied: regex>=2022.4 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from mkdocs-material->mkdocs-mermaid2-plugin<0.7.0,>=0.6.0->nmdc-schema==10.5.6) (2024.5.15)\n",
+      "Requirement already satisfied: et-xmlfile in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from openpyxl->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.1.0)\n",
+      "Requirement already satisfied: pytest>=2.8.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (8.2.1)\n",
+      "Requirement already satisfied: arrow>=0.15.0 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from isoduration->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.3.0)\n",
+      "Requirement already satisfied: ply in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from jsonpath-ng->linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (3.11)\n",
+      "Requirement already satisfied: sortedcontainers in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytrie->curies>=0.5.4->linkml-runtime<2.0.0,>=1.6.2->nmdc-schema==10.5.6) (2.4.0)\n",
+      "Requirement already satisfied: rdflib-jsonld==0.6.1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from rdflib-shim->pyshex>=0.7.20->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.6.1)\n",
+      "Requirement already satisfied: ruamel.yaml.clib>=0.2.7 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from ruamel.yaml->linkml-dataops->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (0.2.8)\n",
+      "Requirement already satisfied: types-python-dateutil>=2.8.10 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from arrow>=0.15.0->isoduration->jsonschema[format]>=4.0.0->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.9.0.20240316)\n",
+      "Requirement already satisfied: iniconfig in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.0)\n",
+      "Requirement already satisfied: pluggy<2.0,>=1.5 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.5.0)\n",
+      "Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (1.2.1)\n",
+      "Requirement already satisfied: tomli>=1 in /Users/EECavanna/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.10/site-packages (from pytest>=2.8.1->pytest-logging<2016.0.0,>=2015.11.4->prefixcommons>=0.1.7->linkml<2.0.0,>=1.6.10->nmdc-schema==10.5.6) (2.0.1)\n",
+      "Downloading nmdc_schema-10.5.6-py3-none-any.whl (475 kB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m475.0/475.0 kB\u001b[0m \u001b[31m5.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: nmdc-schema\n",
+      "  Attempting uninstall: nmdc-schema\n",
+      "    Found existing installation: nmdc_schema 11.0.0rc16\n",
+      "    Uninstalling nmdc_schema-11.0.0rc16:\n",
+      "      Successfully uninstalled nmdc_schema-11.0.0rc16\n",
+      "Successfully installed nmdc-schema-10.5.6\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --upgrade pip\n",
     "%pip install -r requirements.txt\n",
-    "%pip install nmdc-schema==10.5.4  # note: the 10.3.0-to-10.4.0 migrator was introduced in schema package version 10.5.4"
+    "%pip install nmdc-schema==10.5.6  # note: the 10.3.0-to-10.4.0 migrator was introduced in schema package version 10.5.4 and a bugfix was introduced in 10.5.6"
    ]
   },
   {
@@ -155,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "dbecd561",
    "metadata": {},
    "outputs": [],
@@ -184,10 +332,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "1eac645a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mongodump version: 100.7.4\n",
+      "git version: fb74684da15f56d40231ab04ded86c71c1d8f37c\n",
+      "Go version: go1.19.11\n",
+      "   os: darwin\n",
+      "   arch: arm64\n",
+      "   compiler: gc\n",
+      "mongorestore version: 100.7.4\n",
+      "git version: fb74684da15f56d40231ab04ded86c71c1d8f37c\n",
+      "Go version: go1.19.11\n",
+      "   os: darwin\n",
+      "   arch: arm64\n",
+      "   compiler: gc\n"
+     ]
+    }
+   ],
    "source": [
     "cfg = Config()\n",
     "\n",
@@ -212,10 +379,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "8e95f559",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Origin Mongo server version:      6.0.4\n",
+      "Transformer Mongo server version: 6.0.4\n"
+     ]
+    }
+   ],
    "source": [
     "# Mongo client for \"origin\" MongoDB server.\n",
     "origin_mongo_client = pymongo.MongoClient(host=cfg.origin_mongo_server_uri, directConnection=True)\n",
@@ -254,12 +430,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "5c982eb0c04e606d",
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NMDC Schema title:   NMDC\n",
+      "NMDC Schema version: 10.5.6\n"
+     ]
+    }
+   ],
    "source": [
     "nmdc_jsonschema: dict = get_nmdc_jsonschema_dict()\n",
     "nmdc_jsonschema_validator = Draft7Validator(nmdc_jsonschema)\n",
@@ -300,10 +485,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "831ac241",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--excludeCollection='mags_activity_set' --excludeCollection='sites' --excludeCollection='read_based_taxonomy_analysis_activity_set' --excludeCollection='_runtime.api.allow' --excludeCollection='notes' --excludeCollection='study_set' --excludeCollection='ids_nmdc_mga0' --excludeCollection='extraction_set' --excludeCollection='typecodes' --excludeCollection='minter.services' --excludeCollection='metatranscriptome_activity_set' --excludeCollection='query_runs' --excludeCollection='object_types' --excludeCollection='minter.id_records' --excludeCollection='collecting_biosamples_from_site_set' --excludeCollection='metagenome_assembly_set' --excludeCollection='queries' --excludeCollection='metagenome_annotation_activity_set' --excludeCollection='processed_sample_set' --excludeCollection='services' --excludeCollection='minter.requesters' --excludeCollection='operations' --excludeCollection='requesters' --excludeCollection='triggers' --excludeCollection='_tmp__get_file_size_bytes' --excludeCollection='schema_classes' --excludeCollection='capabilities' --excludeCollection='system.views' --excludeCollection='_runtime.analytics' --excludeCollection='planned_process_set' --excludeCollection='ids' --excludeCollection='fs.chunks' --excludeCollection='jobs' --excludeCollection='txn_log' --excludeCollection='read_qc_analysis_activity_set' --excludeCollection='etl_software_version' --excludeCollection='ids_nmdc_gfs0' --excludeCollection='file_type_enum' --excludeCollection='_runtime.healthcheck' --excludeCollection='metabolomics_analysis_activity_set' --excludeCollection='run_events' --excludeCollection='_migration_events' --excludeCollection='objects' --excludeCollection='date_created' --excludeCollection='workflows' --excludeCollection='field_research_site_set' --excludeCollection='metaproteomics_analysis_activity_set' --excludeCollection='material_sample_set' --excludeCollection='minter.typecodes' --excludeCollection='ids_nmdc_mta0' --excludeCollection='shoulders' --excludeCollection='id_records' --excludeCollection='fs.files' --excludeCollection='biosample_set' --excludeCollection='page_tokens' --excludeCollection='ids_nmdc_fk4' --excludeCollection='minter.schema_classes' --excludeCollection='users' --excludeCollection='ids_nmdc_sys0' --excludeCollection='ids_nmdc_fk0' --excludeCollection='activity_set' --excludeCollection='nmdc_schema_version' --excludeCollection='minter.shoulders' --excludeCollection='library_preparation_set' --excludeCollection='functional_annotation_agg' --excludeCollection='pooling_set' --excludeCollection='omics_processing_set' --excludeCollection='metagenome_sequencing_activity_set' --excludeCollection='metap_gene_function_aggregation' --excludeCollection='_migration_latest_schema_version' --excludeCollection='EMP_soil_project_run_counts'\n"
+     ]
+    }
+   ],
    "source": [
     "# Build a string containing zero or more `--excludeCollection=\"...\"` options, which can be included in a `mongodump` command.\n",
     "all_collection_names: list[str] = origin_mongo_client[\"nmdc\"].list_collection_names()\n",
@@ -315,10 +508,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "cf8fa1ca",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-06-25T15:12:58.736-0700\twriting nmdc.data_object_set to mongodump.origin.out/nmdc/data_object_set.bson.gz\n",
+      "2024-06-25T15:12:58.766-0700\twriting nmdc.nom_analysis_activity_set to mongodump.origin.out/nmdc/nom_analysis_activity_set.bson.gz\n",
+      "2024-06-25T15:12:58.967-0700\tdone dumping nmdc.nom_analysis_activity_set (2549 documents)\n",
+      "2024-06-25T15:13:01.346-0700\t[################........]  nmdc.data_object_set  70281/104296  (67.4%)\n",
+      "2024-06-25T15:13:01.830-0700\t[########################]  nmdc.data_object_set  104296/104296  (100.0%)\n",
+      "2024-06-25T15:13:01.831-0700\tdone dumping nmdc.data_object_set (104296 documents)\n"
+     ]
+    }
+   ],
    "source": [
     "# Dump the not-excluded collections from the \"origin\" database.\n",
     "!{mongodump} \\\n",
@@ -343,10 +549,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "c4acae55",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--nsInclude='nmdc.nom_analysis_activity_set' --nsInclude='nmdc.data_object_set'\n"
+     ]
+    }
+   ],
    "source": [
     "# Build a string containing zero or more `--nsInclude=\"...\"` options, which can be included in a `mongorestore` command.\n",
     "inclusion_options = [f\"--nsInclude='nmdc.{name}'\" for name in COLLECTION_NAMES]\n",
@@ -356,10 +570,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "cf8fa1ca",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-06-25T15:13:53.551-0700\tpreparing collections to restore from\n",
+      "2024-06-25T15:13:53.551-0700\treading metadata for nmdc.data_object_set from mongodump.origin.out/nmdc/data_object_set.metadata.json.gz\n",
+      "2024-06-25T15:13:53.552-0700\treading metadata for nmdc.nom_analysis_activity_set from mongodump.origin.out/nmdc/nom_analysis_activity_set.metadata.json.gz\n",
+      "2024-06-25T15:13:53.571-0700\trestoring nmdc.data_object_set from mongodump.origin.out/nmdc/data_object_set.bson.gz\n",
+      "2024-06-25T15:13:53.580-0700\trestoring nmdc.nom_analysis_activity_set from mongodump.origin.out/nmdc/nom_analysis_activity_set.bson.gz\n",
+      "2024-06-25T15:13:53.774-0700\tfinished restoring nmdc.nom_analysis_activity_set (2549 documents, 0 failures)\n",
+      "2024-06-25T15:13:55.827-0700\tfinished restoring nmdc.data_object_set (104296 documents, 0 failures)\n",
+      "2024-06-25T15:13:55.827-0700\trestoring indexes for collection nmdc.nom_analysis_activity_set from metadata\n",
+      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:13:55.827-0700\trestoring indexes for collection nmdc.data_object_set from metadata\n",
+      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"file_size_bytes\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"file_size_bytes\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"url\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"url\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"data_object_type\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"data_object_type\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:13:55.827-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:13:55.828-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"md5_checksum\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"md5_checksum\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:13:56.664-0700\t106845 document(s) restored successfully. 0 document(s) failed to restore.\n"
+     ]
+    }
+   ],
    "source": [
     "# Restore the dumped collections to the \"transformer\" MongoDB server.\n",
     "!{mongorestore} \\\n",
@@ -388,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "df8ee3da",
    "metadata": {},
    "outputs": [],
@@ -401,8 +638,7 @@
     "logger = logging.getLogger(name=\"migrator_logger\")\n",
     "logger.setLevel(logging.DEBUG)\n",
     "file_handler = logging.FileHandler(LOG_FILE_PATH)\n",
-    "formatter = logging.Formatter(fmt=\"[[%(asctime)s][%(name)s][%(levelname)s]] %(message)s\",\n",
-    "                              datefmt=\"%Y-%m-%d %H:%M:%S.%f\")\n",
+    "formatter = logging.Formatter(fmt=\"[%(asctime)s\\t%(name)s\\t%(levelname)s]\\t%(message)s\")\n",
     "file_handler.setFormatter(formatter)\n",
     "if logger.hasHandlers():\n",
     "    logger.handlers.clear()  # avoid duplicate log entries\n",
@@ -411,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "05869340",
    "metadata": {},
    "outputs": [],
@@ -445,10 +681,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "05869340",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validating collection data_object_set (104296 documents)\n",
+      "Validating collection nom_analysis_activity_set (2549 documents)\n"
+     ]
+    }
+   ],
    "source": [
     "# Ensure that, if the (large) \"functional_annotation_agg\" collection is present in `COLLECTION_NAMES`,\n",
     "# it goes at the end of the list we process. That way, we can find out about validation errors in\n",
@@ -498,10 +743,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "db6e432d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-06-25T15:17:48.984-0700\twriting nmdc.data_object_set to mongodump.transformer.out/nmdc/data_object_set.bson.gz\n",
+      "2024-06-25T15:17:48.988-0700\twriting nmdc.nom_analysis_activity_set to mongodump.transformer.out/nmdc/nom_analysis_activity_set.bson.gz\n",
+      "2024-06-25T15:17:49.007-0700\tdone dumping nmdc.nom_analysis_activity_set (2549 documents)\n",
+      "2024-06-25T15:17:49.825-0700\tdone dumping nmdc.data_object_set (104296 documents)\n"
+     ]
+    }
+   ],
    "source": [
     "# Dump the database from the \"transformer\" MongoDB server.\n",
     "!{mongodump} \\\n",
@@ -526,7 +782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "dbbe706d",
    "metadata": {},
    "outputs": [],
@@ -546,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "ca49f61a",
    "metadata": {},
    "outputs": [],
@@ -580,10 +836,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "1dfbcf0a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-06-25T15:18:01.284-0700\tusing --dir flag instead of arguments\n",
+      "2024-06-25T15:18:01.285-0700\tusing write concern: &{majority false 0}\n",
+      "2024-06-25T15:18:01.538-0700\tpreparing collections to restore from\n",
+      "2024-06-25T15:18:01.538-0700\tfound collection nmdc.data_object_set bson to restore to nmdc.data_object_set\n",
+      "2024-06-25T15:18:01.538-0700\tfound collection metadata from nmdc.data_object_set to restore to nmdc.data_object_set\n",
+      "2024-06-25T15:18:01.538-0700\tfound collection nmdc.nom_analysis_activity_set bson to restore to nmdc.nom_analysis_activity_set\n",
+      "2024-06-25T15:18:01.538-0700\tfound collection metadata from nmdc.nom_analysis_activity_set to restore to nmdc.nom_analysis_activity_set\n",
+      "2024-06-25T15:18:01.538-0700\treading metadata for nmdc.data_object_set from mongodump.transformer.out/nmdc/data_object_set.metadata.json.gz\n",
+      "2024-06-25T15:18:01.539-0700\treading metadata for nmdc.nom_analysis_activity_set from mongodump.transformer.out/nmdc/nom_analysis_activity_set.metadata.json.gz\n",
+      "2024-06-25T15:18:01.565-0700\tdropping collection nmdc.data_object_set before restoring\n",
+      "2024-06-25T15:18:01.565-0700\tdropping collection nmdc.nom_analysis_activity_set before restoring\n",
+      "2024-06-25T15:18:01.589-0700\tcreating collection nmdc.data_object_set with no metadata\n",
+      "2024-06-25T15:18:01.616-0700\tcreating collection nmdc.nom_analysis_activity_set with no metadata\n",
+      "2024-06-25T15:18:01.654-0700\trestoring nmdc.data_object_set from mongodump.transformer.out/nmdc/data_object_set.bson.gz\n",
+      "2024-06-25T15:18:01.670-0700\trestoring nmdc.nom_analysis_activity_set from mongodump.transformer.out/nmdc/nom_analysis_activity_set.bson.gz\n",
+      "2024-06-25T15:18:02.543-0700\tfinished restoring nmdc.nom_analysis_activity_set (2549 documents, 0 failures)\n",
+      "2024-06-25T15:18:04.472-0700\t[###.....................]  nmdc.data_object_set  736KB/5.56MB  (12.9%)\n",
+      "2024-06-25T15:18:07.472-0700\t[#####...................]  nmdc.data_object_set  1.30MB/5.56MB  (23.4%)\n",
+      "2024-06-25T15:18:10.472-0700\t[#########...............]  nmdc.data_object_set  2.14MB/5.56MB  (38.6%)\n",
+      "2024-06-25T15:18:13.472-0700\t[#############...........]  nmdc.data_object_set  3.07MB/5.56MB  (55.3%)\n",
+      "2024-06-25T15:18:16.471-0700\t[#################.......]  nmdc.data_object_set  3.94MB/5.56MB  (70.9%)\n",
+      "2024-06-25T15:18:19.472-0700\t[####################....]  nmdc.data_object_set  4.84MB/5.56MB  (87.0%)\n",
+      "2024-06-25T15:18:21.723-0700\t[########################]  nmdc.data_object_set  5.56MB/5.56MB  (100.0%)\n",
+      "2024-06-25T15:18:21.723-0700\tfinished restoring nmdc.data_object_set (104296 documents, 0 failures)\n",
+      "2024-06-25T15:18:21.723-0700\trestoring indexes for collection nmdc.data_object_set from metadata\n",
+      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"file_size_bytes\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"file_size_bytes\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"url\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"url\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"data_object_type\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"data_object_type\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:18:21.723-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"background\":true, \"name\":\"md5_checksum\", \"v\":2}, Key:primitive.D{primitive.E{Key:\"md5_checksum\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:18:21.724-0700\t\trun create Index command for indexes: file_size_bytes, url, data_object_type, id_1, md5_checksum\n",
+      "2024-06-25T15:18:21.724-0700\trestoring indexes for collection nmdc.nom_analysis_activity_set from metadata\n",
+      "2024-06-25T15:18:21.724-0700\tindex: &idx.IndexDocument{Options:primitive.M{\"name\":\"id_1\", \"unique\":true, \"v\":2}, Key:primitive.D{primitive.E{Key:\"id\", Value:1}}, PartialFilterExpression:primitive.D(nil)}\n",
+      "2024-06-25T15:18:21.724-0700\t\trun create Index command for indexes: id_1\n",
+      "2024-06-25T15:18:22.799-0700\t106845 document(s) restored successfully. 0 document(s) failed to restore.\n"
+     ]
+    }
+   ],
    "source": [
     "# Replace the same-named collection(s) on the origin server, with the transformed one(s).\n",
     "!{mongorestore} \\\n",
@@ -610,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "d1eaa6c92789c4f3",
    "metadata": {
     "collapsed": false


### PR DESCRIPTION
Note: I erased the usual PR boilerplate content from this PR.

In this branch, I updated a migration notebook to use a newer version of the `nmdc-schema` PyPI package. Using a newer version was necessary in order to get access to a recently-revised migrator.

The revised migrator uses an additional collection, so I added that to the notebook.

Also, I fixed the format string for the logger (while I was already editing the notebook).