### PR TITLE
fix: changesheet can update bytes-ranged slot

### DIFF
--- a/tests/files/test_changesheet_update_bytes_ranged_slot.tsv
+++ b/tests/files/test_changesheet_update_bytes_ranged_slot.tsv
@@ -1,2 +1,2 @@
 id	action	attribute	value
-nmdc:dobj-11-m2kj6723	update	file_size_bytes	1271907
+nmdc:dobj-11-000n1286	update	file_size_bytes	1271907

--- a/tests/files/test_changesheet_update_bytes_ranged_slot.tsv
+++ b/tests/files/test_changesheet_update_bytes_ranged_slot.tsv
@@ -1,0 +1,2 @@
+id	action	attribute	value
+nmdc:dobj-11-m2kj6723	update	file_size_bytes	1271907

--- a/tests/test_api/test_metadata.py
+++ b/tests/test_api/test_metadata.py
@@ -53,6 +53,14 @@ def test_load_changesheet():
 
 def test_changesheet_update_slot_with_range_bytes():
     mdb = get_mongo_db()
+    dobj_local_id = "dobj-11-000n1286"
+    remove_tmp_doc = False
+    if mdb.data_object_set.find_one({"id": "nmdc:" + dobj_local_id}) is None:
+        with open(
+            REPO_ROOT_DIR.joinpath("tests", "files", f"nmdc_{dobj_local_id}.json")
+        ) as f:
+            mdb.data_object_set.insert_one(json.load(f))
+            remove_tmp_doc = True
     df = load_changesheet(
         REPO_ROOT_DIR.joinpath(
             "tests", "files", "test_changesheet_update_bytes_ranged_slot.tsv"
@@ -60,6 +68,8 @@ def test_changesheet_update_slot_with_range_bytes():
         mdb,
     )
     _validate_changesheet(df, mdb)
+    if remove_tmp_doc:
+        mdb.data_object_set.delete_one({"id": "nmdc:" + dobj_local_id})
 
 
 @pytest.mark.skip(reason="no /site-packages/nmdc_schema/external_identifiers.yaml ?")

--- a/tests/test_api/test_metadata.py
+++ b/tests/test_api/test_metadata.py
@@ -51,6 +51,17 @@ def test_load_changesheet():
     assert isinstance(df, pd.DataFrame)
 
 
+def test_changesheet_update_slot_with_range_bytes():
+    mdb = get_mongo_db()
+    df = load_changesheet(
+        REPO_ROOT_DIR.joinpath(
+            "tests", "files", "test_changesheet_update_bytes_ranged_slot.tsv"
+        ),
+        mdb,
+    )
+    _validate_changesheet(df, mdb)
+
+
 @pytest.mark.skip(reason="no /site-packages/nmdc_schema/external_identifiers.yaml ?")
 def test_update_01():
     mdb = get_mongo(run_config_frozen__normal_env).db


### PR DESCRIPTION
# Description

Infer python builtin type for coercion via <https://w3id.org/linkml/base>.

Fixes #613

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] added test `test_changesheet_update_slot_with_range_bytes`

# Definition of Done (DoD) Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


