### PR TITLE
Web docs index page missing translators/exporter tutorials

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ nav:
     - tutorials/auth.md
     - tutorials/json.md
     - tutorials/metadata-in.md
+    - tutorials/translators.md
+    - tutorials/exporters.md
   - How-to guides:
     - howto-guides/author-changesheets.md
     - howto-guides/create-triggers.md


### PR DESCRIPTION
The index page on our web docs currently doesn't show the documentation pages made for translators and exporters in PR #729 

Merge this PR for them to be made visible/accessible through the index page.