### PR TITLE
Fix handling of GOLD and JGI IDs in submission data translator

### DIFF
--- a/nmdc_runtime/site/translation/gold_translator.py
+++ b/nmdc_runtime/site/translation/gold_translator.py
@@ -108,7 +108,9 @@ class GoldStudyTranslator(Translator):
             for id in self._project_ids_by_biosample_id[gold_biosample_id]
         )
         return [
-            self._get_curie("biosample", project["ncbiBioSampleAccession"])
+            self._ensure_curie(
+                project["ncbiBioSampleAccession"], default_prefix="biosample"
+            )
             for project in biosample_projects
             if project["ncbiBioSampleAccession"]
         ]
@@ -471,7 +473,9 @@ class GoldStudyTranslator(Translator):
         """
         return nmdc.Study(
             description=gold_study.get("description"),
-            gold_study_identifiers=self._get_curie("gold", gold_study["studyGoldId"]),
+            gold_study_identifiers=self._ensure_curie(
+                gold_study["studyGoldId"], default_prefix="gold"
+            ),
             id=nmdc_study_id,
             name=gold_study.get("studyName"),
             principal_investigator=self._get_pi(gold_study),
@@ -522,7 +526,9 @@ class GoldStudyTranslator(Translator):
             env_local_scale=self._get_env_term_value(gold_biosample, "envoLocalScale"),
             env_medium=self._get_env_term_value(gold_biosample, "envoMedium"),
             geo_loc_name=self._get_text_value(gold_biosample, "geoLocation"),
-            gold_biosample_identifiers=self._get_curie("gold", gold_biosample_id),
+            gold_biosample_identifiers=self._ensure_curie(
+                gold_biosample_id, default_prefix="gold"
+            ),
             habitat=gold_biosample.get("habitat"),
             host_name=gold_biosample.get("hostName"),
             host_taxid=self._get_host_taxid(gold_biosample),
@@ -579,8 +585,8 @@ class GoldStudyTranslator(Translator):
         return nmdc.NucleotideSequencing(
             id=nmdc_nucleotide_sequencing_id,
             name=gold_project.get("projectName"),
-            gold_sequencing_project_identifiers=self._get_curie(
-                "gold", gold_project_id
+            gold_sequencing_project_identifiers=self._ensure_curie(
+                gold_project_id, default_prefix="gold"
             ),
             ncbi_project_name=gold_project.get("projectName"),
             type="nmdc:NucleotideSequencing",

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -189,7 +189,7 @@ class SubmissionPortalTranslator(Translator):
         if not gold_study_id:
             return None
 
-        return [self._get_curie("GOLD", gold_study_id)]
+        return [self._ensure_curie(gold_study_id, default_prefix="gold")]
 
     def _get_quantity_value(
         self, raw_value: Optional[str], unit: Optional[str] = None

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -191,6 +191,20 @@ class SubmissionPortalTranslator(Translator):
 
         return [self._ensure_curie(gold_study_id, default_prefix="gold")]
 
+    def _get_jgi_study_identifiers(
+        self, metadata_submission: JSON_OBJECT
+    ) -> Union[List[str], None]:
+        """Construct a JGI proposal CURIE from the multiomics from data
+
+        :param metadata_submission: submission portal entry
+        :return: JGI proposal CURIE
+        """
+        jgi_study_id = get_in(["multiOmicsForm", "JGIStudyId"], metadata_submission)
+        if not jgi_study_id:
+            return None
+
+        return [self._ensure_curie(jgi_study_id, default_prefix="jgi.proposal")]
+
     def _get_quantity_value(
         self, raw_value: Optional[str], unit: Optional[str] = None
     ) -> Union[nmdc.QuantityValue, None]:
@@ -410,9 +424,6 @@ class SubmissionPortalTranslator(Translator):
         :return: nmdc:Study object
         """
         return nmdc.Study(
-            alternative_identifiers=self._get_from(
-                metadata_submission, ["multiOmicsForm", "JGIStudyId"]
-            ),
             alternative_names=self._get_from(
                 metadata_submission, ["multiOmicsForm", "alternativeNames"]
             ),
@@ -435,6 +446,9 @@ class SubmissionPortalTranslator(Translator):
             id=nmdc_study_id,
             insdc_bioproject_identifiers=self._get_from(
                 metadata_submission, ["multiOmicsForm", "NCBIBioProjectId"]
+            ),
+            jgi_portal_study_identifiers=self._get_jgi_study_identifiers(
+                metadata_submission
             ),
             name=self._get_from(metadata_submission, ["studyForm", "studyName"]),
             notes=self._get_from(metadata_submission, ["studyForm", "notes"]),

--- a/nmdc_runtime/site/translation/translator.py
+++ b/nmdc_runtime/site/translation/translator.py
@@ -14,8 +14,15 @@ class Translator(ABC):
     def _index_by_id(self, collection, id):
         return {item[id]: item for item in collection}
 
-    def _get_curie(self, prefix: str, local: str) -> str:
-        return f"{prefix}:{local}"
+    @staticmethod
+    def _ensure_curie(identifier: str, *, default_prefix: str) -> str:
+        identifier_parts = identifier.split(":", 1)
+
+        # Don't add prefix if identifier is already a CURIE
+        if len(identifier_parts) == 2:
+            return identifier
+
+        return f"{default_prefix}:{identifier_parts[0]}"
 
     @abstractmethod
     def get_database(self) -> nmdc.Database:

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -168,7 +168,7 @@ def test_get_gold_study_identifiers():
     )
     assert gold_ids is not None
     assert len(gold_ids) == 1
