### PR TITLE
doc: clarify that user must be site admin to generate site credentials

### DIFF
--- a/nmdc_runtime/api/endpoints/sites.py
+++ b/nmdc_runtime/api/endpoints/sites.py
@@ -193,7 +193,10 @@ def get_site_object_link(
 
 @router.post("/sites/{site_id}:generateCredentials", response_model=ClientCredentials)
 def generate_credentials_for_site_client(
-    site_id: str = Path(..., description="The ID of a site for which you, the authenticated user, are an admin."),
+    site_id: str = Path(
+        ...,
+        description="The ID of a site for which you, the authenticated user, are an admin.",
+    ),
     mdb: pymongo.database.Database = Depends(get_mongo_db),
     user: User = Depends(get_current_active_user),
 ):

--- a/nmdc_runtime/api/endpoints/sites.py
+++ b/nmdc_runtime/api/endpoints/sites.py
@@ -195,7 +195,7 @@ def get_site_object_link(
 def generate_credentials_for_site_client(
     site_id: str = Path(
         ...,
-        description="The ID of a site for which you, the authenticated user, are an admin.",
+        description="The ID of the site.",
     ),
     mdb: pymongo.database.Database = Depends(get_mongo_db),
     user: User = Depends(get_current_active_user),

--- a/nmdc_runtime/api/endpoints/sites.py
+++ b/nmdc_runtime/api/endpoints/sites.py
@@ -2,7 +2,7 @@ from typing import List
 
 import botocore
 import pymongo.database
-from fastapi import APIRouter, Depends, status, HTTPException
+from fastapi import APIRouter, Depends, status, HTTPException, Path
 from starlette.status import HTTP_403_FORBIDDEN
 
 from nmdc_runtime.api.core.auth import (
@@ -193,10 +193,15 @@ def get_site_object_link(
 
 @router.post("/sites/{site_id}:generateCredentials", response_model=ClientCredentials)
 def generate_credentials_for_site_client(
-    site_id: str,
+    site_id: str = Path(..., description="The ID of a site for which you, the authenticated user, are an admin."),
     mdb: pymongo.database.Database = Depends(get_mongo_db),
     user: User = Depends(get_current_active_user),
 ):
+    """
+    Generate a client_id and client_secret for the given site.
+
+    You must be authenticated as a user who is registered as an admin for the given site.
+    """
     raise404_if_none(
         mdb.sites.find_one({"id": site_id}), detail=f"no site with ID '{site_id}'"
     )

--- a/nmdc_runtime/api/endpoints/sites.py
+++ b/nmdc_runtime/api/endpoints/sites.py
@@ -203,7 +203,7 @@ def generate_credentials_for_site_client(
     """
     Generate a client_id and client_secret for the given site.
 
-    You must be authenticated as a user who is registered as an admin for the given site.
+    You must be authenticated as a user who is registered as an admin of the given site.
     """
     raise404_if_none(
         mdb.sites.find_one({"id": site_id}), detail=f"no site with ID '{site_id}'"


### PR DESCRIPTION
Fixes #606 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] visual inspection of generated docs UI

![image](https://github.com/user-attachments/assets/cff21438-88e5-4b51-8b5d-472200f8f9db)

# Definition of Done (DoD) Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code


