### PR TITLE
Simplify local mongorestore of remote mongodump

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,7 @@ ORCID_NMDC_CLIENT_SECRET=replaceme
 ORCID_BASE_URL=https://orcid.org
 
 INFO_BANNER_INNERHTML='Announcement: Something important is about to happen. If you have questions, please contact <a href="mailto:support@microbiomedata.org">support@microbiomedata.org</a>.'
+
+# To get the latest mongo dump directory, run e.g.
+# ssh -i ~/.ssh/nersc -q ${NERSC_USERNAME}@dtn01.nersc.gov 'bash -s ' < util/get_latest_nmdc_prod_dump_dir.sh 2>/dev/null
+MONGO_REMOTE_DUMP_DIR=/global/cfs/projectdirs/m3408/nmdc-mongodumps/dump_nmdc-prod_2024-11-26_20-12-40

--- a/Makefile
+++ b/Makefile
@@ -99,12 +99,18 @@ nersc-mongo-tunnels:
 
 mongorestore-nmdc-db:
 	mkdir -p /tmp/remote-mongodump/nmdc
-	# SSH into the remote server, stream the dump directory as a gzipped tar archive, and extract it locally.
-	ssh -i ~/.ssh/nersc ${NERSC_USERNAME}@dtn01.nersc.gov \
-		'tar -czf - -C /global/cfs/projectdirs/m3408/nmdc-mongodumps/dump_nmdc-prod_2024-11-25_20-12-02/nmdc .' \
-		| tar -xzv -C /tmp/remote-mongodump/nmdc
+	# Optionally, manually update MONGO_REMOTE_DUMP_DIR env var:
+	# ```bash
+	# export MONGO_REMOTE_DUMP_DIR=$(ssh -i ~/.ssh/nersc -q ${NERSC_USERNAME}@dtn01.nersc.gov 'bash -s ' < get_latest_nmdc_prod_dump_dir.sh 2>/dev/null)
+	# ```
+	# Rsync the remote dump directory items of interest:
+	rsync -av --exclude='_*' --exclude='fs\.*' \
+		-e "ssh -i ~/.ssh/nersc" \
+		${NERSC_USERNAME}@dtn01.nersc.gov:${MONGO_REMOTE_DUMP_DIR}/nmdc/ \
+		/tmp/remote-mongodump/nmdc
+	# Restore from `rsync`ed local directory:
 	mongorestore -v -h localhost:27018 -u admin -p root --authenticationDatabase=admin \
-		--drop --nsInclude='nmdc.*' --dir /tmp/remote-mongodump
+		--drop --nsInclude='nmdc.*' --gzip --dir /tmp/remote-mongodump
 
 quick-blade:
 	python -c "from nmdc_runtime.api.core.idgen import generate_id; print(f'nmdc:nt-11-{generate_id(length=8, split_every=0)}')"

--- a/util/get_latest_nmdc_prod_dump_dir.sh
+++ b/util/get_latest_nmdc_prod_dump_dir.sh
@@ -1,0 +1,2 @@
+ls -dlt /global/cfs/projectdirs/m3408/nmdc-mongodumps/dump_nmdc-prod_* | head -n 1 | awk -F' ' '{print $NF}'
+


### PR DESCRIPTION
In this branch, I update the `mongorestore-nmdc-db` `Makefile` target to not use streaming gzipping. I use `rsync` instead, which will also speed up re-runs. I Introduce the `MONGO_REMOTE_DUMP_DIR` environment variable, along with guidance in `.env.example` for updating it with the "latest" remote directory name (via a one-liner utility script `util/get_latest_nmdc_prod_dump_dir.sh`.


### Related issue(s)

Closes #800

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running

```bash
make nersc-sshproxy # ensures ssh identity file `~/.ssh/nersc`
export NERSC_USERNAME=dwinston
export MONGO_REMOTE_DUMP_DIR=$(ssh -i ~/.ssh/nersc -q ${NERSC_USERNAME}@dtn01.nersc.gov 'bash -s ' < util/get_latest_nmdc_prod_dump_dir.sh 2>/dev/null)
make mongorestore-nmdc-db
```

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

Documentation is inline (rather than in `docs` directory), and it was updated there.

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