-    assert gold_ids[0] == "GOLD:Gs000000"
+    assert gold_ids[0] == "gold:Gs000000"
 
     gold_ids = translator._get_gold_study_identifiers(
         {"multiOmicsForm": {"GOLDStudyId": ""}}

--- a/tests/test_data/test_submission_portal_translator_data.yaml
+++ b/tests/test_data/test_submission_portal_translator_data.yaml
@@ -83,8 +83,8 @@ input:
       multiOmicsForm:
         alternativeNames: []
         studyNumber: ''
-        GOLDStudyId: ''
-        JGIStudyId: ''
+        GOLDStudyId: 'Gs0123456'
+        JGIStudyId: '123456'
         NCBIBioProjectId: ''
         omicsProcessingTypes:
         - mg
@@ -991,6 +991,10 @@ output:
       - Principal Investigator
       - Funding acquisition
       type: nmdc:CreditAssociation
+    gold_study_identifiers:
+    - gold:Gs0123456
+    jgi_portal_study_identifiers:
+    - jgi.proposal:123456
 ---
 input:
   metadata_submission:

--- a/tests/test_data/test_translator.py
+++ b/tests/test_data/test_translator.py
@@ -1,0 +1,16 @@
+from nmdc_schema import nmdc
+
+from nmdc_runtime.site.translation.translator import Translator
+
+
+class TestTranslator(Translator):
+    def get_database(self) -> nmdc.Database:
+        pass
+
+
+def test_ensure_curie():
+    assert TestTranslator._ensure_curie("nmdc:bsm-11-z8x8p723", default_prefix="nmdc") == "nmdc:bsm-11-z8x8p723"
+
+    assert TestTranslator._ensure_curie("bsm-11-z8x8p723", default_prefix="nmdc") == "nmdc:bsm-11-z8x8p723"
+
+    assert TestTranslator._ensure_curie("gold:Gb0123456", default_prefix="nmdc") == "gold:Gb0123456"


### PR DESCRIPTION
These changes update the submission portal data translator to place the JGI proposal ID into the `jgi_portal_study_identifiers` slot on `Study`. Previously it was placing it in `alternative_identifiers`, which is all that was available when the translation code was originally written.

### Details

Additional minor changes:

* Previously the submission portal data translator was prepending the prefix `GOLD:` to GOLD study IDs. This has been updated to `gold:`.
* The `Translator._get_curie()` method has been renamed to `Translator._ensure_curie()`. The behavior and calling semantics have been changed a bit to clarify that it _will not_ add a prefix if the provided identifier already has one. See test cases in `tests/test_data/test_translator.py` for examples.
* `tests/test_data/test_submission_portal_translator_data.yaml` has been updated with GOLD and JGI IDs to exercise the updated code.

### Related issue(s)

These issues were uncovered while working on https://github.com/microbiomedata/issues/issues/888

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] MongoDB migrations
- [x] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

Added/updated automated tests

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
