### PR TITLE
Remove test code's dependence on a static Mongo dump

### DIFF
--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -5,6 +5,7 @@ import re
 import pytest
 import requests
 from dagster import build_op_context
+from fastapi import HTTPException
 from starlette import status
 from tenacity import wait_random_exponential, retry
 from toolz import get_in
@@ -349,9 +350,15 @@ def test_get_class_name_and_collection_names_by_doc_id():
     assert response.status_code == 404
 
 
-def test_find_data_objects_for_study(api_site_client):
-    response = api_site_client.request(
-        "GET",
-        "/data_objects/study/nmdc:sty-11-hdd4bf83",
-    )
-    assert response.status_code == 404
+def test_find_data_objects_for_nonexistent_study(api_site_client):
+    r"""
+    Confirms that the endpoint raises an `HTTPException` when the specified Study doesn't exist.
+    Reference: https://docs.pytest.org/en/stable/reference/reference.html#pytest.raises
+
+    TODO: Add tests focused on the situation where the Study _does_ exist.
+    """
+    with pytest.raises(HTTPException):
+        api_site_client.request(
+            "GET",
+            "/data_objects/study/nmdc:sty-11-hdd4bf83",
+        )

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -351,13 +351,16 @@ def test_get_class_name_and_collection_names_by_doc_id():
 
 def test_find_data_objects_for_nonexistent_study(api_site_client):
     r"""
-    Confirms that the endpoint raises an `HTTPException` when the specified Study doesn't exist.
+    Confirms the endpoint returns an unsuccessful status code when no `Study` having the specified `id` exists.
     Reference: https://docs.pytest.org/en/stable/reference/reference.html#pytest.raises
 
-    TODO: Add tests focused on the situation where the Study _does_ exist.
+    Note: The `api_site_client` fixture's `request` method will raise an exception if the server responds with
+          an unsuccessful status code.
+
+    TODO: Add tests focused on the situation where the `Study` _does_ exist.
     """
     ensure_schema_collections_and_alldocs()
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(requests.exceptions.HTTPError):
         api_site_client.request(
             "GET",
             "/data_objects/study/nmdc:sty-11-hdd4bf83",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -356,6 +356,7 @@ def test_find_data_objects_for_nonexistent_study(api_site_client):
 
     TODO: Add tests focused on the situation where the Study _does_ exist.
     """
+    ensure_schema_collections_and_alldocs()
     with pytest.raises(requests.HTTPError):
         api_site_client.request(
             "GET",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -5,7 +5,6 @@ import re
 import pytest
 import requests
 from dagster import build_op_context
-from fastapi import HTTPException
 from starlette import status
 from tenacity import wait_random_exponential, retry
 from toolz import get_in
@@ -357,7 +356,7 @@ def test_find_data_objects_for_nonexistent_study(api_site_client):
 
     TODO: Add tests focused on the situation where the Study _does_ exist.
     """
-    with pytest.raises(HTTPException):
+    with pytest.raises(requests.HTTPError):
         api_site_client.request(
             "GET",
             "/data_objects/study/nmdc:sty-11-hdd4bf83",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -55,39 +55,48 @@ def ensure_schema_collections_and_alldocs():
     # Docs: https://microbiomedata.github.io/nmdc-schema/Study/
     # Docs: https://microbiomedata.github.io/berkeley-schema-fy24/Study/
     study_id = "nmdc:sty-11-hdd4bf83"  # matches the `id` used in a test below
-    mdb.get_collection("study_set").insert_many([
+    mdb.get_collection("study_set").replace_one(
+        dict(id=study_id),
         dict(id=study_id,
              type="nmdc:Study",
              study_category="research_study"),
-    ])
+        upsert=True,
+    )
     # Docs: https://microbiomedata.github.io/nmdc-schema/Biosample/
     # Docs: https://microbiomedata.github.io/berkeley-schema-fy24/Biosample/
     biosample_id = "nmdc:bsm-11-b1"
-    mdb.get_collection("biosample_set").insert_many([
+    mdb.get_collection("biosample_set").replace_one(
+        dict(id=biosample_id),
         dict(id=biosample_id,
              type="nmdc:Biosample",
              env_broad_scale=controlled_identified_term_value,
              env_local_scale=controlled_identified_term_value,
              env_medium=controlled_identified_term_value,
              part_of=study_id),
-    ])
+        upsert=True,
+    )
     # Docs: https://microbiomedata.github.io/nmdc-schema/DataObject/
     # Docs: https://microbiomedata.github.io/berkeley-schema-fy24/DataObject/
     data_object_ids = [f"nmdc:dobj-11-d{i}" for i in range(0, 100)]
-    mdb.get_collection("data_object_set").insert_many([
-        dict(id=data_object_id,
-             type="nmdc:DataObject",
-             name="my_name",
-             description="my_description")
-        for data_object_id in data_object_ids
-    ])
+    for data_object_id in data_object_ids:
+        mdb.get_collection("data_object_set").replace_one(
+            dict(id=data_object_id),
+            dict(id=data_object_id,
+                 type="nmdc:DataObject",
+                 name="my_name",
+                 description="my_description"),
+            upsert=True,
+        )
     # Populate a (contrived) collection whose documents "relate" Biosamples to DataObjects.
-    mdb.get_collection("contrived_thing_set").insert_many([
-        dict(id="nmdc:cvd-11-p1",
+    contrived_thing_id = "nmdc:cvd-11-p1"
+    mdb.get_collection("contrived_thing_set").replace_one(
+        dict(id=contrived_thing_id),
+        dict(id=contrived_thing_id,
              type="nmdc:ContrivedThing",
              has_input=biosample_id,
              has_output=data_object_ids),
-    ])
+        upsert=True,
+    )
 
     ensure_unique_id_indexes(mdb)
     print("materializing alldocs...")


### PR DESCRIPTION
Here are the changes I made in this PR branch:
1. **I removed the test set up code** that downloaded and restored a static Mongo dump that conformed to a specific version of `nmdc-schema`.
   1. That code was not compatible with branches of the Runtime on which a different version of `nmdc-schema` was in use. In practice, we saw test failures when the Runtime was using the "Berkeley schema" (i.e. `nmdc-schema` version 11.x); but I think we would have seen test failures even when the Runtime was using certain versions of the legacy schema (i.e. `nmdc-schema` version 10.x), depending upon how that schema version differed from the one the dump happens to conform to.
2. **I removed the test** that depended upon the aforementioned (removed) set up code loading specific data into the `alldocs` collection.
   1. **I replaced that test** with one that confirms that the endpoint (i.e. the endpoint being tested) returns an unsuccessful HTTP response when there is no `Study` having the specified `id`.
   3. I added a `TODO` comment about adding tests for the scenario where the `Study` _does_ exist (in which case, the endpoint would utilize the `alldocs` collection). This is what the original (removed) test did, but it depended upon the problematic set up code I referred to in item 1.
3. I also removed some unused `import` statements (I think they had been left there by mistake).