### PR TITLE
Update minter to use first typecode when pattern contains multiple typecodes

### DIFF
--- a/nmdc_runtime/minter/config.py
+++ b/nmdc_runtime/minter/config.py
@@ -12,20 +12,54 @@ def minting_service_id() -> str | None:
     return os.getenv("MINTING_SERVICE_ID")
 
 
+def extract_typecode_from_pattern(pattern: str) -> str:
+    r"""
+    Returns the typecode portion of the specified string.
+
+    >>> extract_typecode_from_pattern("foo-123-456$")  # original behavior
+    'foo'
+    >>> extract_typecode_from_pattern("(foo)-123-456$")  # returns first and only typecode
+    'foo'
+    >>> extract_typecode_from_pattern("(foo|bar)-123-456$")  # returns first of 2 typecodes
+    'foo'
+    >>> extract_typecode_from_pattern("(foo|bar|baz)-123-456$")  # returns first of > 2 typecodes
+    'foo'
+    """
+
+    # Get the portion of the pattern preceding the first hyphen.
+    # e.g. "foo-bar-baz" → ["foo", "bar-baz"] → "foo"
+    typecode_sub_pattern = pattern.split("-", maxsplit=1)[0]
+
+    # If that portion of the pattern is enclosed in parentheses, get the portion between the parentheses.
+    # e.g. "(apple|banana|carrot)" → "apple|banana|carrot"
+    if typecode_sub_pattern.startswith("(") and typecode_sub_pattern.endswith(")"):
+        inner_pattern = typecode_sub_pattern[1:-1]
+
+        # Finally, get everything before the first `|`, if any.
+        # e.g. "(apple|banana|carrot)" → "apple"
+        # e.g. "(apple)" → "apple"
+        typecode = inner_pattern.split("|", maxsplit=1)[0]
+    else:
+        # Note: This is the original behavior, before we added support for multi-typecode patterns.
+        # e.g. "foo" → "foo"
+        typecode = typecode_sub_pattern
+
+    return typecode
+
 @lru_cache()
 def typecodes() -> List[dict]:
     r"""
-    Returns a list of typecodes—plus related info—obtained from the schema.
+    Returns a list of dictionaries containing typecodes and other information derived from the schema.
 
-    Preconditions:
+    Preconditions about the schema:
     - The typecode portion of the pattern is between the pattern prefix and the first subsequent hyphen.
     - The typecode portion of the pattern either consists of a single typecode verbatim (e.g. "foo");
       or consists of multiple typecodes in a pipe-delimited list enclosed in parentheses (e.g. "(foo|bar|baz)").
     - The typecode portion of the pattern does not, itself, contain any hyphens.
 
-    TODO: Get typecodes in a different way than by extracting them from a larger string, which seems brittle to me.
+    TODO: Get the typecodes in a different way than by extracting them from a larger string, which seems brittle to me.
           Getting them a different way may require schema authors to _define_ them a different way (e.g. defining them
-          in a dedicated property of a class, named `typecode`).
+          in a dedicated property of a class; for example, one named `typecode`).
     """
     id_pattern_prefix = r"^(nmdc):"
 
@@ -38,26 +72,11 @@ def typecodes() -> List[dict]:
                 # e.g. "^(nmdc):foo-bar-baz" → "foo-bar-baz"
                 pattern_without_prefix: str = p[len(id_pattern_prefix):]
 
-                # Get the portion of the remaining pattern preceding the first hyphen.
-                # e.g. "foo-bar-baz" → ["foo", "bar-baz"] → "foo"
-                typecode_sub_pattern = pattern_without_prefix.split("-", maxsplit=1)[0]
-
-                # If the remaining pattern is enclosed in parentheses, get the portion between them.
-                # e.g. "(apple|banana|carrot)" → "apple|banana|carrot"
-                if typecode_sub_pattern.startswith("(") and typecode_sub_pattern.endswith(")"):
-                    inner_pattern = typecode_sub_pattern[1:-1]
-
-                    # Finally, get everything before the first `|`, if any.
-                    typecode = inner_pattern.split("|", maxsplit=1)[0]
-                else:
-                    # Note: This is the original behavior, before we added support for multi-typecode patterns.
-                    typecode = typecode_sub_pattern
-
                 rv.append(
                     {
                         "id": "nmdc:" + cls_name + "_" + "typecode",
                         "schema_class": "nmdc:" + cls_name,
-                        "name": typecode,
+                        "name": extract_typecode_from_pattern(pattern_without_prefix),
                     }
                 )
             case _:

--- a/nmdc_runtime/minter/config.py
+++ b/nmdc_runtime/minter/config.py
@@ -1,5 +1,6 @@
 import os
 from functools import lru_cache
+from typing import List
 
 from nmdc_runtime.util import get_nmdc_jsonschema_dict
 
@@ -12,17 +13,51 @@ def minting_service_id() -> str | None:
 
 
 @lru_cache()
