### PR TITLE
Document the `/nmdcschema/typecodes` API endpoint (reverse engineered)

### DIFF
--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -59,7 +59,7 @@ def get_nmdc_schema_typecodes() -> List[Dict[str, str]]:
     Each object has three properties:
     - `id`: a string that consists of "nmdc:" + the class name + "_typecode"
     - `schema_class`: a string that consists of "nmdc:" + the class name
-    - `name` the typecode the minter would use when minting an ID for an instance of that class
+    - `name`: the typecode the minter would use when minting an ID for an instance of that class
     """
     return typecodes()
 

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 import re
+from typing import List, Dict
 
 import pymongo
 from fastapi import APIRouter, Depends, HTTPException
@@ -50,7 +51,16 @@ def get_nmdc_schema_version():
 
 
 @router.get("/nmdcschema/typecodes")
-def get_nmdc_schema_typecodes():
+def get_nmdc_schema_typecodes() -> List[Dict[str, str]]:
+    r"""
+    Returns a list of objects, each of which indicates (a) a schema class, and (b) the typecode
+    that the minter would use when generating a new ID for an instance of that schema class.
+
+    Each object has three properties:
+    - `id`: a string that consists of "nmdc:" + the class name + "_typecode"
+    - `schema_class`: a string that consists of "nmdc:" + the class name
+    - `name` the typecode the minter would use when minting an ID for an instance of that class
+    """
     return typecodes()
 
 


### PR DESCRIPTION
In this branch, I added some documentation to an API endpoint that lacked it. The API endpoint was introduced via https://github.com/microbiomedata/nmdc-runtime/pull/386 (to resolve issue https://github.com/microbiomedata/nmdc-runtime/issues/385).

Fixes #747 

## Type of change

- [x] Added missing documentation

# How Has This Been Tested?

- I read it back to myself and it made sense to me

**Configuration Details**: none

# Definition of Done (DoD) Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas