### PR TITLE
`berkeley`: Determine class ancestry per-type value (within collection) instead of per-collection (when generating `alldocs`)

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1080,7 +1080,7 @@ def materialize_alldocs(context) -> int:
             #       determining the class ancestry of only _one_ of them (we call this the "representative") and then
             #       (later) attributing that class ancestry to all of them.
             #
-            representative_doc = next(docs_having_type, default=None)
+            representative_doc = next(docs_having_type)
 
             # Instantiate the Python class represented by the "representative" document.
             db_dict = {

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1071,7 +1071,7 @@ def materialize_alldocs(context) -> int:
             num_docs_having_type = mdb[collection_name].count_documents(filter=filter_)
             docs_having_type = mdb[collection_name].find(filter=filter_)
             context.log.info(
-                f"Found {len(num_docs_having_type)} documents having {type_value=} in {collection_name=}."
+                f"Found {num_docs_having_type} documents having {type_value=} in {collection_name=}."
             )
 
             # Get a "representative" document from the result.
@@ -1084,8 +1084,9 @@ def materialize_alldocs(context) -> int:
 
             # Instantiate the Python class represented by the "representative" document.
             db_dict = {
+                # Shed the `_id` attribute, since the constructor doesn't allow it.
                 collection_name: [dissoc(representative_doc, "_id")]
-            }  # omits key incompatible with constructor
+            }
             nmdc_db = NMDCDatabase(**db_dict)
             representative_instance = getattr(nmdc_db, collection_name)[0]
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1059,6 +1059,9 @@ def materialize_alldocs(context) -> int:
         # - https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.distinct
         #
         distinct_type_values = mdb[collection_name].distinct(key="type")
+        context.log.info(
+            f"Found {len(distinct_type_values)} distinct `type` values in {collection_name=}: {distinct_type_values=}"
+        )
         for type_value in distinct_type_values:
 
             # Process all the documents in this collection that have this value in their `type` field.

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1083,7 +1083,9 @@ def materialize_alldocs(context) -> int:
             representative_doc = next(docs_having_type, default=None)
 
             # Instantiate the Python class represented by the "representative" document.
-            db_dict = {collection_name: [dissoc(representative_doc, "_id")]}  # omits key incompatible with constructor
+            db_dict = {
+                collection_name: [dissoc(representative_doc, "_id")]
+            }  # omits key incompatible with constructor
             nmdc_db = NMDCDatabase(**db_dict)
             representative_instance = getattr(nmdc_db, collection_name)[0]
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1105,8 +1105,8 @@ def materialize_alldocs(context) -> int:
                 ]
             )
             context.log.info(
-                f"Inserted {len(inserted_many_result.inserted_ids)} documents originally having {type_value=} "
-                f"in {collection_name=}."
+                f"Inserted {len(inserted_many_result.inserted_ids)} documents from {collection_name=} "
+                f"originally having {type_value=}."
             )
 
     # Re-idx for `alldocs` collection


### PR DESCRIPTION
# Description

Fixed a bug in the code that was being used to generate the alldocs collection.

Options:
- See first commit (ea17ec3) for the not optimized algorithm that @PeopleMakeCulture, @sujaypatil96, and @eecavanna discussed in real time on Thursday.
- See second commit (1c5788d) for an optimized algorithm that @eecavanna thought of later and did not run by @PeopleMakeCulture or @sujaypatil96. Y'all can revert to the first commit if you want.

The bug in the original code was that a single document in each collection was being used to get the class ancestry of _every_ document in that collection. This could produce incorrect class ancestries when dealing with a database that conforms to the Berkeley schema, since a collection can store documents of differing types.

In the first commit, we changed it to determine the class ancestry document-by-document. I never ran this on Dagster, but I assume it would have taken about 10 minutes (or a few hours, if including the `functional_annotation_agg` collection).

In the second commit, we changed it to be more like the original code, where we are using `insert_many` (instead of `insert_one` as in the first commit). Unlike in the original code, we do not assume all documents in a collection have the same class ancestry; however, we do take advantage of the fact that documents having the same `type` value will have the same class ancestry. This allows us to process them in batches.

Fixes #690

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [ ] It has not been tested yet

**Configuration Details**: none

# Definition of Done (DoD) Checklist:
A simple checklist of necessary activities that add verifiable/demonstrable value to the product by asserting the quality of a feature, not the functionality of that feature; the latter should be stated as acceptance criteria in the issue this PR closes. Not all activities in the PR template will be applicable to each feature since the definition of done is intended to be a comprehensive checklist. Consciously decide the applicability of value-added activities on a feature-by-feature basis.

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
