### PR TITLE
Configure `pytest` GHA workflow so developers can trigger it manually

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,6 +19,9 @@ on:
       - '**.Dockerfile'
       - '**.py'
       - 'requirements/main.txt'
+  # Allow developers to trigger this workflow manually via the "Actions" page on GitHub.
+  # Reference: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch: { }
 
 
 jobs:


### PR DESCRIPTION
In this branch, I configured the GitHub Actions (GHA) workflow that runs `pytest`, so that developers will be able to trigger (i.e. run) it manually (i.e. by clicking a button in the GitHub web GUI). Developers will be able to do that on _any_ branch of this repo; once this configuration exists in the `main` branch, specifically.

> [!IMPORTANT]  
> The base branch of this PR is frozen. I want to make an exception for this PR. It does not affect the behavior of the Runtime application in any way and it has no implications for things downstream of the Runtime. It only enables a new option within the "Actions" tab of this repository on GitHub.