### PR TITLE
Add broker name to NCBI XML, and also pull in `protocol_link.name` from LibraryPreparation objects

### DIFF
--- a/nmdc_runtime/site/export/ncbi_xml.py
+++ b/nmdc_runtime/site/export/ncbi_xml.py
@@ -322,9 +322,11 @@ class NCBISubmissionXML:
 
                 for lib_prep_dict in nmdc_library_preparation:
                     if biosample_id in lib_prep_dict:
-                        lib_prep_protocol_names[biosample_id] = lib_prep_dict.get(
-                            "protocol_link", {}
-                        ).get("name", "")
+                        lib_prep_protocol_names[biosample_id] = (
+                            lib_prep_dict[biosample_id]
+                            .get("protocol_link", {})
+                            .get("name", "")
+                        )
 
             if fastq_files:
                 files_elements = [

--- a/nmdc_runtime/site/export/ncbi_xml.py
+++ b/nmdc_runtime/site/export/ncbi_xml.py
@@ -231,7 +231,9 @@ class NCBISubmissionXML:
                     ]
                     + [
                         self.set_element(
-                            "Attribute", "NMDC", {"attribute_name": "broker name"}
+                            "Attribute",
+                            "National Microbiome Data Collaborative",
+                            {"attribute_name": "broker name"},
                         )
                     ],
                 ),

--- a/nmdc_runtime/site/export/ncbi_xml.py
+++ b/nmdc_runtime/site/export/ncbi_xml.py
@@ -285,6 +285,7 @@ class NCBISubmissionXML:
         org: str,
         nmdc_omics_processing: list,
         nmdc_biosamples: list,
+        nmdc_library_preparation: list,
     ):
         bsm_id_name_dict = {
             biosample["id"]: biosample["name"] for biosample in nmdc_biosamples
@@ -294,6 +295,7 @@ class NCBISubmissionXML:
             fastq_files = []
             biosample_ids = []
             omics_processing_ids = {}
+            lib_prep_protocol_names = {}
             instrument_name = ""
             omics_type = ""
             library_name = ""
@@ -317,6 +319,12 @@ class NCBISubmissionXML:
                                 .lower()
                             )
                             library_name = bsm_id_name_dict.get(biosample_id, "")
+
+                for lib_prep_dict in nmdc_library_preparation:
+                    if biosample_id in lib_prep_dict:
+                        lib_prep_protocol_names[biosample_id] = lib_prep_dict.get(
+                            "protocol_link", {}
+                        ).get("name", "")
 
             if fastq_files:
                 files_elements = [
@@ -443,6 +451,15 @@ class NCBISubmissionXML:
                         )
                     )
 
+                for biosample_id, lib_prep_name in lib_prep_protocol_names.items():
+                    sra_attributes.append(
+                        self.set_element(
+                            "Attribute",
+                            lib_prep_name,
+                            {"name": "library_construction_protocol"},
+                        )
+                    )
+
                 for biosample_id, omics_processing_id in omics_processing_ids.items():
                     identifier_element = self.set_element(
                         "Identifier",
@@ -474,6 +491,7 @@ class NCBISubmissionXML:
         biosamples_list: list,
         biosample_omics_processing_list: list,
         biosample_data_objects_list: list,
+        biosample_library_preparation_list: list,
     ):
         data_type = None
         ncbi_project_id = None
@@ -515,6 +533,7 @@ class NCBISubmissionXML:
             org=self.ncbi_submission_metadata.get("organization", ""),
             nmdc_omics_processing=biosample_omics_processing_list,
             nmdc_biosamples=biosamples_list,
+            nmdc_library_preparation=biosample_library_preparation_list,
         )
 
         rough_string = ET.tostring(self.root, "unicode")

--- a/nmdc_runtime/site/export/ncbi_xml.py
+++ b/nmdc_runtime/site/export/ncbi_xml.py
@@ -66,7 +66,7 @@ class NCBISubmissionXML:
             element.append(child)
         return element
 
