### PR TITLE
Update Swagger tag descriptions to match Berkeley API GUI how-to guide

### DIFF
--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -222,11 +222,8 @@ issue an update query).
     {
         "name": "metadata",
         "description": """
-The [metadata endpoints](https://api.microbiomedata.org/docs#/metadata) can be used to get and filter metadata from 
-collection set types (including [studies](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/Study.html), 
-[biosamples](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/Biosample.html), 
-[data objects](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/DataObject.html), and 
-[activities](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/Activity.html)).<br/>
+The [metadata endpoints](https://api.microbiomedata.org/docs#/metadata) can be used to get and filter metadata from collection set types (including studies, biosamples, planned processes, and data objects as discussed in the __find__ section).
+<br/>
  
 The __metadata__ endpoints allow users to retrieve metadata from the data portal using the various GET endpoints 
 that are slightly different than the __find__ endpoints, but some can be used similarly. As with the __find__  endpoints, 
@@ -254,11 +251,8 @@ The applicable parameters of the __metadata__ endpoints, with acceptable syntax 
     {
         "name": "find",
         "description": """
-The [find endpoints](https://api.microbiomedata.org/docs#/find:~:text=Find%20NMDC-,metadata,-entities.) are provided with 
-NMDC metadata entities already specified - where metadata about [studies](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/Study.html), 
-[biosamples](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/Biosample.html), 
-[data objects](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/DataObject.html), and 
-[activities](https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/Activity.html) can be retrieved using GET requests. 
+The [find endpoints](https://api.microbiomedata.org/docs#/find:~:text=Find%20NMDC-,metadata,-entities.) are provided with NMDC metadata entities already specified - where metadata about [studies](https://w3id.org/nmdc/Study), [biosamples](https://w3id.org/nmdc/Biosample), [data objects](https://w3id.org/nmdc/DataObject/), and [planned processes](https://w3id.org/nmdc/PlannedProcess/) can be retrieved using GET requests. 
+<br/>
 
 Each endpoint is unique and requires the applicable attribute names to be known in order to structure a query in a meaningful way. 
 Please note that endpoints with parameters that do not have a red ___* required___ label next to them are optional.<br/>
@@ -280,7 +274,8 @@ The applicable parameters of the ___find___ endpoints, with acceptable syntax an
 | study_id | The unique identifier of a study | Curie e.g. `prefix:identifier` | `nmdc:sty-11-34xj1150` |
 | sample_id | The unique identifier of a biosample | Curie e.g. `prefix:identifier` | `nmdc:bsm-11-w43vsm21` |
 | data_object_id | The unique identifier of a data object | Curie e.g. `prefix:identifier` | `nmdc:dobj-11-7c6np651` |
-| activity_id | The unique identifier for an NMDC workflow execution activity | Curie e.g. `prefix:identifier` | `nmdc:wfmgan-11-hvcnga50.1`|<br/>
+| planned_process_id | The unique identifier for an NMDC planned process | Curie e.g. `prefix:identifier` | `nmdc:wfmgan-11-hvcnga50.1`|
+
 <br/>
 </details>
 

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -233,9 +233,6 @@ Unlike the compact syntax used in the __find__  endpoints, the syntax for the fi
 uses [MongoDB-like language querying](https://www.mongodb.com/docs/manual/tutorial/query-documents/). 
 The applicable parameters of the __metadata__ endpoints, with acceptable syntax and examples, are in the table below.
 
-<details>
-<summary>More Details</summary>
-
 | Parameter | Description | Syntax | Example |
 | :---: | :-----------: | :-------: | :---: | 
 | collection_name | The name of the collection to be queried. For a list of collection names please see the [Database class](https://microbiomedata.github.io/nmdc-schema/Database/) of the NMDC Schema | String | `biosample_set` |
@@ -245,7 +242,7 @@ The applicable parameters of the __metadata__ endpoints, with acceptable syntax 
 | projection | Indicates the desired attributes to be included in the response. Helpful for trimming down the returned results | Comma-separated list of attributes that belong to the documents in the collection being queried | `name, ecosystem_type` |
 | doc_id | The unique identifier of the item being requested. For example, the identifier of a biosample or an extraction | Curie e.g. `prefix:identifier` | `nmdc:bsm-11-ha3vfb58` |<br/>
 <br/>
-</details>        
+
         """,
     },
     {
@@ -258,8 +255,6 @@ Each endpoint is unique and requires the applicable attribute names to be known 
 Please note that endpoints with parameters that do not have a red ___* required___ label next to them are optional.<br/>
 
 The applicable parameters of the ___find___ endpoints, with acceptable syntax and examples, are in the table below.
-
-<details><summary>More Details</summary>
 
 | Parameter | Description | Syntax | Example |
 | :---: | :-----------: | :-------: | :---: |
@@ -277,7 +272,6 @@ The applicable parameters of the ___find___ endpoints, with acceptable syntax an
 | planned_process_id | The unique identifier for an NMDC planned process | Curie e.g. `prefix:identifier` | `nmdc:wfmgan-11-hvcnga50.1`|
 
 <br/>
-</details>
 
 """,
     },


### PR DESCRIPTION
# Description

In this branch, I updated Swagger tag descriptions to be consistent with the latest Berkeley Schema-compatible API GUI how-to guide ([here](https://github.com/microbiomedata/NMDC_documentation/blob/7f0ce6d7f671785e4733fdc14eac0c2f766b6cb9/docs/howto_guides/api_gui.md)). That was my main objective.

While I was at it, I also disabled a buggy feature, where expanding a table within a tag description would simultaneously collapse the endpoints in that tag section; and vice versa. This was happening because the click event was being propagated up the DOM tree, being received be listeners at every level (i.e. there was no `event.stopPropagation()` happening within the tag description level). Now, the table is always visible.

Fixes #646 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [x] I viewed Swagger UI in my local development environment
- [x] I clicked on the tag description and its contents and observed the behavior of the nearby elements

**Configuration Details**: none

# Definition of Done (DoD) Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

