### PR TITLE
696 update dagster op for materialize alldocs

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1034,15 +1034,18 @@ def site_code_mapping() -> dict:
 
 @op(required_resource_keys={"mongo"})
 def materialize_alldocs(context) -> int:
+    """
+    This function re-creates the alldocs collection to reflect the current state of the Mongo database.
+    See nmdc-runtime/docs/nb/bulk_validation_referential_integrity_check.ipynb for more details.
+    """
     mdb = context.resources.mongo.db
     schema_view = nmdc_schema_view()
 
     # batch size for writing documents to alldocs
     BULK_WRITE_BATCH_SIZE = 2000
-    
+
     collection_names = populated_schema_collection_names_with_id_field(mdb)
     context.log.info(f"{collection_names=}")
-    
 
     # Drop any existing `alldocs` collection (e.g. from previous use of this op).
     #
@@ -1055,22 +1058,31 @@ def materialize_alldocs(context) -> int:
     # Build alldocs
     context.log.info("constructing `alldocs` collection")
 
-    document_class_names = set(chain.from_iterable(collection_name_to_class_names.values()))
+    document_class_names = set(
+        chain.from_iterable(collection_name_to_class_names.values())
+    )
 
     # Any ancestor of a document class is a document-referenceable range, i.e., a valid range of a document-reference-ranged slot.
-    document_referenceable_ranges = set(chain.from_iterable(schema_view.class_ancestors(cls_name) for cls_name in document_class_names))
+    document_referenceable_ranges = set(
+        chain.from_iterable(
+            schema_view.class_ancestors(cls_name) for cls_name in document_class_names
+        )
+    )
 
     cls_slot_map = {
-    cls_name : {slot.name: slot
-                for slot in schema_view.class_induced_slots(cls_name)
-               }
-    for cls_name in document_class_names
+        cls_name: {
+            slot.name: slot for slot in schema_view.class_induced_slots(cls_name)
+        }
+        for cls_name in document_class_names
     }
 
     document_reference_ranged_slots = defaultdict(list)
     for cls_name, slot_map in cls_slot_map.items():
         for slot_name, slot in slot_map.items():
-            if set(get_names_of_classes_in_effective_range_of_slot(schema_view, slot)) & document_referenceable_ranges:
+            if (
+                set(get_names_of_classes_in_effective_range_of_slot(schema_view, slot))
+                & document_referenceable_ranges
+            ):
                 document_reference_ranged_slots[cls_name].append(slot_name)
 
     for coll_name in collection_names:
@@ -1078,12 +1090,14 @@ def materialize_alldocs(context) -> int:
         requests = []
         documents_processed_counter = 0
         for doc in mdb[coll_name].find():
-            doc_type = doc['type'][5:] # lop off "nmdc:" prefix
-            slots_to_include = ["id", "type"] + document_reference_ranged_slots[doc_type]
+            doc_type = doc["type"][5:]  # lop off "nmdc:" prefix
+            slots_to_include = ["id", "type"] + document_reference_ranged_slots[
+                doc_type
+            ]
             new_doc = keyfilter(lambda slot: slot in slots_to_include, doc)
             new_doc["_type_and_ancestors"] = schema_view.class_ancestors(doc_type)
             requests.append(InsertOne(new_doc))
-            if len(requests) == BULK_WRITE_BATCH_SIZE: 
+            if len(requests) == BULK_WRITE_BATCH_SIZE:
                 result = mdb.alldocs.bulk_write(requests, ordered=False)
                 requests.clear()
                 documents_processed_counter += BULK_WRITE_BATCH_SIZE
@@ -1091,11 +1105,12 @@ def materialize_alldocs(context) -> int:
             result = mdb.alldocs.bulk_write(requests, ordered=False)
             documents_processed_counter += len(requests)
         context.log.info(
-                f"Inserted {documents_processed_counter} documents from {coll_name=} ")
+            f"Inserted {documents_processed_counter} documents from {coll_name=} "
+        )
 
     context.log.info(
         f"refreshed {mdb.alldocs} collection with {mdb.alldocs.estimated_document_count()} docs."
-            )
+    )
 
     # Re-idx for `alldocs` collection
     mdb.alldocs.create_index("id", unique=True)
