### PR TITLE
`berkeley`: Restore tests that were being skipped by mistake (oops)

### DIFF
--- a/tests/test_data/test_neon_benthic_data_translator.py
+++ b/tests/test_data/test_neon_benthic_data_translator.py
@@ -5,12 +5,6 @@ from nmdc_runtime.site.translation.neon_benthic_translator import (
 )
 import pandas as pd
 
-# FIXME: Update the NEON Benthic Data Translator to work with the Berkeley schema, then un-skip this module's tests.
-#        Reference: https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions
-pytest.skip(
-    "Skipping tests targeting NEON Benthic Data Translator because it has not been updated to work with the Berkeley schema yet", 
-    allow_module_level=True,
-)
 
 # Mock data for testing
 benthic_data = {

--- a/tests/test_data/test_neon_soil_data_translator.py
+++ b/tests/test_data/test_neon_soil_data_translator.py
@@ -9,12 +9,6 @@ from nmdc_runtime.site.translation.neon_utils import (
 )
 import pandas as pd
 
-# FIXME: Update the NEON Soil Data Translator to work with the Berkeley schema, then un-skip this module's tests.
-#        Reference: https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions
-pytest.skip(
-    "Skipping tests targeting NEON Soil Data Translator because it has not been updated to work with the Berkeley schema yet",
-    allow_module_level=True,
-)
 
 # Mock data for testing
 mms_data = {

--- a/tests/test_ops/test_gold_api_ops.py
+++ b/tests/test_ops/test_gold_api_ops.py
@@ -32,11 +32,6 @@ def op_context(client_config):
     )
 
 
-# FIXME: Update the API endpoint to work with the Berkeley schema, then un-skip this test.
-#        Reference: https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions
-@pytest.mark.skip(
-    reason="API endpoint has not been updated to work with the Berkeley schema yet"
-)
 def test_gold_biosamples_by_study(client_config, op_context):
     with requests_mock.mock() as mock:
         mock.get(
@@ -52,11 +47,6 @@ def test_gold_biosamples_by_study(client_config, op_context):
         assert mock.last_request.headers["Authorization"].startswith("Basic ")
 
 
-# FIXME: Update the API endpoint to work with the Berkeley schema, then un-skip this test.
-#        Reference: https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions
-@pytest.mark.skip(
-    reason="API endpoint has not been updated to work with the Berkeley schema yet"
-)
 def test_gold_projects_by_study(client_config, op_context):
     with requests_mock.mock() as mock:
         mock.get(
@@ -72,11 +62,6 @@ def test_gold_projects_by_study(client_config, op_context):
         assert mock.last_request.headers["Authorization"].startswith("Basic ")
 
 
-# FIXME: Update the API endpoint to work with the Berkeley schema, then un-skip this test.
-#        Reference: https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions
-@pytest.mark.skip(
-    reason="API endpoint has not been updated to work with the Berkeley schema yet"
-)
 def test_gold_analysis_projects_by_study(client_config, op_context):
     with requests_mock.mock() as mock:
         mock.get(
@@ -92,11 +77,6 @@ def test_gold_analysis_projects_by_study(client_config, op_context):
         assert mock.last_request.headers["Authorization"].startswith("Basic ")
 
 
-# FIXME: Update the API endpoint to work with the Berkeley schema, then un-skip this test.
-#        Reference: https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions
-@pytest.mark.skip(
-    reason="API endpoint has not been updated to work with the Berkeley schema yet"
-)
 def test_gold_study(client_config, op_context):
     with requests_mock.mock() as mock:
         mock.get(


### PR DESCRIPTION
# Description

In PR https://github.com/microbiomedata/nmdc-runtime/pull/676, I configured pytest to skip running the following tests:

1. All tests in: `tests/test_data/test_neon_benthic_data_translator.py`
2. All tests in: `tests/test_data/test_neon_soil_data_translator.py`
3. All (4) tests in: `tests/test_ops/test_gold_api_ops.py`

In this PR, I have undone that; i.e. I've unskipped them, so that pytest will run them.

Fixes #687

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- 👀 

**Configuration Details**: none

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code