### PR TITLE
Display copy-paste HTTP Authorization header with Bearer token on Swagger UI for ORCiD-Authenticated user

### DIFF
--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -488,10 +488,7 @@ def custom_swagger_ui_html(
         onComplete += f"""
             ui.preauthorizeApiKey('bearerAuth', '{access_token}');
             token_info = document.createElement('section');
-            token_info.classList.add('nmdc-info');
-            token_info.classList.add('nmdc-info-token');
-            token_info.classList.add('block');
-            token_info.classList.add('col-12');
+            token_info.classList.add('nmdc-info', 'nmdc-info-token', 'block', 'col-12');
             token_info.innerHTML = <double-quote>
                 <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>
                 <p>
@@ -514,10 +511,7 @@ def custom_swagger_ui_html(
         info_banner_innerhtml = os.getenv("INFO_BANNER_INNERHTML")
         onComplete += f"""
             banner = document.createElement('section');
-            banner.classList.add('nmdc-info');
-            banner.classList.add('nmdc-info-banner');
-            banner.classList.add('block');
-            banner.classList.add('col-12');
+            banner.classList.add('nmdc-info', 'nmdc-info-banner', 'block', 'col-12');
             banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;
             document.querySelector('.information-container').prepend(banner);
         """.replace(

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -510,7 +510,9 @@ def custom_swagger_ui_html(
                 </p>
             </double-quote>;
             document.querySelector(<double-quote>.information-container</double-quote>).append(token_info);
-        """.replace("\n", " ")
+        """.replace(
+            "\n", " "
+        )
     if os.getenv("INFO_BANNER_INNERHTML"):
         info_banner_innerhtml = os.getenv("INFO_BANNER_INNERHTML")
         onComplete += f"""
@@ -521,7 +523,9 @@ def custom_swagger_ui_html(
             banner.classList.add(<double-quote>col-12</double-quote>);
             banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;
             document.querySelector(<double-quote>.information-container</double-quote>).prepend(banner);
-        """.replace("\n", " ")
+        """.replace(
+            "\n", " "
+        )
     if onComplete:
         # Note: The `nmdcInit` JavaScript event is a custom event we use to trigger anything that is listening for it.
         #       Reference: https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -571,7 +571,7 @@ def custom_swagger_ui_html(
             "</body>",
             f"""
                 <script>
-                    console.debug('Listening for event: nmdcInit');
+                    console.debug("Listening for event: nmdcInit");
                     window.addEventListener("nmdcInit", (event) => {{
                         // Get the DOM elements we'll be referencing below. 
                         const tokenMaskTogglerEl = document.getElementById("token-mask-toggler");

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -496,7 +496,7 @@ def custom_swagger_ui_html(
             token_info.classList.add(<double-quote>block</double-quote>);\
             token_info.classList.add(<double-quote>col-12</double-quote>);\
             token_info.innerHTML = <double-quote>\
-            <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>\
+                <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>\
                 <p>\
                     <code>\
                         <span>Authorization: Bearer </span>\

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -487,6 +487,8 @@ def custom_swagger_ui_html(
     if access_token is not None:
         onComplete += f"""
             ui.preauthorizeApiKey('bearerAuth', '{access_token}');
+            
+            // Build an HTML element tree representing a banner containing the user's token.
             token_info = document.createElement('section');
             token_info.classList.add('nmdc-info', 'nmdc-info-token', 'block', 'col-12');
             token_info.innerHTML = <double-quote>

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -485,43 +485,43 @@ def custom_swagger_ui_html(
     swagger_ui_parameters = {"withCredentials": True}
     onComplete = ""
     if access_token is not None:
-        onComplete += f"""\
-            ui.preauthorizeApiKey(\
-                <double-quote>bearerAuth</double-quote>,\
-                <double-quote>{access_token}</double-quote>\
-            );\
-            token_info = document.createElement(<double-quote>section</double-quote>);\
-            token_info.classList.add(<double-quote>nmdc-info</double-quote>);\
-            token_info.classList.add(<double-quote>nmdc-info-token</double-quote>);\
-            token_info.classList.add(<double-quote>block</double-quote>);\
-            token_info.classList.add(<double-quote>col-12</double-quote>);\
-            token_info.innerHTML = <double-quote>\
-                <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>\
-                <p>\
-                    <code>\
-                        <span>Authorization: Bearer </span>\
-                        <span id='token' data-token-value='{access_token}' data-state='masked'>***</span>\
-                    </code>\
-                </p>\
-                <p>\
-                    <button id='token-mask-toggler'>Show token</button>\
-                    <button id='token-copier'>Copy token</button>\
-                    <span id='token-copier-message'></span>\
-                </p>\
-            </double-quote>;\
-            document.querySelector(<double-quote>.information-container</double-quote>).append(token_info);\
-        """
+        onComplete += f"""
+            ui.preauthorizeApiKey(
+                <double-quote>bearerAuth</double-quote>,
+                <double-quote>{access_token}</double-quote>
+            );
+            token_info = document.createElement(<double-quote>section</double-quote>);
+            token_info.classList.add(<double-quote>nmdc-info</double-quote>);
+            token_info.classList.add(<double-quote>nmdc-info-token</double-quote>);
+            token_info.classList.add(<double-quote>block</double-quote>);
+            token_info.classList.add(<double-quote>col-12</double-quote>);
+            token_info.innerHTML = <double-quote>
+                <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>
+                <p>
+                    <code>
+                        <span>Authorization: Bearer </span>
+                        <span id='token' data-token-value='{access_token}' data-state='masked'>***</span>
+                    </code>
+                </p>
+                <p>
+                    <button id='token-mask-toggler'>Show token</button>
+                    <button id='token-copier'>Copy token</button>
+                    <span id='token-copier-message'></span>
+                </p>
+            </double-quote>;
+            document.querySelector(<double-quote>.information-container</double-quote>).append(token_info);
+        """.replace("\n", " ")
     if os.getenv("INFO_BANNER_INNERHTML"):
         info_banner_innerhtml = os.getenv("INFO_BANNER_INNERHTML")
-        onComplete += f"""\
-            banner = document.createElement(<double-quote>section</double-quote>);\
-            banner.classList.add(<double-quote>nmdc-info</double-quote>);\
-            banner.classList.add(<double-quote>nmdc-info-banner</double-quote>);\
-            banner.classList.add(<double-quote>block</double-quote>);\
-            banner.classList.add(<double-quote>col-12</double-quote>);\
-            banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;\
-            document.querySelector(<double-quote>.information-container</double-quote>).prepend(banner);\
-        """
+        onComplete += f"""
+            banner = document.createElement(<double-quote>section</double-quote>);
+            banner.classList.add(<double-quote>nmdc-info</double-quote>);
+            banner.classList.add(<double-quote>nmdc-info-banner</double-quote>);
+            banner.classList.add(<double-quote>block</double-quote>);
+            banner.classList.add(<double-quote>col-12</double-quote>);
+            banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;
+            document.querySelector(<double-quote>.information-container</double-quote>).prepend(banner);
+        """.replace("\n", " ")
     if onComplete:
         # Note: The `nmdcInit` JavaScript event is a custom event we use to trigger anything that is listening for it.
         #       Reference: https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -485,10 +485,33 @@ def custom_swagger_ui_html(
     swagger_ui_parameters = {"withCredentials": True}
     onComplete = ""
     if access_token is not None:
-        onComplete += f"""ui.preauthorizeApiKey(<double-quote>bearerAuth</double-quote>, <double-quote>{access_token}</double-quote>); """
+        onComplete += f"""\
+            ui.preauthorizeApiKey(\
+                <double-quote>bearerAuth</double-quote>,\
+                <double-quote>{access_token}</double-quote>\
+            );\
+            token_info = document.createElement(<double-quote>section</double-quote>);\
+            token_info.classList.add(<double-quote>nmdc-info</double-quote>);\
+            token_info.classList.add(<double-quote>nmdc-info-token</double-quote>);\
+            token_info.classList.add(<double-quote>block</double-quote>);\
+            token_info.classList.add(<double-quote>col-12</double-quote>);\
+            token_info.innerHTML = <double-quote>\
+            <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>\
+                <p><code>Authorization: Bearer {access_token}</code></p>\
+            </double-quote>;\
+            document.querySelector(<double-quote>.information-container</double-quote>).append(token_info);\
+        """
     if os.getenv("INFO_BANNER_INNERHTML"):
         info_banner_innerhtml = os.getenv("INFO_BANNER_INNERHTML")
-        onComplete += f"""banner = document.createElement(<double-quote>section</double-quote>); banner.classList.add(<double-quote>nmdc-info-banner</double-quote>); banner.classList.add(<double-quote>block</double-quote>); banner.classList.add(<double-quote>col-12</double-quote>); banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`; document.querySelector(<double-quote>.information-container</double-quote>).prepend(banner); """
+        onComplete += f"""\
+            banner = document.createElement(<double-quote>section</double-quote>);\
+            banner.classList.add(<double-quote>nmdc-info</double-quote>);\
+            banner.classList.add(<double-quote>nmdc-info-banner</double-quote>);\
+            banner.classList.add(<double-quote>block</double-quote>);\
+            banner.classList.add(<double-quote>col-12</double-quote>);\
+            banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;\
+            document.querySelector(<double-quote>.information-container</double-quote>).prepend(banner);\
+        """
     if onComplete:
         swagger_ui_parameters.update(
             {
@@ -512,7 +535,17 @@ def custom_swagger_ui_html(
         .replace("</double-quote>", '"')
         .replace(
             "</head>",
-            "<style>.nmdc-info-banner { padding: 1em; background-color: #448aff1a; border: .075rem solid #448aff; }</style></head>",
+            f"""<style>\
+                    .nmdc-info {{\
+                        padding: 1em;\
+                        background-color: #448aff1a;\
+                        border: .075rem solid #448aff;\
+                    }}\
+                    .nmdc-info-token code {{\
+                        font-size: x-small;\
+                    }}\
+                </style>\
+            </head>""",
         )
     )
     return HTMLResponse(content=content)

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -594,8 +594,7 @@ def custom_swagger_ui_html(
                         console.debug("Setting up token copier");
                         tokenCopierEl.addEventListener("click", async (event) => {{
                             tokenCopierMessageEl.innerHTML = "";
-                            try {{
-                                const tokenEl = document.getElementById("token");                            
+                            try {{                            
                                 await navigator.clipboard.writeText(tokenEl.dataset.tokenValue);
                                 tokenCopierMessageEl.innerHTML = "<span style='color: green;'>Copied to clipboard</span>";
                             }} catch (error) {{

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -556,6 +556,12 @@ def custom_swagger_ui_html(
                     .nmdc-info-token code {{
                         font-size: x-small;
                     }}
+                    .nmdc-success {{
+                        color: green;
+                    }}
+                    .nmdc-error {{
+                        color: red;
+                    }}
                 </style>
             </head>""",
         )
@@ -595,10 +601,10 @@ def custom_swagger_ui_html(
                             tokenCopierMessageEl.innerHTML = "";
                             try {{                            
                                 await navigator.clipboard.writeText(tokenEl.dataset.tokenValue);
-                                tokenCopierMessageEl.innerHTML = "<span style='color: green;'>Copied to clipboard</span>";
+                                tokenCopierMessageEl.innerHTML = "<span class='nmdc-success'>Copied to clipboard</span>";
                             }} catch (error) {{
                                 console.error(error.message);
-                                tokenCopierMessageEl.innerHTML = "<span style='color: red;'>Copying failed</span>";
+                                tokenCopierMessageEl.innerHTML = "<span class='nmdc-error'>Copying failed</span>";
                             }}
                         }})
                     }});

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -540,9 +540,11 @@ def custom_swagger_ui_html(
         .replace('</unquote-safe>"', "")
         .replace("<double-quote>", '"')
         .replace("</double-quote>", '"')
+        # Inject a style element immediately before the closing `</head>` tag.
         .replace(
             "</head>",
-            f"""<style>
+            f"""
+                <style>
                     .nmdc-info {{
                         padding: 1em;
                         background-color: #448aff1a;

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -606,7 +606,7 @@ def custom_swagger_ui_html(
                     }});
                 </script>
             </body>
-            """
+            """,
         )
     )
     return HTMLResponse(content=content)

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -486,15 +486,12 @@ def custom_swagger_ui_html(
     onComplete = ""
     if access_token is not None:
         onComplete += f"""
-            ui.preauthorizeApiKey(
-                <double-quote>bearerAuth</double-quote>,
-                <double-quote>{access_token}</double-quote>
-            );
-            token_info = document.createElement(<double-quote>section</double-quote>);
-            token_info.classList.add(<double-quote>nmdc-info</double-quote>);
-            token_info.classList.add(<double-quote>nmdc-info-token</double-quote>);
-            token_info.classList.add(<double-quote>block</double-quote>);
-            token_info.classList.add(<double-quote>col-12</double-quote>);
+            ui.preauthorizeApiKey('bearerAuth', '{access_token}');
+            token_info = document.createElement('section');
+            token_info.classList.add('nmdc-info');
+            token_info.classList.add('nmdc-info-token');
+            token_info.classList.add('block');
+            token_info.classList.add('col-12');
             token_info.innerHTML = <double-quote>
                 <p>You are now authorized. Prefer a command-line interface (CLI)? Use this header for HTTP requests:</p>
                 <p>
@@ -509,20 +506,20 @@ def custom_swagger_ui_html(
                     <span id='token-copier-message'></span>
                 </p>
             </double-quote>;
-            document.querySelector(<double-quote>.information-container</double-quote>).append(token_info);
+            document.querySelector('.information-container').append(token_info);
         """.replace(
             "\n", " "
         )
     if os.getenv("INFO_BANNER_INNERHTML"):
         info_banner_innerhtml = os.getenv("INFO_BANNER_INNERHTML")
         onComplete += f"""
-            banner = document.createElement(<double-quote>section</double-quote>);
-            banner.classList.add(<double-quote>nmdc-info</double-quote>);
-            banner.classList.add(<double-quote>nmdc-info-banner</double-quote>);
-            banner.classList.add(<double-quote>block</double-quote>);
-            banner.classList.add(<double-quote>col-12</double-quote>);
+            banner = document.createElement('section');
+            banner.classList.add('nmdc-info');
+            banner.classList.add('nmdc-info-banner');
+            banner.classList.add('block');
+            banner.classList.add('col-12');
             banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;
-            document.querySelector(<double-quote>.information-container</double-quote>).prepend(banner);
+            document.querySelector('.information-container').prepend(banner);
         """.replace(
             "\n", " "
         )

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -560,7 +560,7 @@ def custom_swagger_ui_html(
                 </style>\
             </head>""",
         )
-        # Inject a JavaScript script before the closing `<body>` tag.
+        # Inject a JavaScript script immediately before the closing `</body>` tag.
         .replace(
             "</body>",
             f"""

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -545,19 +545,18 @@ def custom_swagger_ui_html(
         .replace('</unquote-safe>"', "")
         .replace("<double-quote>", '"')
         .replace("</double-quote>", '"')
-        # TODO: Remove unnecessary trailing backslashes.
         .replace(
             "</head>",
-            f"""<style>\
-                    .nmdc-info {{\
-                        padding: 1em;\
-                        background-color: #448aff1a;\
-                        border: .075rem solid #448aff;\
-                    }}\
-                    .nmdc-info-token code {{\
-                        font-size: x-small;\
-                    }}\
-                </style>\
+            f"""<style>
+                    .nmdc-info {{
+                        padding: 1em;
+                        background-color: #448aff1a;
+                        border: .075rem solid #448aff;
+                    }}
+                    .nmdc-info-token code {{
+                        font-size: x-small;
+                    }}
+                </style>
             </head>""",
         )
         # Inject a JavaScript script immediately before the closing `</body>` tag.


### PR DESCRIPTION
closes #742

In this branch, I used the Swagger UI's `onComplete` parameter to display bearer token info if present as a cookie (e.g. via ORCiD login).

### Details

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/254cf835-1975-4f25-83dd-7db403743d28">


### Related issue(s)

Closes #742
...

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by manual inspection of `http://127.0.0.1:8000/docs`

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->


- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
