### PR TITLE
Update `/nmdcschema/{collection_name}` API endpoint description to include performance-related guidance

### DIFF
--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -116,10 +116,18 @@ def list_from_collection(
     mdb: MongoDatabase = Depends(get_mongo_db),
 ):
     """
-    The GET /nmdcschema/{collection_name} endpoint is a general purpose way to retrieve metadata about a specified
-    collection given user-provided filter and projection criteria. Please see the [Collection Names](https://microbiomedata.github.io/nmdc-schema/Database/)
-    that may be retrieved. Please note that metadata may only be retrieved about one collection at a time.
+    Returns resources that match the specified filter criteria, residing in the specified database collection.
+
+    The names of all the slots of the [`Database` class](https://microbiomedata.github.io/nmdc-schema/Database/)
+    in the NMDC Schema are valid collection names.
     """
+    # TODO: The note about collection names above is currently accurate, but will not necessarily be accurate, since the
+    #       `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`, which are
+    #       things our teammate says must be true about a `Database` slot for it to represent a MongoDB collection.
+    #
+    # TODO: Implement an API endpoint that returns all valid collection names (can get them via a `SchemaView`),
+    #       Then replace the note above with a suggestion that the user access that API endpoint.
+
     rv = list_resources(req, mdb, collection_name)
     rv["resources"] = [strip_oid(d) for d in rv["resources"]]
     return rv

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -130,9 +130,10 @@ def list_from_collection(
        the regex is a [prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use),
        That will allow MongoDB to optimize the way it uses the regex, making this API endpoint respond faster.
     """
-    # TODO: The note about collection names above is currently accurate, but will not necessarily be accurate, since the
-    #       `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`, which are
-    #       things our teammate says must be true about a `Database` slot for it to represent a MongoDB collection.
+    # TODO: The note about collection names above is currently accurate, but will not necessarily always be accurate,
+    #       since the `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`,
+    #       which are things NMDC Schema maintainers say a `Database` slot must be in order for it to represent
+    #       a MongoDB collection.
     #
     # TODO: Implement an API endpoint that returns all valid collection names (can get them via a `SchemaView`),
     #       Then replace the note above with a suggestion that the user access that API endpoint.

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -116,19 +116,18 @@ def list_from_collection(
     mdb: MongoDatabase = Depends(get_mongo_db),
 ):
     """
-    Returns resources that match the specified filter criteria, residing in the specified database collection.
+    Returns resources that match the specified filter criteria and reside in the specified collection.
 
-    The names of all the slots of the [`Database` class](https://microbiomedata.github.io/nmdc-schema/Database/)
-    in the NMDC Schema are valid collection names.
+    You can get all the valid collection names from the [`Database` class](https://microbiomedata.github.io/nmdc-schema/Database/)
+    page of the NMDC Schema documentation.
 
-    Note: If the maximum page size is set to a non-zero number and _more than that number_ of resources match the filter
-          criteria, this endpoint will paginate the resources. When the specified collection contains many documents,
-          the pagination process can take a long time—even longer than if no maximum page size were specified at all.
+    Note: If the specified maximum page size is a non-zero number and the specified collection contains _more than that
+          number_ of resources that match the filter criteria, this endpoint will paginate the resources. Pagination
+          can take a long time—especially for collections having many documents.
 
     **Tips:**
-    1. When the filter includes a regex you are using to match strings that have a given prefix,
-       use a regex that is a so-called "[prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use)."
-       All "prefix expressions" begin with either a caret (`^`) or a left anchor (`\A`).
+    1. When the filter includes a regex and you are using that regex to match the beginning of a string, try to use a
+       regex that is a "[prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use)."
     """
     # TODO: The note about collection names above is currently accurate, but will not necessarily be accurate, since the
     #       `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`, which are

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -121,13 +121,14 @@ def list_from_collection(
     You can get all the valid collection names from the [Database class](https://microbiomedata.github.io/nmdc-schema/Database/)
     page of the NMDC Schema documentation.
 
-    Note: If the specified maximum page size is a non-zero number and the specified collection contains _more than that
-          number_ of resources that match the filter criteria, this endpoint will paginate the resources. Pagination
-          can take a long time—especially for collections having many documents.
+    Note: If the specified maximum page size is a number greater than zero, and _more than that number of resources_
+          in the collection match the filter criteria, this endpoint will paginate the resources. Pagination can take
+          a long time—especially for collections that contain a lot of documents (e.g. millions).
 
     **Tips:**
-    1. When the filter includes a regex and you are using that regex to match the beginning of a string, try to use a
-       regex that is a "[prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use)."
+    1. When the filter includes a regex and you're using that regex to match the beginning of a string, try to ensure
+       the regex is a [prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use),
+       That will allow MongoDB to optimize the way it uses the regex, making this API endpoint be faster.
     """
     # TODO: The note about collection names above is currently accurate, but will not necessarily be accurate, since the
     #       `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`, which are

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -128,7 +128,7 @@ def list_from_collection(
     **Tips:**
     1. When the filter includes a regex and you're using that regex to match the beginning of a string, try to ensure
        the regex is a [prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use),
-       That will allow MongoDB to optimize the way it uses the regex, making this API endpoint be faster.
+       That will allow MongoDB to optimize the way it uses the regex, making this API endpoint respond faster.
     """
     # TODO: The note about collection names above is currently accurate, but will not necessarily be accurate, since the
     #       `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`, which are

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -118,7 +118,7 @@ def list_from_collection(
     """
     Returns resources that match the specified filter criteria and reside in the specified collection.
 
-    You can get all the valid collection names from the [`Database` class](https://microbiomedata.github.io/nmdc-schema/Database/)
+    You can get all the valid collection names from the [Database class](https://microbiomedata.github.io/nmdc-schema/Database/)
     page of the NMDC Schema documentation.
 
     Note: If the specified maximum page size is a non-zero number and the specified collection contains _more than that

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -120,6 +120,15 @@ def list_from_collection(
 
     The names of all the slots of the [`Database` class](https://microbiomedata.github.io/nmdc-schema/Database/)
     in the NMDC Schema are valid collection names.
+
+    Note: If the maximum page size is set to a non-zero number and _more than that number_ of resources match the filter
+          criteria, this endpoint will paginate the resources. When the specified collection contains many documents,
+          the pagination process can take a long time—even longer than if no maximum page size were specified at all.
+
+    **Tips:**
+    1. When the filter includes a regex you are using to match strings that have a given prefix,
+       use a regex that is a so-called "[prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use)."
+       All "prefix expressions" begin with either a caret (`^`) or a left anchor (`\A`).
     """
     # TODO: The note about collection names above is currently accurate, but will not necessarily be accurate, since the
     #       `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`, which are

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -78,6 +78,15 @@ def check_filter(filter_: str):
 
 
 def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
+    r"""
+    Returns a dictionary containing the requested MongoDB documents, maybe alongside pagination information.
+
+    Note: If the specified `ListRequest` has a non-zero `max_page_size` number and the number of documents matching the
+          filter criteria is _larger_ than that number, this function will paginate the resources. Paginating the
+          resources currently involves MongoDB sorting _all_ matching documents, which can take a long time, especially
+          when the collection involved contains many documents.
+    """
+
     id_field = "id"
     if "id_1" not in mdb[collection_name].index_information():
         logging.warning(


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "In this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

In this branch, I updated documentation about an API endpoint and a helper function that it calls.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I updated user-facing documentation about an API endpoint in an attempt to help users avoid performance-related surprises and to more easily work around them if they do encounter them. This documentation gets displayed on Swagger UI.

I also updated some internal documentation (a docstring) related to a function called by that endpoint.

Finally, I added some `TODO` comments related to telling the user what all the valid collection names are. We currently send them to the schema docs for that. We could, instead, implement an API endpoint that returns a list. That would allow us to refrain from giving the nuanced answer of "It's the names of the slots of the `Database` class, as long as those slots are multivalued and inlined_as_list." The API endpoint we implement could check the latter conditions instead of making that the user's responsibility.

Props to @dwinston for bringing the MongoDB concept of a "prefix expression" to my attention.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Related to #797 

The reported performance issue still persists. This PR branch does not include a fix—just some user-facing guidance and internal documentation related to it.

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I spin up my local development environment, viewed the endpoint's updated documentation on Swagger UI (shown here), and confirmed it looked the way I expected.

![image](https://github.com/user-attachments/assets/ac367240-1eef-4634-b9f9-bfe6197291dc)

For comparison, here's what the documentation used to be:

![image](https://github.com/user-attachments/assets/a3746ae4-ec64-4395-a1c1-86910d4b4d9f)

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
