### PR TITLE
Add indexes to `alldocs` collection for `has_input` and `has_output` keys/slots

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1043,6 +1043,10 @@ def materialize_alldocs(context) -> int:
 
     # Re-idx for `alldocs` collection
     mdb.alldocs.create_index("id", unique=True)
+    # The indexes were added to improve the performance of the
+    # /data_objects/study/{study_id} endpoint
+    mdb.alldocs.create_index("has_input")
+    mdb.alldocs.create_index("has_output")
     context.log.info(
         f"refreshed {mdb.alldocs} collection with {mdb.alldocs.estimated_document_count()} docs."
     )


### PR DESCRIPTION
# Description

This PR seeks to resolve the server timeout error occurring in the below linked issue by adding indexes on two more keys/slots in the `alldocs` collection -- `has_input` and `has_output`. As of this PR, we have an index only only on one of they keys/slots which is `id`.

Fixes #654 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Used the study id of the largest study currently in NMDC Mongo, `nmdc:sty-11-34xj1150` which is the study id for the NEON soil study and ran the API endpoint on a Swagger/fastAPI instance on my local machine. The endpoint ran to completion and took ~30s.

# Definition of Done (DoD) Checklist:

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [ ] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


