### PR TITLE
not all schema collections suffix with `_set`s

### DIFF
--- a/nmdc_runtime/api/db/mongo.py
+++ b/nmdc_runtime/api/db/mongo.py
@@ -62,6 +62,7 @@ def nmdc_schema_collection_names(mdb: MongoDatabase) -> Set[str]:
     return {name for name in names if mdb[name].estimated_document_count() > 0}
 
 
+@lru_cache
 def get_collection_names_from_schema() -> list[str]:
     """
     Returns the names of the slots of the `Database` class that describe database collections.

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -545,7 +545,7 @@ def _add_schema_docs_with_or_without_replacement(
     if all(coll_index_on_id_map[coll] for coll in docs.keys()):
         replace = True
     elif all(not coll_index_on_id_map[coll] for coll in docs.keys()):
-        # XXX: This is a hack because e.g. <https://w3id.org/nmdc/FunctionalAnnotationAggMember>
+        # FIXME: XXX: This is a hack because e.g. <https://w3id.org/nmdc/FunctionalAnnotationAggMember>
         # documents should be unique with compound key (metagenome_annotation_id, gene_function_id)
         # and yet this is not explicit in the schema. One potential solution is to auto-generate an `id`
         # as a deterministic hash of the compound key.

--- a/nmdc_runtime/site/util.py
+++ b/nmdc_runtime/site/util.py
@@ -4,6 +4,7 @@ from subprocess import Popen, PIPE, STDOUT, CalledProcessError
 
 from pymongo.database import Database as MongoDatabase
 
+from nmdc_runtime.api.db.mongo import get_collection_names_from_schema
 from nmdc_runtime.site.resources import mongo_resource
 
 mode_test = {
@@ -34,13 +35,9 @@ def run_and_log(shell_cmd, context):
 
 
 @lru_cache
-def collection_indexed_on_id(mdb: MongoDatabase) -> dict:
-    set_collection_names = [
-        name for name in mdb.list_collection_names() if name.endswith("_set")
-    ]
-    return {
-        name: ("id_1" in mdb[name].index_information()) for name in set_collection_names
-    }
+def schema_collection_has_index_on_id(mdb: MongoDatabase) -> dict:
+    names = set(mdb.list_collection_names()) & set(get_collection_names_from_schema())
+    return {name: ("id_1" in mdb[name].index_information()) for name in names}
 
 
 def get_basename(filename: str) -> str:

--- a/nmdc_runtime/site/util.py
+++ b/nmdc_runtime/site/util.py
@@ -36,8 +36,13 @@ def run_and_log(shell_cmd, context):
 
 @lru_cache
 def schema_collection_has_index_on_id(mdb: MongoDatabase) -> dict:
-    names = set(mdb.list_collection_names()) & set(get_collection_names_from_schema())
-    return {name: ("id_1" in mdb[name].index_information()) for name in names}
+    present_collection_names = set(mdb.list_collection_names())
+    return {
+        name: (
+            name in present_collection_names and "id_1" in mdb[name].index_information()
+        )
+        for name in get_collection_names_from_schema()
+    }
 
 
 def get_basename(filename: str) -> str:

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -194,21 +194,6 @@ def test_metadata_validate_json_with_unknown_collection(api_site_client):
     assert rv.json()["result"] == "errors"
 
 
-def test_metadata_submit_json_functional_annotation_agg(api_site_client):
-    rv = api_site_client.request(
-        "POST",
-        "/metadata/json:submit",
-        {
-            "field_research_site_set": [
-                {"id": "nmdc:frsite-11-s2dqk408", "name": "BESC-470-CL2_38_23"},
-                {"id": "nmdc:frsite-11-s2dqk408", "name": "BESC-470-CL2_38_23"},
-                {"id": "nmdc:frsite-11-s2dqk408", "name": "BESC-470-CL2_38_23"},
-            ]
-        },
-    )
-    assert rv.json()["result"] == "errors"
-
-
 def test_submit_changesheet():
     sheet_in = ChangesheetIn(
         name="sheet",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -194,6 +194,21 @@ def test_metadata_validate_json_with_unknown_collection(api_site_client):
     assert rv.json()["result"] == "errors"
 
 
+def test_metadata_submit_json_functional_annotation_agg(api_site_client):
+    rv = api_site_client.request(
+        "POST",
+        "/metadata/json:submit",
+        {
+            "field_research_site_set": [
+                {"id": "nmdc:frsite-11-s2dqk408", "name": "BESC-470-CL2_38_23"},
+                {"id": "nmdc:frsite-11-s2dqk408", "name": "BESC-470-CL2_38_23"},
+                {"id": "nmdc:frsite-11-s2dqk408", "name": "BESC-470-CL2_38_23"},
+            ]
+        },
+    )
+    assert rv.json()["result"] == "errors"
+
+
 def test_submit_changesheet():
     sheet_in = ChangesheetIn(
         name="sheet",

--- a/tests/test_ops/test_hello.py
+++ b/tests/test_ops/test_hello.py
@@ -1,8 +1,0 @@
-from dagster import build_op_context
-
-from nmdc_runtime.site.ops import hello
-
-
-def test_hello():
-    context = build_op_context()
-    assert hello(context) == "Hello, NMDC!"

--- a/tests/test_ops/test_ops.py
+++ b/tests/test_ops/test_ops.py
@@ -1,0 +1,79 @@
+import json
+import os
+
+import pytest
+from dagster import build_op_context
+
+from nmdc_runtime.api.endpoints.util import persist_content_and_get_drs_object
+from nmdc_runtime.site.resources import (
+    mongo_resource,
+    runtime_api_site_client_resource,
+    RuntimeApiSiteClient,
+    runtime_api_user_client_resource,
+    RuntimeApiUserClient,
+)
+
+from nmdc_runtime.site.ops import (
+    perform_mongo_updates,
+    _add_schema_docs_with_or_without_replacement,
+)
+
+
+@pytest.fixture
+def op_context():
+    return build_op_context(
+        resources={
+            "mongo": mongo_resource.configured(
+                {
+                    "dbname": os.getenv("MONGO_DBNAME"),
+                    "host": os.getenv("MONGO_HOST"),
+                    "password": os.getenv("MONGO_PASSWORD"),
+                    "username": os.getenv("MONGO_USERNAME"),
+                }
+            ),
+            "runtime_api_user_client": runtime_api_user_client_resource.configured(
+                {
+                    "base_url": os.getenv("API_HOST"),
+                    "username": os.getenv("API_ADMIN_USER"),
+                    "password": os.getenv("API_ADMIN_PASS"),
+                },
+            ),
+            "runtime_api_site_client": runtime_api_site_client_resource.configured(
+                {
+                    "base_url": os.getenv("API_HOST"),
+                    "site_id": os.getenv("API_SITE_ID"),
+                    "client_id": os.getenv("API_SITE_CLIENT_ID"),
+                    "client_secret": os.getenv("API_SITE_CLIENT_SECRET"),
+                }
+            ),
+        }
+    )
+
+
+def test_perform_mongo_updates_functional_annotation_agg(op_context):
+    mongo = op_context.resources.mongo
+    docs = {
+        "functional_annotation_agg": [
+            {
+                "metagenome_annotation_id": "nmdc:wfmtan-13-hemh0a82.1",
+                "gene_function_id": "KEGG.ORTHOLOGY:K00005",
+                "count": 10,
+            },
+            {
+                "metagenome_annotation_id": "nmdc:wfmtan-13-hemh0a82.1",
+                "gene_function_id": "KEGG.ORTHOLOGY:K01426",
+                "count": 5,
+            },
+        ]
+    }
+    # Ensure the docs are not already in the test database.
+    for doc_spec in docs["functional_annotation_agg"]:
+        mongo.db.functional_annotation_agg.delete_many(doc_spec)
+
+    _add_schema_docs_with_or_without_replacement(mongo, docs)
+    assert (
+        mongo.db.functional_annotation_agg.count_documents(
+            {"$or": docs["functional_annotation_agg"]}
+        )
+        == 2
+    )


### PR DESCRIPTION
# Description

Just like not all heroes wear capes, not all not all schema collections suffix with `_set`s.

Interpret `perform_mongo_updates` for non-`id`-having schema collections as simple insertions. Leave note in code about decision to insist on schema-supplied uniqueness signal.

This is a hack because e.g. <https://w3id.org/nmdc/FunctionalAnnotationAggMember> documents appear by eye to be unique via a compound key (metagenome_annotation_id, gene_function_id) and yet this is not explicit in the schema.

One potential solution is to auto-generate an `id` for such documents as a deterministic hash of the compound key, but any such `id` generation strategy should be unambiguous to a schema consumer such as nmdc-runtime.

For now, decision is to potentially re-insert "duplicate" documents, i.e. to interpret lack of `id` as lack of unique document identity for de-duplication.

Fixes #611

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `test_perform_mongo_updates_functional_annotation_agg`

# Definition of Done (DoD) Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


