### PR TITLE
`berkeley`: Unskip `test_submit_workflow_activities` test and make it work with Berkeley schema

### DIFF
--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -270,9 +270,6 @@ def test_submit_changesheet():
     assert True
 
 
-#@pytest.mark.skip(
-#    reason="Skipping because race condition causes  http://fastapi:8000/nmdcschema/ids/nmdc:wfrqc-11-t0tvnp52.2 to 404?"
-#)
 def test_submit_workflow_activities(api_site_client):
     test_collection, test_id = (
         "workflow_execution_set",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -281,7 +281,7 @@ def test_submit_workflow_activities(api_site_client):
     test_payload = {
         test_collection: [
             {
-                "id": nmdc:wfrqc-11-abcdef,
+                "id": "nmdc:wfrqc-11-abcdef",
                 "name": "Read QC Activity for nmdc:wfrqc-11-t0tvnp52.1",
                 "started_at_time": "2024-01-11T20:48:30.718133+00:00",
                 "ended_at_time": "2024-01-11T21:11:44.884260+00:00",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -304,7 +304,7 @@ def test_submit_workflow_activities(api_site_client):
         mdb[test_collection].delete_one({"id": test_id})
     rv = api_site_client.request(
         "POST",
-        "/v1/workflows/activities",
+        "/workflows/workflow_executions",
         test_payload,
     )
     assert rv.json() == {"message": "jobs accepted"}

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -281,7 +281,7 @@ def test_submit_workflow_activities(api_site_client):
     test_payload = {
         test_collection: [
             {
-                "id": "nmdc:wfrqc-11-abcdef",
+                "id": test_id,
                 "name": "Read QC Activity for nmdc:wfrqc-11-t0tvnp52.1",
                 "started_at_time": "2024-01-11T20:48:30.718133+00:00",
                 "ended_at_time": "2024-01-11T21:11:44.884260+00:00",
@@ -292,10 +292,10 @@ def test_submit_workflow_activities(api_site_client):
                 "has_output": [
                     "nmdc:dobj-11-w5dak635",
                     "nmdc:dobj-11-g6d71n77",
-                    "nmdc:dobj-11-bds7qq03",
+                    "nmdc:dobj-11-bds7qq03"
                 ],
                 "type": "nmdc:ReadQcAnalysis",
-                "version": "v1.0.8",
+                "version": "v1.0.8"
             }
         ]
     }

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -270,9 +270,9 @@ def test_submit_changesheet():
     assert True
 
 
-@pytest.mark.skip(
-    reason="Skipping because race condition causes  http://fastapi:8000/nmdcschema/ids/nmdc:wfrqc-11-t0tvnp52.2 to 404?"
-)
+#@pytest.mark.skip(
+#    reason="Skipping because race condition causes  http://fastapi:8000/nmdcschema/ids/nmdc:wfrqc-11-t0tvnp52.2 to 404?"
+#)
 def test_submit_workflow_activities(api_site_client):
     test_collection, test_id = (
         "workflow_execution_set",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -275,13 +275,13 @@ def test_submit_changesheet():
 )
 def test_submit_workflow_activities(api_site_client):
     test_collection, test_id = (
-        "read_qc_analysis_activity_set",
+        "workflow_execution_set",
         "nmdc:wfrqc-11-t0tvnp52.2",
     )
     test_payload = {
         test_collection: [
             {
-                "id": test_id,
+                "id": nmdc:wfrqc-11-abcdef,
                 "name": "Read QC Activity for nmdc:wfrqc-11-t0tvnp52.1",
                 "started_at_time": "2024-01-11T20:48:30.718133+00:00",
                 "ended_at_time": "2024-01-11T21:11:44.884260+00:00",
@@ -294,7 +294,7 @@ def test_submit_workflow_activities(api_site_client):
                     "nmdc:dobj-11-g6d71n77",
                     "nmdc:dobj-11-bds7qq03",
                 ],
-                "type": "nmdc:ReadQcAnalysisActivity",
+                "type": "nmdc:ReadQcAnalysis",
                 "version": "v1.0.8",
             }
         ]


### PR DESCRIPTION
# Description

This PR fixes test_submit_workflow_activities to be compatible with berkeley schema

Fixes # [(issue)](https://github.com/microbiomedata/nmdc-runtime/issues/683)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [ ] Test A
- [ ] Test B

testing is from github acations

**Configuration Details**: none

# Definition of Done (DoD) Checklist:
A simple checklist of necessary activities that add verifiable/demonstrable value to the product by asserting the quality of a feature, not the functionality of that feature; the latter should be stated as acceptance criteria in the issue this PR closes. Not all activities in the PR template will be applicable to each feature since the definition of done is intended to be a comprehensive checklist. Consciously decide the applicability of value-added activities on a feature-by-feature basis.

- [ ] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [ ] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


