### PR TITLE
Update `nmdc-schema` package to `11.0.1` and synchronize transitive dependencies

### DIFF
--- a/demo/metadata_migration/notebooks/migrate_11_0_0_to_11_0_1.ipynb
+++ b/demo/metadata_migration/notebooks/migrate_11_0_0_to_11_0_1.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "# Migrate MongoDB database from `nmdc-schema` `v11.0.0` to `v11.0.1`",
+   "id": "d05efc6327778f9c"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "There are no migrators associated with any schema changes between schema versions `v11.0.0` and `v11.0.1`. So, this notebook is a \"no op\" (i.e. \"no operation\").",
+   "id": "b99d5924e825b9a2"
+  },
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "is_executing": true
+    }
+   },
+   "source": "# no op",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -25,7 +25,7 @@ mkdocs-jupyter
 mkdocs-material
 mkdocs-mermaid2-plugin
 motor
-nmdc-schema==11.0.0
+nmdc-schema==11.0.1
 openpyxl
 pandas
 passlib[bcrypt]

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -108,7 +108,7 @@ croniter==3.0.3
     # via dagster
 cryptography==43.0.1
     # via python-jose
-curies==0.7.10
+curies==0.8.0
     # via
     #   linkml-runtime
     #   prefixmaps
@@ -298,7 +298,7 @@ jsonschema==4.23.0
     #   linkml
     #   linkml-runtime
     #   nbformat
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 jupyter==1.1.1
     # via -r requirements/main.in
@@ -376,7 +376,7 @@ markdown-it-py==3.0.0
     #   jupytext
     #   mdit-py-plugins
     #   rich
-markupsafe==3.0.0
+markupsafe==3.0.1
     # via
     #   jinja2
     #   mako
@@ -441,7 +441,7 @@ nbformat==5.10.4
     #   nbconvert
 nest-asyncio==1.6.0
     # via ipykernel
-nmdc-schema==11.0.0
+nmdc-schema==11.0.1
     # via -r requirements/main.in
 notebook==7.2.2
     # via jupyter
@@ -508,6 +508,8 @@ prompt-toolkit==3.0.48
     # via
     #   ipython
     #   jupyter-console
+propcache==0.2.0
+    # via yarl
 protobuf==4.25.5
     # via
     #   dagster
@@ -861,7 +863,7 @@ xlrd==2.0.1
     # via -r requirements/main.in
 xlsxwriter==3.2.0
     # via -r requirements/main.in
-yarl==1.13.1
+yarl==1.14.0
     # via gql
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# Description

In this branch, I updated the `nmdc-schema` package to `11.0.1` and synchronized transitive dependencies. I also added a "no op" migration notebook for the jump from 11.0.0 to 11.0.1.

Fixes #720

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `$ make test-build && make test-run`

# Definition of Done (DoD) Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


