### PR TITLE
Remove obsolete guidance from development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ http://127.0.0.1:8000/redoc/.
 
 Tests can be found in `tests` and are run with the following commands:
 
-On an M1 Mac? May need to `export DOCKER_DEFAULT_PLATFORM=linux/amd64`. (Update 2024/12/12 - DO NOT USE this env var with newer Docker Desktop)
-
 ```bash
 make up-test
 make test


### PR DESCRIPTION
`export DOCKER_DEFAULT_PLATFORM=linux/amd64` was an older recommendation to allow amd64 containers to run on M1/M2 macs. However newer versions of Docker Desktop don't like this, and you should just let Docker pull the right container,
