### PR TITLE
[DRAFT - Needs more feedback] Add support for user specified token lifetimes

### DIFF
--- a/nmdc_runtime/api/core/auth.py
+++ b/nmdc_runtime/api/core/auth.py
@@ -66,9 +66,10 @@ class TokenExpires(BaseModel):
     days: Optional[int] = 1
     hours: Optional[int] = 0
     minutes: Optional[int] = 0
+    seconds: Optional[int] = 0
 
 
-ACCESS_TOKEN_EXPIRES = TokenExpires(days=1, hours=0, minutes=0)
+ACCESS_TOKEN_EXPIRES = TokenExpires(days=1, hours=0, minutes=0, seconds=0)
 
 
 class Token(BaseModel):
@@ -174,14 +175,19 @@ class OAuth2PasswordOrClientCredentialsRequestForm:
         bearer_creds: Optional[HTTPAuthorizationCredentials] = Depends(
             bearer_credentials
         ),
-        grant_type: str = Form(None, pattern="^password$|^client_credentials$"),
-        username: Optional[str] = Form(None),
-        password: Optional[str] = Form(None),
+        grant_type: str = Form(None, 
+                               pattern="^password$|^client_credentials$", 
+                               description="Select type of login credentials - either `password` or `client_credentials`"),
+        username: Optional[str] = Form(None, description="Username for grant_type `password`"),
+        password: Optional[str] = Form(None, description="Password for grant_type `password`"),
         scope: str = Form(""),
-        client_id: Optional[str] = Form(None),
-        client_secret: Optional[str] = Form(None),
+        client_id: Optional[str] = Form(None, description="Client ID for grant_type `client_credentials`"),
+        client_secret: Optional[str] = Form(None, description="Client secret for grant_type `client_credentials`"),
+        expires: Optional[str] = Form(None, description="Seconds until token expires (Default 1 day)"),
     ):
-        if bearer_creds:
+        if bearer_creds:    
+            # TODO: This is never being used since it gets overwritten later on. 
+            #       Should we remove this?
             self.grant_type = "client_credentials"
             self.username, self.password = None, None
             self.scopes = scope.split()
@@ -207,3 +213,5 @@ class OAuth2PasswordOrClientCredentialsRequestForm:
         self.scopes = scope.split()
         self.client_id = client_id
         self.client_secret = client_secret
+        self.expires = expires
+

--- a/nmdc_runtime/api/core/auth.py
+++ b/nmdc_runtime/api/core/auth.py
@@ -175,18 +175,30 @@ class OAuth2PasswordOrClientCredentialsRequestForm:
         bearer_creds: Optional[HTTPAuthorizationCredentials] = Depends(
             bearer_credentials
         ),
-        grant_type: str = Form(None, 
-                               pattern="^password$|^client_credentials$", 
-                               description="Select type of login credentials - either `password` or `client_credentials`"),
-        username: Optional[str] = Form(None, description="Username for grant_type `password`"),
-        password: Optional[str] = Form(None, description="Password for grant_type `password`"),
+        grant_type: str = Form(
+            None,
+            pattern="^password$|^client_credentials$",
+            description="Select type of login credentials - either `password` or `client_credentials`",
+        ),
+        username: Optional[str] = Form(
+            None, description="Username for grant_type `password`"
+        ),
+        password: Optional[str] = Form(
+            None, description="Password for grant_type `password`"
+        ),
         scope: str = Form(""),
-        client_id: Optional[str] = Form(None, description="Client ID for grant_type `client_credentials`"),
-        client_secret: Optional[str] = Form(None, description="Client secret for grant_type `client_credentials`"),
-        expires: Optional[str] = Form(None, description="Seconds until token expires (Default 1 day)"),
+        client_id: Optional[str] = Form(
+            None, description="Client ID for grant_type `client_credentials`"
+        ),
+        client_secret: Optional[str] = Form(
+            None, description="Client secret for grant_type `client_credentials`"
+        ),
+        expires: Optional[str] = Form(
+            None, description="Seconds until token expires (Default 1 day)"
+        ),
     ):
