### PR TITLE
Add GHA workflow that deploys app to `nmdc-berkeley` Spin namespace

### DIFF
--- a/.github/workflows/build-and-release-to-spin-berkeley.yml
+++ b/.github/workflows/build-and-release-to-spin-berkeley.yml
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images:
+          images: |
             ghcr.io/microbiomedata/nmdc-runtime-${{ matrix.image }}
           flavor: |
             latest=false

--- a/.github/workflows/build-and-release-to-spin-berkeley.yml
+++ b/.github/workflows/build-and-release-to-spin-berkeley.yml
@@ -1,6 +1,7 @@
 # Note: This GitHub Actions workflow was initialized by copy/pasting the contents of `build-and-release-to-spin.yml`.
 #       Changes made here since then include:
 #       - Changed the triggering branch to `berkeley` (was `main`)
+#       - Excluded Git tag creation from triggering criteria
 #       - Hard-coded the Spin namespace as `nmdc-berkeley` for deployment
 #       - Disabled pushing to Docker Hub (only push to GHCR)
 #       - Changed tagging rules to, effectively, "always tag as :berkeley"
@@ -11,8 +12,6 @@ on:
   push:
     branches:
       - berkeley  # the `berkeley` branch, not the `main` branch
-    tags:
-      - 'v*'
     paths:
       - '.github/workflows/build-and-release-to-spin-berkeley.yml'
       - 'Makefile'

--- a/.github/workflows/build-and-release-to-spin-berkeley.yml
+++ b/.github/workflows/build-and-release-to-spin-berkeley.yml
@@ -1,0 +1,102 @@
+# Note: This GitHub Actions workflow was initialized by copy/pasting the contents of `build-and-release-to-spin.yml`.
+#       Changes made here since then include:
+#       - Changed the triggering branch to `berkeley` (was `main`)
+#       - Hard-coded the Spin namespace as `nmdc-berkeley` for deployment
+#       - Disabled pushing to Docker Hub (only push to GHCR)
+#       - Changed tagging rules to, effectively, "always tag as :berkeley"
+
+name: Build Docker images and release to Spin (nmdc-berkeley)
+
+on:
+  push:
+    branches:
+      - berkeley  # the `berkeley` branch, not the `main` branch
+    tags:
+      - 'v*'
+    paths:
+      - '.github/workflows/build-and-release-to-spin-berkeley.yml'
+      - 'Makefile'
+      - '**.Dockerfile'
+      - '**.py'
+      - 'requirements/main.txt'
+
+env:
+  # We don't want to do certain steps if this is running in a fork
+  IS_ORIGINAL_REPO: ${{ github.repository == 'microbiomedata/nmdc-runtime' }}
+
+  # Used when sending redeploy action requests to Rancher
+  RANCHER_NAMESPACE: 'nmdc-berkeley'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: [ fastapi, dagster ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # history for all branches and tags is needed for setuptools-scm (part of build and push step)
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images:
+            ghcr.io/microbiomedata/nmdc-runtime-${{ matrix.image }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=berkeley
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Reference: https://docs.docker.com/build/ci/github-actions/push-multi-registries/
+      # Reference: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ env.IS_ORIGINAL_REPO }}
+          file: nmdc_runtime/${{ matrix.image }}.Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  release:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        deployment: [ runtime-api, dagster-dagit, dagster-daemon ]
+
+    steps:
+      - name: Redeploy ${{ env.RANCHER_NAMESPACE }}:${{ matrix.deployment }}
+        if: ${{ env.IS_ORIGINAL_REPO }}
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ secrets.RANCHER_URL }}/v3/project/${{ secrets.RANCHER_CONTEXT }}/workloads/deployment:${{ env.RANCHER_NAMESPACE }}:${{ matrix.deployment }}?action=redeploy
+          method: POST
+          bearerToken: ${{ secrets.RANCHER_TOKEN }}


### PR DESCRIPTION
# Description

In this branch, I added a GHA workflow that builds a container image from the `berkeley` branch, pushes that container image up to GHCR, and then redeploys the Runtime/Dagster workloads in the `nmdc-berkeley` namespace on Spin.

I expect this workflow to be a **temporary** one that will be deleted in several months, once the Berkeley Schema Roll Out squad ends and the `nmdc-berkeley` namespace on Spin gets deleted.

Fixes #582 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- This has not been tested yet. Once it has been merged into `main`, I will test it by making a change on the `berkeley` branch and verifying that the workflow runs, container images get pushed to GHCR, and Spin workloads get redeployed.

**Configuration Details**: none

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