-    def set_description(self, email, user, first, last, org, date=None):
+    def set_description(self, email, first, last, org, date=None):
         date = date or datetime.datetime.now().strftime("%Y-%m-%d")
         description = self.set_element(
             "Description",
@@ -74,7 +74,6 @@ class NCBISubmissionXML:
                 self.set_element(
                     "Comment", f"NMDC Submission for {self.nmdc_study_id}"
                 ),
-                self.set_element("Submitter", attrib={"user_name": user}),
                 self.set_element(
                     "Organization",
                     attrib={"role": "owner", "type": "center"},
@@ -205,7 +204,7 @@ class NCBISubmissionXML:
                     children=[
                         self.set_element(
                             "Title",
-                            f"NMDC Biosample {sample_id_value} from {organism_name} part of {self.nmdc_study_id} study",
+                            f"NMDC Biosample {sample_id_value} from {organism_name}, part of {self.nmdc_study_id} study",
                         ),
                     ],
                 ),
@@ -229,6 +228,11 @@ class NCBISubmissionXML:
                             "Attribute", attributes[key], {"attribute_name": key}
                         )
                         for key in sorted(attributes)
+                    ]
+                    + [
+                        self.set_element(
+                            "Attribute", "NMDC", {"attribute_name": "broker name"}
+                        )
                     ],
                 ),
             ]
