### PR TITLE
fix: check for LinkML base type "Decimal" on loading changesheet

### DIFF
--- a/demo/metadata_migration/notebooks/helpers.py
+++ b/demo/metadata_migration/notebooks/helpers.py
@@ -32,11 +32,13 @@ class Config:
         # If the server uses authentication, include authentication-related CLI options.
         server_uses_authentication: bool = mongo_username not in ["", None]
         if server_uses_authentication:
-            base_options.extend([
-                f"--username='{mongo_username}'",
-                f"--password='{mongo_password}'",
-                f"--authenticationDatabase='admin'",
-            ])
+            base_options.extend(
+                [
+                    f"--username='{mongo_username}'",
+                    f"--password='{mongo_password}'",
+                    f"--authenticationDatabase='admin'",
+                ]
+            )
 
         return " ".join(base_options)
 
@@ -54,7 +56,9 @@ class Config:
 
         # Validate the dump folder paths.
         origin_dump_folder_path = notebook_config["PATH_TO_ORIGIN_MONGO_DUMP_FOLDER"]
-        transformer_dump_folder_path = notebook_config["PATH_TO_TRANSFORMER_MONGO_DUMP_FOLDER"]
+        transformer_dump_folder_path = notebook_config[
+            "PATH_TO_TRANSFORMER_MONGO_DUMP_FOLDER"
+        ]
         if not Path(origin_dump_folder_path).parent.is_dir():
             raise FileNotFoundError(
                 f"Parent folder of {origin_dump_folder_path} (origin Mongo dump folder path) not found."
@@ -71,7 +75,9 @@ class Config:
         if not Path(mongodump_path).is_file():
             raise FileNotFoundError(f"mongodump binary not found at: {mongodump_path}")
         if not Path(mongorestore_path).is_file():
-            raise FileNotFoundError(f"mongorestore binary not found at: {mongorestore_path}")
+            raise FileNotFoundError(
+                f"mongorestore binary not found at: {mongorestore_path}"
+            )
         if not Path(mongosh_path).is_file():
             raise FileNotFoundError(f"mongosh binary not found at: {mongosh_path}")
 
@@ -85,21 +91,27 @@ class Config:
         transformer_mongo_port = notebook_config["TRANSFORMER_MONGO_PORT"]
         transformer_mongo_username = notebook_config["TRANSFORMER_MONGO_USERNAME"]
         transformer_mongo_password = notebook_config["TRANSFORMER_MONGO_PASSWORD"]
-        transformer_mongo_database_name = notebook_config["TRANSFORMER_MONGO_DATABASE_NAME"]
+        transformer_mongo_database_name = notebook_config[
+            "TRANSFORMER_MONGO_DATABASE_NAME"
+        ]
 
         # Validate the database names.
         if origin_mongo_database_name.strip() == "":
             raise ValueError(f"Origin database name cannot be empty")
         if transformer_mongo_database_name.strip() == "":
             raise ValueError(f"Transformer database name cannot be empty")
-        if all([
-            origin_mongo_host == transformer_mongo_host,
-            origin_mongo_port == transformer_mongo_port,
-            origin_mongo_database_name == transformer_mongo_database_name,
-        ]):
+        if all(
+            [
+                origin_mongo_host == transformer_mongo_host,
+                origin_mongo_port == transformer_mongo_port,
+                origin_mongo_database_name == transformer_mongo_database_name,
+            ]
+        ):
             # Note: We don't allow the use of the origin database as the transformer,
             #       because that would prevent us from easily aborting the migration.
-            raise ValueError(f"The origin and transformer cannot both be the same database")
+            raise ValueError(
+                f"The origin and transformer cannot both be the same database"
+            )
 
         return dict(
             origin_dump_folder_path=origin_dump_folder_path,
@@ -121,12 +133,16 @@ class Config:
 
     def __init__(self, notebook_config_file_path: str = "./.notebook.env") -> None:
         # Parse and validate the notebook config file.
-        notebook_config = self.parse_and_validate_notebook_config_file(notebook_config_file_path)
+        notebook_config = self.parse_and_validate_notebook_config_file(
+            notebook_config_file_path
+        )
         self.mongodump_path = notebook_config["mongodump_path"]
         self.mongorestore_path = notebook_config["mongorestore_path"]
         self.mongosh_path = notebook_config["mongosh_path"]
         self.origin_dump_folder_path = notebook_config["origin_dump_folder_path"]
-        self.transformer_dump_folder_path = notebook_config["transformer_dump_folder_path"]
+        self.transformer_dump_folder_path = notebook_config[
+            "transformer_dump_folder_path"
+        ]
 
         # Parse the Mongo connection parameters.
         self.origin_mongo_host = notebook_config["origin_mongo_host"]
@@ -138,7 +154,9 @@ class Config:
         self.transformer_mongo_port = notebook_config["transformer_mongo_port"]
         self.transformer_mongo_username = notebook_config["transformer_mongo_username"]
         self.transformer_mongo_password = notebook_config["transformer_mongo_password"]
-        self.transformer_mongo_database_name = notebook_config["transformer_mongo_database_name"]
+        self.transformer_mongo_database_name = notebook_config[
+            "transformer_mongo_database_name"
+        ]
 
 
 def setup_logger(
@@ -197,7 +215,9 @@ def get_collection_names_from_schema(schema_view: SchemaView) -> List[str]:
 
 
 @cache  # memoizes the decorated function
-def translate_class_uri_into_schema_class_name(schema_view: SchemaView, class_uri: str) -> Optional[str]:
+def translate_class_uri_into_schema_class_name(
+    schema_view: SchemaView, class_uri: str
+) -> Optional[str]:
     r"""
     Returns the name of the schema class that has the specified value as its `class_uri`.
 
@@ -219,7 +239,9 @@ def translate_class_uri_into_schema_class_name(schema_view: SchemaView, class_ur
     return schema_class_name
 
 
-def derive_schema_class_name_from_document(schema_view: SchemaView, document: dict) -> Optional[str]:
+def derive_schema_class_name_from_document(
+    schema_view: SchemaView, document: dict
+) -> Optional[str]:
     r"""
     Returns the name of the schema class, if any, of which the specified document claims to represent an instance.
 
@@ -233,5 +255,7 @@ def derive_schema_class_name_from_document(schema_view: SchemaView, document: di
     schema_class_name = None
     if "type" in document and isinstance(document["type"], str):
         class_uri = document["type"]
-        schema_class_name = translate_class_uri_into_schema_class_name(schema_view, class_uri)
+        schema_class_name = translate_class_uri_into_schema_class_name(
+            schema_view, class_uri
+        )
     return schema_class_name

--- a/demo/metadata_migration/notebooks/test_helpers.py
+++ b/demo/metadata_migration/notebooks/test_helpers.py
@@ -26,9 +26,12 @@ class TestConfig(unittest.TestCase):
             mongo_username="alice",
             mongo_password="shhh",
         )
-        assert s == f"""
+        assert (
+            s
+            == f"""
             --host='thehost' --port='12345' --username='alice' --password='shhh' --authenticationDatabase='admin'
         """.strip()
+        )
 
         # Case 2: Input username is empty string.
         s = Config.make_mongo_cli_base_options(
@@ -37,9 +40,12 @@ class TestConfig(unittest.TestCase):
             mongo_username="",
             mongo_password="shhh",
         )
-        assert s == f"""
+        assert (
+            s
+            == f"""
             --host='thehost' --port='12345'
         """.strip()
+        )
 
         # Case 2: Input username is `None`.
         s = Config.make_mongo_cli_base_options(
@@ -48,15 +54,20 @@ class TestConfig(unittest.TestCase):
             mongo_username=None,
             mongo_password="shhh",
         )
-        assert s == f"""
+        assert (
+            s
+            == f"""
             --host='thehost' --port='12345'
         """.strip()
+        )
 
     def test_init_method(self):
-        with (TempFile() as notebook_config_file,
-              TempFile() as mongodump_binary,
-              TempFile() as mongorestore_binary,
-              TempFile() as mongosh_binary):
+        with (
+            TempFile() as notebook_config_file,
+            TempFile() as mongodump_binary,
+            TempFile() as mongorestore_binary,
+            TempFile() as mongosh_binary,
+        ):
 
             # Create named temporary directories and get their paths.
             origin_dump_folder_path = mkdtemp()
@@ -120,7 +131,9 @@ class TestConfig(unittest.TestCase):
             assert cfg.transformer_mongo_port == transformer_mongo_port
             assert cfg.transformer_mongo_username == transformer_mongo_username
             assert cfg.transformer_mongo_password == transformer_mongo_password
-            assert cfg.transformer_mongo_database_name == transformer_mongo_database_name
+            assert (
+                cfg.transformer_mongo_database_name == transformer_mongo_database_name
+            )
 
             # Delete the temporary directories (i.e. clean up).
             shutil.rmtree(origin_dump_folder_path)

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -211,12 +211,11 @@ def load_changesheet(
         # by e.g. overriding `base` when `uri` is a "known" type (`xsd:decimal` in the case of DecimalDegree).
         try:
             base_type = view.induced_type(ranges.rsplit("|", maxsplit=1)[-1]).base
-            df.at[ix, "value"] = getattr(builtins, base_type)(value)
-        except AttributeError as e:
             if base_type == "Decimal":
                 # Note: Use of bson.decimal128.Decimal128 here would require changing JSON encoding/decoding.
                 # Choosing to use `float` to preserve existing (expected) behavior.
                 df.at[ix, "value"] = float(value)
+            df.at[ix, "value"] = getattr(builtins, base_type)(value)
         except:
             continue
     return df

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -212,6 +212,11 @@ def load_changesheet(
         try:
             base_type = view.induced_type(ranges.rsplit("|", maxsplit=1)[-1]).base
             df.at[ix, "value"] = getattr(builtins, base_type)(value)
+        except AttributeError as e:
+            if base_type == "Decimal":
+                # Note: Use of bson.decimal128.Decimal128 here would require changing JSON encoding/decoding.
+                # Choosing to use `float` to preserve existing (expected) behavior.
+                df.at[ix, "value"] = float(value)
         except:
             continue
     return df

--- a/tests/files/nmdc_bsm-11-0pyv7738.json
+++ b/tests/files/nmdc_bsm-11-0pyv7738.json
@@ -1,0 +1,53 @@
+{
+  "id": "nmdc:bsm-11-0pyv7738",
+  "name": "Lybrand_FT_01_W",
+  "description": "Lybrand NEON (EMSL 50267)",
+  "env_broad_scale": {
+    "has_raw_value": "ENVO:00000446",
+    "term": {
+      "id": "ENVO:00000446",
+      "type": "nmdc:OntologyClass"
+    },
+    "type": "nmdc:ControlledIdentifiedTermValue"
+  },
+  "env_local_scale": {
+    "has_raw_value": "ENVO:01000861",
+    "term": {
+      "id": "ENVO:01000861",
+      "type": "nmdc:OntologyClass"
+    },
+    "type": "nmdc:ControlledIdentifiedTermValue"
+  },
+  "env_medium": {
+    "has_raw_value": "ENVO:00001998",
+    "term": {
+      "id": "ENVO:00001998",
+      "name": "soil",
+      "type": "nmdc:OntologyClass"
+    },
+    "type": "nmdc:ControlledIdentifiedTermValue"
+  },
+  "type": "nmdc:Biosample",
+  "collection_date": {
+    "has_raw_value": "2015-03",
+    "type": "nmdc:TimestampValue"
+  },
+  "geo_loc_name": {
+    "has_raw_value": "USA: AK, North Slope",
+    "type": "nmdc:TextValue"
+  },
+  "lat_lon": {
+    "has_raw_value": "68.627175 -149.590514",
+    "latitude": 68.627175,
+    "longitude": -149.590514,
+    "type": "nmdc:GeolocationValue"
+  },
+  "sample_collection_site": "TOOL",
+  "biosample_categories": [
+    "NEON"
+  ],
+  "gold_biosample_identifiers": [],
+  "associated_studies": [
+    "nmdc:sty-11-db67n062"
+  ]
+}

--- a/tests/files/test_changesheet_decimal_value.tsv
+++ b/tests/files/test_changesheet_decimal_value.tsv
@@ -1,0 +1,5 @@
+comment	action	id	attribute	value
+add metadata to EMSL studies 50718 and 50267	update	nmdc:bsm-11-0pyv7738	depth.has_numeric_value	0.38
+add metadata to EMSL studies 50718 and 50267	update	nmdc:bsm-11-0pyv7738	depth.has_raw_value	0.38 m
+add metadata to EMSL studies 50718 and 50267	update	nmdc:bsm-11-0pyv7738	elev	719
+add metadata to EMSL studies 50718 and 50267	update	nmdc:bsm-11-0pyv7738	depth.type	nmdc:QuantityValue

--- a/tests/test_api/test_metadata.py
+++ b/tests/test_api/test_metadata.py
@@ -162,6 +162,7 @@ def test_update_01():
 def test_changesheet_array_item_nested_attributes():
     mdb = get_mongo(run_config_frozen__normal_env).db
     local_id = "sty-11-r2h77870"
+    remove_tmp_doc = False
     if mdb.study_set.find_one({"id": "nmdc:" + local_id}) is None:
         with open(
             REPO_ROOT_DIR.joinpath(
@@ -202,6 +203,7 @@ def test_changesheet_array_item_nested_attributes():
 def test_update_pi_websites():
     mdb = get_mongo(run_config_frozen__normal_env).db
     local_id = "sty-11-r2h77870"
+    remove_tmp_doc = False
     if mdb.study_set.find_one({"id": "nmdc:" + local_id}) is None:
         with open(
             REPO_ROOT_DIR.joinpath(

--- a/tests/test_api/test_metadata.py
+++ b/tests/test_api/test_metadata.py
@@ -59,6 +59,26 @@ def test_load_changesheet():
     if remove_tmp_doc:
         mdb.study_set.delete_one({"id": "nmdc:" + sty_local_id})
 
+
+def test_changesheet_update_slot_with_range_decimal():
+    mdb = get_mongo_db()
+    bsm_local_id = "bsm-11-0pyv7738"
+    remove_tmp_doc = False
+    if mdb.data_object_set.find_one({"id": "nmdc:" + bsm_local_id}) is None:
+        with open(
+            REPO_ROOT_DIR.joinpath("tests", "files", f"nmdc_{bsm_local_id}.json")
+        ) as f:
+            mdb.biosample_set.insert_one(json.load(f))
+            remove_tmp_doc = True
+    df = load_changesheet(
+        REPO_ROOT_DIR.joinpath("tests", "files", "test_changesheet_decimal_value.tsv"),
+        mdb,
+    )
+    _validate_changesheet(df, mdb)
+    if remove_tmp_doc:
+        mdb.biosample_set.delete_one({"id": "nmdc:" + bsm_local_id})
+
+
 def test_changesheet_update_slot_with_range_bytes():
     mdb = get_mongo_db()
     dobj_local_id = "dobj-11-000n1286"
@@ -144,7 +164,9 @@ def test_changesheet_array_item_nested_attributes():
     local_id = "sty-11-r2h77870"
     if mdb.study_set.find_one({"id": "nmdc:" + local_id}) is None:
         with open(
-            REPO_ROOT_DIR.joinpath("tests", "files", f"study_no_credit_associations.json")
+            REPO_ROOT_DIR.joinpath(
+                "tests", "files", f"study_no_credit_associations.json"
+            )
         ) as f:
             mdb.study_set.insert_one(json.load(f))
             remove_tmp_doc = True
@@ -182,7 +204,9 @@ def test_update_pi_websites():
     local_id = "sty-11-r2h77870"
     if mdb.study_set.find_one({"id": "nmdc:" + local_id}) is None:
         with open(
-            REPO_ROOT_DIR.joinpath("tests", "files", f"study_no_credit_associations.json")
+            REPO_ROOT_DIR.joinpath(
+                "tests", "files", f"study_no_credit_associations.json"
+            )
         ) as f:
             mdb.study_set.insert_one(json.load(f))
             remove_tmp_doc = True


### PR DESCRIPTION
# Description

Because "Decimal" is not a Python `builtins` type, and because (py)mongo does not natively json-encode decimal values, and furthermore because existing behavior assumes decimal values will be supplied as floats (as JSON does not support decimals), added case to coerce decimal-typed values to `float`, and left inline comment explaining decision and options for decimal support in future.

Fixes #613

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration, if it is not simply `make up-test && make test-run`.

- [x] test `test_changesheet_update_slot_with_range_decimal` with supporting files in `tests/files`

**Configuration Details**: none

# Definition of Done (DoD) Checklist:

- [x] My code follows the style guidelines of this project (have you run `black nmdc_runtime/`?)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works, incl. considering downstream usage (e.g. <https://github.com/microbiomedata/notebook_hackathons>) if applicable.
- [x] New and existing unit and functional tests pass locally with my changes (`make up-test && make test-run`)