@@ -1104,9 +1119,7 @@ def materialize_alldocs(context) -> int:
     slots_to_index = ["has_input", "has_output", "was_informed_by"]
     [mdb.alldocs.create_index(slot) for slot in slots_to_index]
 
-    context.log.info(
-        f"created indexes on id, {slots_to_index}."
-    )
+    context.log.info(f"created indexes on id, {slots_to_index}.")
     return mdb.alldocs.estimated_document_count()
 
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -7,6 +7,7 @@ import tempfile
 from collections import defaultdict
 from datetime import datetime, timezone
 from io import BytesIO, StringIO
+from toolz.dicttoolz import keyfilter
 from typing import Tuple
 from zipfile import ZipFile
 from itertools import chain
@@ -47,7 +48,7 @@ from nmdc_runtime.api.core.metadata import (
     get_collection_for_id,
     map_id_to_collection,
 )
-from nmdc_runtime.api.core.util import dotted_path_for, hash_from_str, json_clean, now, pick
+from nmdc_runtime.api.core.util import dotted_path_for, hash_from_str, json_clean, now
 from nmdc_runtime.api.endpoints.util import persist_content_and_get_drs_object
 from nmdc_runtime.api.endpoints.find import find_study_by_id
 from nmdc_runtime.api.models.job import Job, JobOperationMetadata
@@ -1088,7 +1089,7 @@ def materialize_alldocs(context) -> int:
         for doc in mdb[coll_name].find():
             doc_type = doc['type'][5:] # lop off "nmdc:" prefix
             slots_to_include = ["id", "type"] + document_reference_ranged_slots[doc_type]
-            new_doc = pick(slots_to_include, doc)
+            new_doc = keyfilter(lambda slot: slot in slots_to_include, doc)
             new_doc["_type_and_ancestors"] = schema_view.class_ancestors(doc_type)
             requests.append(InsertOne(new_doc))
             if len(requests) == BULK_WRITE_BATCH_SIZE: 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1036,22 +1036,13 @@ def site_code_mapping() -> dict:
 def materialize_alldocs(context) -> int:
     mdb = context.resources.mongo.db
     schema_view = nmdc_schema_view()
-    collection_names = populated_schema_collection_names_with_id_field(mdb)
+
+    # batch size for writing documents to alldocs
     BULK_WRITE_BATCH_SIZE = 2000
-
-    # Insert a no-op as an anchor point for this comment.
-    #
-    # Note: There used to be code here that `assert`-ed that each collection could only contain documents of a single
-    #       type. With the legacy schema, that assertion was true. With the Berkeley schema, it is false. That code was
-    #       in place because subsequent code (further below) used a single document in a collection as the source of the
-    #       class ancestry information of _all_ documents in that collection; an optimization that spared us from
-    #       having to do the same for every single document in that collection. With the Berkeley schema, we have
-    #       eliminated that optimization (since it is inadequate; it would produce some incorrect class ancestries
-    #       for descendants of `PlannedProcess`, for example).
-    #
-    pass
-
+    
+    collection_names = populated_schema_collection_names_with_id_field(mdb)
     context.log.info(f"{collection_names=}")
+    
 
     # Drop any existing `alldocs` collection (e.g. from previous use of this op).
     #

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -30,6 +30,7 @@ from nmdc_runtime.api.core.util import sha256hash_from_file
 from nmdc_runtime.api.models.object import DrsObjectIn
 from typing_extensions import Annotated
 
+
 def get_names_of_classes_in_effective_range_of_slot(
     schema_view: SchemaView, slot_definition: linkml_model.SlotDefinition
 ) -> List[str]:
@@ -53,13 +54,17 @@ def get_names_of_classes_in_effective_range_of_slot(
             # Use the slot expression's `range` to get the specified eligible class name
             # and the names of all classes that inherit from that eligible class.
             if slot_expression.range in schema_view.all_classes():
-                own_and_descendant_class_names = schema_view.class_descendants(slot_expression.range)
+                own_and_descendant_class_names = schema_view.class_descendants(
+                    slot_expression.range
+                )
                 names_of_eligible_target_classes.extend(own_and_descendant_class_names)
     else:
         # Use the slot's `range` to get the specified eligible class name
         # and the names of all classes that inherit from that eligible class.
         if slot_definition.range in schema_view.all_classes():
-            own_and_descendant_class_names = schema_view.class_descendants(slot_definition.range)
+            own_and_descendant_class_names = schema_view.class_descendants(
+                slot_definition.range
+            )
             names_of_eligible_target_classes.extend(own_and_descendant_class_names)
 
     # Remove duplicate class names.

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -17,6 +17,8 @@ import fastjsonschema
 import requests
 from frozendict import frozendict
 from jsonschema.validators import Draft7Validator
+from linkml_runtime import linkml_model
+from linkml_runtime.utils.schemaview import SchemaView
 from nmdc_schema.nmdc import Database as NMDCDatabase
 from nmdc_schema.get_nmdc_view import ViewGetter
 from pydantic import Field, BaseModel
@@ -27,6 +29,43 @@ from toolz import merge, unique
 from nmdc_runtime.api.core.util import sha256hash_from_file
 from nmdc_runtime.api.models.object import DrsObjectIn
 from typing_extensions import Annotated
+
+def get_names_of_classes_in_effective_range_of_slot(
+    schema_view: SchemaView, slot_definition: linkml_model.SlotDefinition
+) -> List[str]:
+    r"""
+    Determine the slot's "effective" range, by taking into account its `any_of` constraints (if defined).
+
+    Note: The `any_of` constraints constrain the slot's "effective" range beyond that described by the
+          induced slot definition's `range` attribute. `SchemaView` does not seem to provide the result
+          of applying those additional constraints, so we do it manually here (if any are defined).
+          Reference: https://github.com/orgs/linkml/discussions/2101#discussion-6625646
+
+    Reference: https://linkml.io/linkml-model/latest/docs/any_of/
+    """
+
+    # Initialize the list to be empty.
+    names_of_eligible_target_classes = []
+
+    # If the `any_of` constraint is defined on this slot, use that instead of the `range`.
+    if "any_of" in slot_definition and len(slot_definition.any_of) > 0:
+        for slot_expression in slot_definition.any_of:
+            # Use the slot expression's `range` to get the specified eligible class name
+            # and the names of all classes that inherit from that eligible class.
+            if slot_expression.range in schema_view.all_classes():
+                own_and_descendant_class_names = schema_view.class_descendants(slot_expression.range)
+                names_of_eligible_target_classes.extend(own_and_descendant_class_names)
+    else:
+        # Use the slot's `range` to get the specified eligible class name
+        # and the names of all classes that inherit from that eligible class.
+        if slot_definition.range in schema_view.all_classes():
+            own_and_descendant_class_names = schema_view.class_descendants(slot_definition.range)
+            names_of_eligible_target_classes.extend(own_and_descendant_class_names)
+
+    # Remove duplicate class names.
+    names_of_eligible_target_classes = list(set(names_of_eligible_target_classes))
+
+    return names_of_eligible_target_classes
 
 
 def get_class_names_from_collection_spec(

--- a/tests/test_ops/test_materialize_alldocs.py
+++ b/tests/test_ops/test_materialize_alldocs.py
@@ -42,11 +42,28 @@ def test_materialize_alldocs(op_context):
     #
     # Reference: https://microbiomedata.github.io/berkeley-schema-fy24/FieldResearchSite/#direct
     #
-    field_research_site_class_ancestry_chain = ["FieldResearchSite", "Site", "MaterialEntity", "NamedThing"]
+    field_research_site_class_ancestry_chain = [
+        "FieldResearchSite",
+        "Site",
+        "MaterialEntity",
+        "NamedThing",
+    ]
     field_research_site_documents = [
-        {"id": "frsite-99-00000001", "type": "nmdc:FieldResearchSite", "name": "Site A"},
-        {"id": "frsite-99-00000002", "type": "nmdc:FieldResearchSite", "name": "Site B"},
-        {"id": "frsite-99-00000003", "type": "nmdc:FieldResearchSite", "name": "Site C"},
+        {
+            "id": "frsite-99-00000001",
+            "type": "nmdc:FieldResearchSite",
+            "name": "Site A",
+        },
+        {
+            "id": "frsite-99-00000002",
+            "type": "nmdc:FieldResearchSite",
+            "name": "Site B",
+        },
+        {
+            "id": "frsite-99-00000003",
+            "type": "nmdc:FieldResearchSite",
+            "name": "Site C",
+        },
     ]
     field_research_site_set_collection = mdb.get_collection("field_research_site_set")
     for document in field_research_site_documents:
@@ -70,7 +87,9 @@ def test_materialize_alldocs(op_context):
 
     # Get a reference to the newly-materialized `alldocs` collection.
     alldocs_collection = mdb.get_collection("alldocs")
-    num_alldocs_docs = alldocs_collection.count_documents({})  # here, we get an _exact_ count
+    num_alldocs_docs = alldocs_collection.count_documents(
+        {}
+    )  # here, we get an _exact_ count
 
     # Verify each upstream document is represented correctly—and only once—in the `alldocs` collection.
     #
@@ -86,14 +105,21 @@ def test_materialize_alldocs(op_context):
         collection = mdb.get_collection(collection_name)
         for document in collection.find({}):
             num_upstream_docs += 1
-            document_lacking_type = dissoc(document, "_id", "type")
-            document_having_generic_type = assoc(document_lacking_type, "type", {"$type": "array"})
+            document_having_generic_type = assoc(
+                {"id": document["id"]},
+                "_type_and_ancestors",
+                {"$type": "array"},
+            )
             assert alldocs_collection.count_documents(document_having_generic_type) == 1
 
     # Verify each of the specific documents we created above appears in the `alldocs` collection once,
-    # and that its `type` value has been replaced with its class ancestry chain.
+    # and that `_type_and_ancestors` has been set to its class ancestry chain.
     for document in field_research_site_documents:
-        alldocs_document = assoc(dissoc(document, "type"), "type", field_research_site_class_ancestry_chain)
+        alldocs_document = {
+            "id": document["id"],
+            "type": document["type"],
+            "_type_and_ancestors": field_research_site_class_ancestry_chain,
+        }
         assert alldocs_collection.count_documents(alldocs_document) == 1
 
     # Verify the total number of documents in all the upstream collections, combined,


### PR DESCRIPTION
In this branch, I updated materialize_alldocs in the dagster file.

### Details
In this PR, I:
- updated the "materialize_alldocs" in the dagster op to reflect functionality in bulk_validation_referential_integrity_check.ipynb 
- added necessary utils to utils.py
- replaced `pick` function to use `keyfilter` directly

### Related issue(s)
- Related to #696 

### Related subsystem(s)
- [X] Dagster
- [X] Project documentation (in the `docs` directory)

### Testing
- [X] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by making sure the `ensure_alldocs` job runs in my local dagster environment: ![Succesful Dagster Run](https://github.com/user-attachments/assets/68d11c9e-9ff6-4731-8c27-55903d8bc01b) 

### Documentation
- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [X] I have **updated** all relevant documentation so it will remain accurate

### Maintainability
- [X] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [X] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [X] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [X] I used `black` to format all the Python files I created/modified
- [X] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
