### PR TITLE
Fix bug where one document in each collection is omitted from `alldocs`

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1105,7 +1105,7 @@ def materialize_alldocs(context) -> int:
             # Note: The reason we `chain()` our "representative" document (in an iterable) with the `docs_having_type`
             #       iterator here is that, when we called `next(docs_having_type)` above, we "consumed" our
             #       "representative" document from that iterator. We use `chain()` here so that it gets processed
-            #       along with its cousins (i.e. the other documents accessible via `docs_having_type`).
+            #       along with its cousins (i.e. the documents still accessible via `docs_having_type`).
             #       Reference: https://docs.python.org/3/library/itertools.html#itertools.chain
             #
             inserted_many_result = mdb.alldocs.insert_many(

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1104,8 +1104,8 @@ def materialize_alldocs(context) -> int:
             #
             # Note: The reason we `chain()` our "representative" document (in an iterable) with the `docs_having_type`
             #       iterator here is that, when we called `next(docs_having_type)` above, we "consumed" our
-            #       "representative" document from that iterator. We use `chain()` here so that it gets processed
-            #       along with its cousins (i.e. the documents still accessible via `docs_having_type`).
+            #       "representative" document from that iterator. We use `chain()` here so that that document gets
+            #       inserted alongside its cousins (i.e. the documents _still_ accessible via `docs_having_type`).
             #       Reference: https://docs.python.org/3/library/itertools.html#itertools.chain
             #
             inserted_many_result = mdb.alldocs.insert_many(


### PR DESCRIPTION
In this branch, I fixed a bug in the function that generates the `alldocs` collection. The bug was causing the `alldocs` collection to lack one document from each upstream collection.

This fixes the `E` failures that pytest recently began reporting on the `berkeley` branch (their absence is shown here).

![image](https://github.com/user-attachments/assets/c32e0593-5f02-47b0-853e-8298c81d4e20)

