### PR TITLE
Replace deprecated `utcnow()` calls with `now(timezone.utc)`

### DIFF
--- a/demo/metadata_migration/notebooks/bookkeeper.py
+++ b/demo/metadata_migration/notebooks/bookkeeper.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pymongo import MongoClient
 from nmdc_schema.migrators.migrator_base import MigratorBase
@@ -47,7 +47,7 @@ class Bookkeeper:
     @staticmethod
     def get_current_timestamp() -> str:
         r"""Returns an ISO 8601 timestamp (string) representing the current time in UTC."""
-        utc_now = datetime.utcnow()
+        utc_now = datetime.now(timezone.utc)
         iso_utc_now = utc_now.isoformat()
         return iso_utc_now  # e.g. "2024-02-21T04:31:03.115107"
 

--- a/nmdc_runtime/api/core/auth.py
+++ b/nmdc_runtime/api/core/auth.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict
 
 from fastapi import Depends
@@ -101,9 +101,9 @@ def get_password_hash(password):
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt


### PR DESCRIPTION
Fix to address deprecated datetime.utcnow() calls
