### PR TITLE
NCBI XML Export pipeline migration

### DIFF
--- a/nmdc_runtime/site/export/ncbi_xml_utils.py
+++ b/nmdc_runtime/site/export/ncbi_xml_utils.py
@@ -58,7 +58,7 @@ def fetch_data_objects_from_biosamples(all_docs_collection, biosamples_list):
     return biosample_data_objects
 
 
-def fetch_omics_processing_from_biosamples(all_docs_collection, biosamples_list):
+def fetch_nucleotide_sequencing_from_biosamples(all_docs_collection, biosamples_list):
     biosample_data_objects = []
 
     for biosample in biosamples_list:
@@ -80,11 +80,11 @@ def fetch_omics_processing_from_biosamples(all_docs_collection, biosamples_list)
 
                 for output_id in has_output:
                     if get_classname_from_typecode(output_id) == "DataObject":
-                        omics_processing_doc = all_docs_collection.find_one(
+                        nucleotide_sequencing_doc = all_docs_collection.find_one(
                             {"id": document["id"]}
                         )
-                        if omics_processing_doc:
-                            collected_data_objects.append(omics_processing_doc)
+                        if nucleotide_sequencing_doc:
+                            collected_data_objects.append(nucleotide_sequencing_doc)
                     else:
                         new_current_ids.append(output_id)
 
@@ -117,7 +117,7 @@ def fetch_library_preparation_from_biosamples(all_docs_collection, biosamples_li
         for output_id in initial_output:
             lib_prep_query = {
                 "has_input": output_id,
-                "designated_class": "nmdc:LibraryPreparation",
+                "type": {"$in": ["LibraryPreparation"]},
             }
             lib_prep_doc = all_docs_collection.find_one(lib_prep_query)
 

--- a/nmdc_runtime/site/export/study_metadata.py
+++ b/nmdc_runtime/site/export/study_metadata.py
@@ -133,5 +133,7 @@ def export_study_biosamples_metadata():
 @op(required_resource_keys={"runtime_api_site_client"})
 def get_biosamples_by_study_id(context: OpExecutionContext, nmdc_study: dict):
     client: RuntimeApiSiteClient = context.resources.runtime_api_site_client
-    biosamples = get_all_docs(client, "biosamples", f"part_of:{nmdc_study['id']}")
+    biosamples = get_all_docs(
+        client, "biosamples", f"associated_studies:{nmdc_study['id']}"
+    )
     return biosamples

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -51,7 +51,7 @@ from nmdc_runtime.site.ops import (
     materialize_alldocs,
     get_ncbi_export_pipeline_study,
     get_data_objects_from_biosamples,
-    get_omics_processing_from_biosamples,
+    get_nucleotide_sequencing_from_biosamples,
     get_library_preparation_from_biosamples,
     get_ncbi_export_pipeline_inputs,
     ncbi_submission_xml_from_nmdc_study,
@@ -444,14 +444,16 @@ def nmdc_study_to_ncbi_submission_export():
     nmdc_study = get_ncbi_export_pipeline_study()
     ncbi_submission_metadata = get_ncbi_export_pipeline_inputs()
     biosamples = get_biosamples_by_study_id(nmdc_study)
-    omics_processing_records = get_omics_processing_from_biosamples(biosamples)
+    nucleotide_sequencing_records = get_nucleotide_sequencing_from_biosamples(
+        biosamples
+    )
     data_object_records = get_data_objects_from_biosamples(biosamples)
     library_preparation_records = get_library_preparation_from_biosamples(biosamples)
     xml_data = ncbi_submission_xml_from_nmdc_study(
         nmdc_study,
         ncbi_submission_metadata,
         biosamples,
-        omics_processing_records,
+        nucleotide_sequencing_records,
         data_object_records,
         library_preparation_records,
     )

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -66,7 +66,7 @@ from nmdc_runtime.api.models.util import ResultT
 from nmdc_runtime.site.export.ncbi_xml import NCBISubmissionXML
 from nmdc_runtime.site.export.ncbi_xml_utils import (
     fetch_data_objects_from_biosamples,
-    fetch_omics_processing_from_biosamples,
+    fetch_nucleotide_sequencing_from_biosamples,
     fetch_library_preparation_from_biosamples,
 )
 from nmdc_runtime.site.drsobjects.ingest import mongo_add_docs_result_as_dict
@@ -1197,10 +1197,12 @@ def get_data_objects_from_biosamples(context: OpExecutionContext, biosamples: li
 
 
 @op(required_resource_keys={"mongo"})
-def get_omics_processing_from_biosamples(context: OpExecutionContext, biosamples: list):
+def get_nucleotide_sequencing_from_biosamples(
+    context: OpExecutionContext, biosamples: list
+):
     mdb = context.resources.mongo.db
     alldocs_collection = mdb["alldocs"]
-    biosample_omics_processing = fetch_omics_processing_from_biosamples(
+    biosample_omics_processing = fetch_nucleotide_sequencing_from_biosamples(
         alldocs_collection, biosamples
     )
     return biosample_omics_processing


### PR DESCRIPTION
# Description

This PR "migrates" the NCBI XML Export pipeline to be conformant with the newly released berkeley schema (nmdc-schema==v11.0.0). It also updates the corresponding tests.

Fixes #721 #630 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [x] tests in `tests/test_data/test_ncbi_xml.py`

# Definition of Done (DoD) Checklist:
A simple checklist of necessary activities that add verifiable/demonstrable value to the product by asserting the quality of a feature, not the functionality of that feature; the latter should be stated as acceptance criteria in the issue this PR closes. Not all activities in the PR template will be applicable to each feature since the definition of done is intended to be a comprehensive checklist. Consciously decide the applicability of value-added activities on a feature-by-feature basis.

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (in `docs/` and in <https://github.com/microbiomedata/NMDC_documentation/>?)
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


