### PR TITLE
hotfix: op fails due to invalid helper method invocation

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -528,7 +528,9 @@ def perform_mongo_updates(context, json_in):
     if rv["result"] == "errors":
         raise Failure(str(rv["detail"]))
 
-    add_docs_result = _add_schema_docs_with_or_without_replacement()
+    # TODO containing op `perform_mongo_updates` needs test coverage, as below line had trivial bug.
+    #   ref: https://github.com/microbiomedata/nmdc-runtime/issues/631
+    add_docs_result = _add_schema_docs_with_or_without_replacement(mongo, docs)
     op_patch = UpdateOperationRequest(
         done=True,
         result=add_docs_result,


### PR DESCRIPTION
for #631

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested my manual trigger of `apply_metadata_in` job. Not closing #631 -- left `TODO` to add test coverage, but will merge now to ensure fix is active asap.