-        if bearer_creds:    
-            # TODO: This is never being used since it gets overwritten later on. 
+        if bearer_creds:
+            # TODO: This is never being used since it gets overwritten later on.
             #       Should we remove this?
             self.grant_type = "client_credentials"
             self.username, self.password = None, None
@@ -214,4 +226,3 @@ class OAuth2PasswordOrClientCredentialsRequestForm:
         self.client_id = client_id
         self.client_secret = client_secret
         self.expires = expires
-

--- a/nmdc_runtime/api/endpoints/users.py
+++ b/nmdc_runtime/api/endpoints/users.py
@@ -81,7 +81,7 @@ async def login_for_access_token(
         if timedelta(**ACCESS_TOKEN_EXPIRES.model_dump()) - timedelta(seconds=expires) < timedelta(seconds=0):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Incorrect username or password",
+                detail="expires must be less than 86400",
                 headers={"WWW-Authenticate": "Bearer"},
             )
         access_token_expires = timedelta(seconds=expires)

--- a/nmdc_runtime/api/endpoints/users.py
+++ b/nmdc_runtime/api/endpoints/users.py
@@ -75,10 +75,12 @@ async def login_for_access_token(
     form_data: OAuth2PasswordOrClientCredentialsRequestForm = Depends(),
     mdb: pymongo.database.Database = Depends(get_mongo_db),
 ):
-    
+
     if form_data.expires:
         expires = int(form_data.expires)
-        if timedelta(**ACCESS_TOKEN_EXPIRES.model_dump()) - timedelta(seconds=expires) < timedelta(seconds=0):
+        if timedelta(**ACCESS_TOKEN_EXPIRES.model_dump()) - timedelta(
+            seconds=expires
+        ) < timedelta(seconds=0):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="expires must be less than 86400",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -162,10 +162,10 @@ def test_token():
             base_url + "/token",
             data=data,
         )
-        token_response = _rv.json()
-        return token_response
+        return _rv 
 
-    token = get_token_response()
+    # Test default expiration
+    token = get_token_response().json()
     assert token["token_type"] == "bearer"
     assert "access_token" in token
     assert "expires" in token
@@ -175,7 +175,9 @@ def test_token():
         "minutes": 0,
         "seconds": 0
     }
-    token = get_token_response(7382) 
+
+    # Test custom expiration
+    token = get_token_response(7382) .json()
     assert token["expires"] == {
         "days": 0,
         "hours": 2,
@@ -189,6 +191,9 @@ def test_token():
     # give it margin for error since the operation could take a few seconds
     assert delta > 7200 and delta <= 7382
 
+    # Test expiration over 24 hours
+    response = get_token_response(86401) 
+    assert response.status_code == 401
 
 def test_create_user():
     mdb = get_mongo(run_config_frozen__normal_env).db

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -185,7 +185,7 @@ def test_token():
     access_token = token["access_token"]
     # Decode the JWT access token
     decoded_token = jwt.get_unverified_claims(access_token)
-    delta = decoded_token['exp']-datetime.now(timezone.utc).total_seconds()
+    delta = (datetime.fromtimestamp(decoded_token['exp'], timezone.utc) - datetime.now(timezone.utc)).total_seconds()
     # give it margin for error since the operation could take a few seconds
     assert delta > 7200 and delta <= 7382
 


### PR DESCRIPTION
In this branch, I updated the /users/token/ endpoint to allow specifying a shorter lifetime to address #828 
It enables a new optional parameter to pass in an `expires` value in seconds, and updates `TimeExpires` model to include seconds

### Details

- Updated nmdc_runtime/api/core/auth.py to support `seconds` in TimeExpires and adds support for `expires` field in form
- Updated nmdc_runtime/api/endpoints/users.py to support setting access_token lifetime (as long as it is less that ACCESS_TOKEN_EXPIRES default)
- Added tests in tests/test_api/test_endpoints.py

### Related issue(s)

Fixes #828

### Related subsystem(s)

- [X] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing


- [X] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by adding a new test_get_token() test

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [X] Other (explain below)

Swagger docs updated

### Maintainability

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [ ] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
