### PR TITLE
Ensure basic validation occurs for updates via `POST /queries:run`

### DIFF
--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -11,7 +11,7 @@ from nmdc_runtime.api.db.mongo import (
     get_mongo_db,
     get_nonempty_nmdc_schema_collection_names,
 )
-from nmdc_runtime.api.endpoints.util import permitted, users_allowed
+from nmdc_runtime.api.endpoints.util import permitted, users_allowed, strip_oid
 from nmdc_runtime.api.models.query import (
     Query,
     QueryResponseOptions,
@@ -23,6 +23,7 @@ from nmdc_runtime.api.models.query import (
     UpdateCommand,
 )
 from nmdc_runtime.api.models.user import get_current_active_user, User
+from nmdc_runtime.util import OverlayDB, validate_json
 
 router = APIRouter()
 
@@ -165,6 +166,29 @@ def _run_query(query, mdb) -> CommandResponse:
             {"filter": up_statement.q, "limit": 0 if up_statement.multi else 1}
             for up_statement in query.cmd.updates
         ]
+        with OverlayDB(mdb) as odb:
+            odb.apply_updates(collection_name, query.cmd.updates)
+            _ids_to_check = set()
+            for spec in update_specs:
+                for doc in mdb[collection_name].find(
+                    filter=spec["filter"],
+                    limit=spec["limit"],
+                    projection={
+                        "_id": 1
+                    },  # unique `id` not guaranteed (see e.g. `functional_annotation_agg`)
+                ):
+                    _ids_to_check.add(doc["_id"])
+            docs_to_check = odb._top_db[collection_name].find(
+                {"_id": {"$in": _ids_to_check}}
+            )
+            rv = validate_json(
+                {collection_name: [strip_oid(d) for d in docs_to_check]}, mdb
+            )
+            if rv["result"] == "errors":
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Schema document(s) would be invalid after proposed update: {rv['detail']}",
+                )
         for spec in update_specs:
             docs = list(mdb[collection_name].find(**spec))
             if not docs:

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -169,9 +169,9 @@ def _run_query(query, mdb) -> CommandResponse:
         # Execute this "update" command on a temporary "overlay" database so we can
         # validate its outcome before executing it on the real database. If its outcome
         # is invalid, we will abort and raise an "HTTP 422" exception.
-        # 
+        #
         # TODO: Consider wrapping this entire "preview-then-apply" sequence within a
-        #       MongoDB transaction so as to avoid race conditions where the overlay 
+        #       MongoDB transaction so as to avoid race conditions where the overlay
         #       database at "preview" time does not reflect the state of the database
         #       at "apply" time. This will be necessary once the "preview" step
         #       accounts for referential integrity.

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -434,6 +434,7 @@ def test_find_planned_process_by_id(api_site_client):
 
 
 def test_queries_run_update(api_user_client):
+    """Submit a request to store data that does not comply with the schema."""
     mdb = get_mongo_db()
     allow_spec = {
         "username": api_user_client.username,
@@ -441,7 +442,6 @@ def test_queries_run_update(api_user_client):
     }
     mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
     with pytest.raises(requests.HTTPError):
-        # Submit a request to store data that does not comply with the schema.
         api_user_client.request(
             "POST",
             "/queries:run",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -441,6 +441,7 @@ def test_queries_run_update(api_user_client):
     }
     mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
     with pytest.raises(requests.HTTPError):
+        # Submit a request to store data that does not comply with the schema.
         api_user_client.request(
             "POST",
             "/queries:run",


### PR DESCRIPTION
In this branch, I updated `/queries:run` so that it performs equivalent validation to that of `/metadata/json:submit` for `update` queries.

### Related issue(s)

Fixes #774

### Related subsystem(s)

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)

`test_queries_run_update` automated test.

### Documentation

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
