### PR TITLE
Get ORCID base URL (production vs. sandbox) from environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,4 +40,9 @@ NERSC_USERNAME=replaceme
 ORCID_NMDC_CLIENT_ID=replaceme
 ORCID_NMDC_CLIENT_SECRET=replaceme
 
+# Base URL (without a trailing slash) at which the Runtime can access an instance of ORCID.
+# Note: For the production instance of ORCID, use: https://orcid.org (default)
+#       For the sandbox instance of ORCID, use: https://sandbox.orcid.org
+ORCID_BASE_URL=https://orcid.org
+
 INFO_BANNER_INNERHTML='Announcement: Something important is about to happen. If you have questions, please contact <a href="mailto:support@microbiomedata.org">support@microbiomedata.org</a>.'

--- a/nmdc_runtime/api/core/auth.py
+++ b/nmdc_runtime/api/core/auth.py
@@ -25,6 +25,7 @@ SECRET_KEY = os.getenv("JWT_SECRET_KEY")
 ALGORITHM = "HS256"
 ORCID_NMDC_CLIENT_ID = os.getenv("ORCID_NMDC_CLIENT_ID")
 ORCID_NMDC_CLIENT_SECRET = os.getenv("ORCID_NMDC_CLIENT_SECRET")
+ORCID_BASE_URL = os.getenv("ORCID_BASE_URL", default="https://orcid.org")
 
 # https://orcid.org/.well-known/openid-configuration
 # XXX do we want to live-load this?

--- a/nmdc_runtime/api/endpoints/users.py
+++ b/nmdc_runtime/api/endpoints/users.py
@@ -20,6 +20,7 @@ from nmdc_runtime.api.core.auth import (
     ORCID_JWS_VERITY_ALGORITHM,
     credentials_exception,
     ORCID_NMDC_CLIENT_SECRET,
+    ORCID_BASE_URL,
 )
 from nmdc_runtime.api.core.auth import get_password_hash
 from nmdc_runtime.api.core.util import generate_secret
@@ -39,7 +40,7 @@ router = APIRouter()
 @router.get("/orcid_code", response_class=RedirectResponse, include_in_schema=False)
 async def receive_orcid_code(request: Request, code: str, state: str | None = None):
     rv = requests.post(
-        "https://orcid.org/oauth/token",
+        f"{ORCID_BASE_URL}/oauth/token",
         data=(
             f"client_id={ORCID_NMDC_CLIENT_ID}&client_secret={ORCID_NMDC_CLIENT_SECRET}&"
             f"grant_type=authorization_code&code={code}&redirect_uri={BASE_URL_EXTERNAL}/orcid_code"
@@ -98,7 +99,7 @@ async def login_for_access_token(
                 )
                 payload = json.loads(payload.decode())
                 issuer: str = payload.get("iss")
-                if issuer != "https://orcid.org":
+                if issuer != ORCID_BASE_URL:
                     raise credentials_exception
                 subject: str = payload.get("sub")
                 user = get_user(mdb, subject)

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -22,7 +22,11 @@ from nmdc_runtime.util import (
     ensure_unique_id_indexes,
     REPO_ROOT_DIR,
 )
-from nmdc_runtime.api.core.auth import get_password_hash, ORCID_NMDC_CLIENT_ID, ORCID_BASE_URL
+from nmdc_runtime.api.core.auth import (
+    get_password_hash,
+    ORCID_NMDC_CLIENT_ID,
+    ORCID_BASE_URL,
+)
 from nmdc_runtime.api.db.mongo import (
     get_mongo_db,
 )

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -22,7 +22,7 @@ from nmdc_runtime.util import (
     ensure_unique_id_indexes,
     REPO_ROOT_DIR,
 )
-from nmdc_runtime.api.core.auth import get_password_hash, ORCID_NMDC_CLIENT_ID
+from nmdc_runtime.api.core.auth import get_password_hash, ORCID_NMDC_CLIENT_ID, ORCID_BASE_URL
 from nmdc_runtime.api.db.mongo import (
     get_mongo_db,
 )
@@ -426,7 +426,7 @@ app = FastAPI(
         f'nmdc-schema={version("nmdc_schema")}\n\n'
         "<a href='https://microbiomedata.github.io/nmdc-runtime/'>Documentation</a>\n\n"
         '<img src="/static/ORCIDiD_icon128x128.png" height="18" width="18"/> '
-        f'<a href="https://orcid.org/oauth/authorize?client_id={ORCID_NMDC_CLIENT_ID}'
+        f'<a href="{ORCID_BASE_URL}/oauth/authorize?client_id={ORCID_NMDC_CLIENT_ID}'
         "&response_type=code&scope=openid&"
         f'redirect_uri={BASE_URL_EXTERNAL}/orcid_code">Login with ORCiD</a>'
         " (note: this link is static; if you are logged in, you will see a 'locked' lock icon"


### PR DESCRIPTION
# Description

In this branch, I made it so that the Runtime can be configured to use either the sandbox ORCID environment or the production ORCID environment, via an environment variable. If the environment variable is not defined, the Runtime will default to using the production ORCID environment.

Note: The base branch of this PR is the `berkeley` branch, not the `main` branch.

Fixes #636 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- I have not tested this outside of GitHub Actions. I will rely on a GitHub Actions workflow to test it.

**Configuration Details**: none

# Definition of Done (DoD) Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas


