### PR TITLE
Upgrade to `nmdc-schema` v11.2.1

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -25,7 +25,7 @@ mkdocs-jupyter
 mkdocs-material
 mkdocs-mermaid2-plugin
 motor
-nmdc-schema==11.1.0
+nmdc-schema==11.2.1
 openpyxl
 pandas
 passlib[bcrypt]

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -21,6 +21,8 @@ anyio==4.7.0
     #   jupyter-server
     #   starlette
     #   watchfiles
+appnope==0.1.4
+    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -194,8 +196,6 @@ graphql-relay==3.2.0
     # via graphene
 graphviz==0.20.3
     # via linkml
-greenlet==3.1.1
-    # via sqlalchemy
 grpcio==1.68.1
     # via
     #   dagster
@@ -440,7 +440,7 @@ nbformat==5.10.4
     #   nbconvert
 nest-asyncio==1.6.0
     # via ipykernel
-nmdc-schema==11.1.0
+nmdc-schema==11.2.1
     # via -r requirements/main.in
 notebook==7.3.1
     # via jupyter


### PR DESCRIPTION
This branch does the routine `nmdc-schema` upgrade (to version 11.2.1) in advance of next week's release.

### Related issue(s)

None

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by ensuring `make up-dev` comes up successfully after doing the upgrade.

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