-def typecodes():
+def typecodes() -> List[dict]:
+    r"""
+    Returns a list of typecodes—plus related info—obtained from the schema.
+
+    Preconditions:
+    - The typecode portion of the pattern is between the pattern prefix and the first subsequent hyphen.
+    - The typecode portion of the pattern either consists of a single typecode verbatim (e.g. "foo");
+      or consists of multiple typecodes in a pipe-delimited list enclosed in parentheses (e.g. "(foo|bar|baz)").
+    - The typecode portion of the pattern does not, itself, contain any hyphens.
+
+    TODO: Get typecodes in a different way than by extracting them from a larger string, which seems brittle to me.
+          Getting them a different way may require schema authors to _define_ them a different way (e.g. defining them
+          in a dedicated property of a class, named `typecode`).
+    """
+    id_pattern_prefix = r"^(nmdc):"
+
     rv = []
     schema_dict = get_nmdc_jsonschema_dict()
     for cls_name, defn in schema_dict["$defs"].items():
         match defn.get("properties"):
-            case {"id": {"pattern": p}} if p.startswith("^(nmdc):"):
+            case {"id": {"pattern": p}} if p.startswith(id_pattern_prefix):
+                # Get the portion of the pattern following the prefix.
+                # e.g. "^(nmdc):foo-bar-baz" → "foo-bar-baz"
+                pattern_without_prefix: str = p[len(id_pattern_prefix):]
+
+                # Get the portion of the remaining pattern preceding the first hyphen.
+                # e.g. "foo-bar-baz" → ["foo", "bar-baz"] → "foo"
+                typecode_sub_pattern = pattern_without_prefix.split("-", maxsplit=1)[0]
+
+                # If the remaining pattern is enclosed in parentheses, get the portion between them.
+                # e.g. "(apple|banana|carrot)" → "apple|banana|carrot"
+                if typecode_sub_pattern.startswith("(") and typecode_sub_pattern.endswith(")"):
+                    inner_pattern = typecode_sub_pattern[1:-1]
+
+                    # Finally, get everything before the first `|`, if any.
+                    typecode = inner_pattern.split("|", maxsplit=1)[0]
+                else:
+                    # Note: This is the original behavior, before we added support for multi-typecode patterns.
+                    typecode = typecode_sub_pattern
+
                 rv.append(
                     {
                         "id": "nmdc:" + cls_name + "_" + "typecode",
                         "schema_class": "nmdc:" + cls_name,
-                        "name": p.split(":", maxsplit=1)[-1].split("-", maxsplit=1)[0],
+                        "name": typecode,
                     }
                 )
             case _:

--- a/nmdc_runtime/minter/config.py
+++ b/nmdc_runtime/minter/config.py
@@ -36,12 +36,12 @@ def extract_typecode_from_pattern(pattern: str) -> str:
         inner_pattern = typecode_sub_pattern[1:-1]
 
         # Finally, get everything before the first `|`, if any.
-        # e.g. "(apple|banana|carrot)" → "apple"
-        # e.g. "(apple)" → "apple"
+        # e.g. "apple|banana|carrot" → "apple"
+        # e.g. "apple" → "apple"
         typecode = inner_pattern.split("|", maxsplit=1)[0]
     else:
         # Note: This is the original behavior, before we added support for multi-typecode patterns.
-        # e.g. "foo" → "foo"
+        # e.g. "apple" → "apple"
         typecode = typecode_sub_pattern
 
     return typecode

--- a/nmdc_runtime/minter/config.py
+++ b/nmdc_runtime/minter/config.py
@@ -46,10 +46,11 @@ def extract_typecode_from_pattern(pattern: str) -> str:
 
     return typecode
 
+
 @lru_cache()
 def typecodes() -> List[dict]:
     r"""
-    Returns a list of dictionaries containing typecodes and other information derived from the schema.
+    Returns a list of dictionaries containing typecodes and associated information derived from the schema.
 
     Preconditions about the schema:
     - The typecode portion of the pattern is between the pattern prefix and the first subsequent hyphen.
@@ -70,7 +71,8 @@ def typecodes() -> List[dict]:
             case {"id": {"pattern": p}} if p.startswith(id_pattern_prefix):
                 # Get the portion of the pattern following the prefix.
                 # e.g. "^(nmdc):foo-bar-baz" → "foo-bar-baz"
-                pattern_without_prefix: str = p[len(id_pattern_prefix):]
+                index_of_first_character_following_prefix = len(id_pattern_prefix)
+                pattern_without_prefix = p[index_of_first_character_following_prefix:]
 
                 rv.append(
                     {


### PR DESCRIPTION
# Description

In this branch, I updated the minter so that, in addition to extracting typecodes verbatim from patterns in the schema, it now also extracts the first typecode in a `(...|...|...)`-formatted sequence.

I also added a `TODO` comment about moving away from extracting typecodes from these pattern strings, which I think are authored with the mindset of "here's what I want the schema to allow for values in this field," as opposed to "here's what I want the minter to use when creating an ID."

Fixes https://github.com/microbiomedata/nmdc-runtime/issues/592

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I ran `$ python -m doctest -v nmdc_runtime/minter/config.py` within the `fastapi` container in my development environment. Looks to me like this may be able to be incorporated into the existing `pytest` infrastructure (based on what I see in the pytest documentation, [here](https://docs.pytest.org/en/7.1.x/how-to/doctest.html)), but I haven't done it yet.

# Definition of Done (DoD) Checklist:

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
  > No, I'll leave that to the GitHub Actions workflow once I open the PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <htt ps://github.com/microbiomedata/NMDC_documentation/>?)
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)