@@ -482,7 +486,6 @@ class NCBISubmissionXML:
 
         self.set_description(
             email=self.nmdc_pi_email,
-            user="National Microbiome Data Collaborative (NMDC)",
             first=self.first_name,
             last=self.last_name,
             org=self.ncbi_submission_metadata.get("organization", ""),

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -52,6 +52,7 @@ from nmdc_runtime.site.ops import (
     get_ncbi_export_pipeline_study,
     get_data_objects_from_biosamples,
     get_omics_processing_from_biosamples,
+    get_library_preparation_from_biosamples,
     get_ncbi_export_pipeline_inputs,
     ncbi_submission_xml_from_nmdc_study,
     ncbi_submission_xml_asset,
@@ -390,12 +391,14 @@ def nmdc_study_to_ncbi_submission_export():
     ncbi_submission_metadata = get_ncbi_export_pipeline_inputs()
     biosamples = get_biosamples_by_study_id(nmdc_study)
     omics_processing_records = get_omics_processing_from_biosamples(biosamples)
-    data_objects = get_data_objects_from_biosamples(biosamples)
+    data_object_records = get_data_objects_from_biosamples(biosamples)
+    library_preparation_records = get_library_preparation_from_biosamples(biosamples)
     xml_data = ncbi_submission_xml_from_nmdc_study(
         nmdc_study,
         ncbi_submission_metadata,
         biosamples,
         omics_processing_records,
-        data_objects,
+        data_object_records,
+        library_preparation_records,
     )
     ncbi_submission_xml_asset(xml_data)

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -66,6 +66,7 @@ from nmdc_runtime.site.export.ncbi_xml import NCBISubmissionXML
 from nmdc_runtime.site.export.ncbi_xml_utils import (
     fetch_data_objects_from_biosamples,
     fetch_omics_processing_from_biosamples,
+    fetch_library_preparation_from_biosamples,
 )
 from nmdc_runtime.site.drsobjects.ingest import mongo_add_docs_result_as_dict
 from nmdc_runtime.site.resources import (
@@ -1099,6 +1100,18 @@ def get_omics_processing_from_biosamples(context: OpExecutionContext, biosamples
     return biosample_omics_processing
 
 
+@op(required_resource_keys={"mongo"})
+def get_library_preparation_from_biosamples(
+    context: OpExecutionContext, biosamples: list
+):
+    mdb = context.resources.mongo.db
+    alldocs_collection = mdb["alldocs"]
+    biosample_lib_prep = fetch_library_preparation_from_biosamples(
+        alldocs_collection, biosamples
+    )
+    return biosample_lib_prep
+
+
 @op
 def ncbi_submission_xml_from_nmdc_study(
     context: OpExecutionContext,
@@ -1106,10 +1119,14 @@ def ncbi_submission_xml_from_nmdc_study(
     ncbi_exporter_metadata: dict,
     biosamples: list,
     omics_processing_records: list,
-    data_objects: list,
+    data_object_records: list,
+    library_preparation_records: list,
 ) -> str:
     ncbi_exporter = NCBISubmissionXML(nmdc_study, ncbi_exporter_metadata)
     ncbi_xml = ncbi_exporter.get_submission_xml(
-        biosamples, omics_processing_records, data_objects
+        biosamples,
+        omics_processing_records,
+        data_object_records,
+        library_preparation_records,
     )
     return ncbi_xml

--- a/tests/test_data/test_ncbi_xml.py
+++ b/tests/test_data/test_ncbi_xml.py
@@ -163,6 +163,19 @@ def data_objects_list():
     ]
 
 
+@pytest.fixture
+def library_preparation_dict():
+    return {
+        "end_date": "2018-06-20",
+        "has_input": ["nmdc:procsm-12-sb2v8f15"],
+        "has_output": ["nmdc:procsm-12-ehktny16"],
+        "id": "nmdc:libprp-12-5hhdd393",
+        "processing_institution": "Battelle",
+        "start_date": "2015-07-21T18:00Z",
+        "protocol_link": {"name": "BMI_metagenomicsSequencingSOP_v1"},
+    }
+
+
 class TestNCBISubmissionXML:
     def test_set_element(self, ncbi_submission_client):
         element = ncbi_submission_client.set_element("Test", "Hello", {"attr": "value"})
@@ -173,10 +186,9 @@ class TestNCBISubmissionXML:
     def test_set_description(self, ncbi_submission_client):
         ncbi_submission_client.set_description(
             ncbi_submission_client.nmdc_pi_email,
-            "testuser",
             "Kate",
             "Thibault",
-            "Test Org",
+            "NSF National Ecological Observatory Network",
         )
         description = ET.tostring(
             ncbi_submission_client.root.find("Description"), "unicode"
@@ -184,15 +196,13 @@ class TestNCBISubmissionXML:
 
         root = ET.fromstring(description)
         comment = root.find("Comment").text
-        submitter = root.find("Submitter").attrib["user_name"]
         org_name = root.find("Organization/Name").text
         contact_email = root.find("Organization/Contact").attrib["email"]
         contact_first = root.find("Organization/Contact/Name/First").text
         contact_last = root.find("Organization/Contact/Name/Last").text
 
         assert comment == f"NMDC Submission for {MOCK_NMDC_STUDY['id']}"
-        assert submitter == "testuser"
-        assert org_name == "Test Org"
+        assert org_name == "NSF National Ecological Observatory Network"
         assert contact_email == "kthibault@battelleecology.org"
         assert contact_first == "Kate"
         assert contact_last == "Thibault"
@@ -287,25 +297,31 @@ class TestNCBISubmissionXML:
         nmdc_biosample,
         data_objects_list,
         omics_processing_list,
+        library_preparation_dict,
     ):
         biosample_data_objects = [
             {biosample["id"]: data_objects_list} for biosample in nmdc_biosample
         ]
 
-        biosample_omics_prcessing = [
+        biosample_omics_processing = [
             {biosample["id"]: omics_processing_list} for biosample in nmdc_biosample
+        ]
+
+        biosample_library_preparation = [
+            {biosample["id"]: library_preparation_dict} for biosample in nmdc_biosample
         ]
 
         ncbi_submission_client.set_fastq(
             biosample_data_objects=biosample_data_objects,
             bioproject_id=MOCK_NMDC_STUDY["insdc_bioproject_identifiers"][0],
             org="Test Org",
-            nmdc_omics_processing=biosample_omics_prcessing,
+            nmdc_omics_processing=biosample_omics_processing,
             nmdc_biosamples=nmdc_biosample,
+            nmdc_library_preparation=biosample_library_preparation,
         )
 
         action_elements = ncbi_submission_client.root.findall(".//Action")
-        assert len(action_elements) == len(biosample_data_objects)
+        assert len(action_elements) == 1  # 1 SRA <Action> block
 
         for action_element in action_elements:
             action_xml = ET.tostring(action_element, "unicode")
@@ -316,6 +332,14 @@ class TestNCBISubmissionXML:
             assert "PRJNA1029061" in action_xml
             assert "nmdc:bsm-12-p9q5v236" in action_xml
             assert "Test Org" in action_xml
+            # library Attributes in SRA <Action> block
+            assert "ILLUMINA" in action_xml
+            assert "NextSeq 550" in action_xml
+            assert "METAGENOMIC" in action_xml
+            assert "RANDOM" in action_xml
+            assert "paired" in action_xml
+            assert "ARIK.20150721.AMC.EPIPSAMMON.3" in action_xml
+            assert "BMI_metagenomicsSequencingSOP_v1" in action_xml
 
     def test_get_submission_xml(
         self,
@@ -324,6 +348,7 @@ class TestNCBISubmissionXML:
         nmdc_biosample,
         data_objects_list,
         omics_processing_list,
+        library_preparation_dict,
     ):
         mocker.patch(
             "nmdc_runtime.site.export.ncbi_xml.load_mappings",
@@ -377,16 +402,21 @@ class TestNCBISubmissionXML:
             {biosample["id"]: omics_processing_list} for biosample in nmdc_biosample
         ]
 
+        biosample_library_preparation = [
+            {biosample["id"]: library_preparation_dict} for biosample in nmdc_biosample
+        ]
+
         ncbi_submission_client.set_fastq(
             biosample_data_objects=biosample_data_objects,
             bioproject_id=MOCK_NMDC_STUDY["insdc_bioproject_identifiers"][0],
             org="Test Org",
             nmdc_omics_processing=biosample_omics_prcessing,
             nmdc_biosamples=nmdc_biosample,
+            nmdc_library_preparation=biosample_library_preparation,
         )
 
         submission_xml = ncbi_submission_client.get_submission_xml(
-            nmdc_biosample, [], biosample_data_objects
+            nmdc_biosample, [], biosample_data_objects, biosample_library_preparation
         )
 
         assert "nmdc:bsm-12-p9q5v236" in submission_xml
@@ -394,7 +424,7 @@ class TestNCBISubmissionXML:
         assert "sediment" in submission_xml
         assert "USA: Colorado, Arikaree River" in submission_xml
         assert "2015-07-21T18:00Z" in submission_xml
-        assert "National Microbiome Data Collaborative (NMDC)" in submission_xml
+        assert "National Microbiome Data Collaborative" in submission_xml
         assert (
             "National Ecological Observatory Network: soil metagenomes (DP1.10107.001)"
             in submission_xml


### PR DESCRIPTION
# Description

- [x] Add _broker name_ as custom NCBI BioSample `<Attribute>`
- [x] Pull in the value from `protocol.link.name` on `LibraryPreparation` records and use it to populate `<Attribute name="library_preparation_protocol"></Attribute>` in SRA <Action> blocks

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

# Definition of Done (DoD) Checklist:
A simple checklist of necessary activities that add verifiable/demonstrable value to the product by asserting the quality of a feature, not the functionality of that feature; the latter should be stated as acceptance criteria in the issue this PR closes. Not all activities in the PR template will be applicable to each feature since the definition of done is intended to be a comprehensive checklist. Consciously decide the applicability of value-added activities on a feature-by-feature basis.

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


