### PR TITLE
Fix bug where `validate_json` referential integrity check ignored documents in database

### DIFF
--- a/nmdc_runtime/api/endpoints/metadata.py
+++ b/nmdc_runtime/api/endpoints/metadata.py
@@ -168,10 +168,13 @@ async def get_stored_metadata_object(
 
 @router.post("/metadata/json:validate", name="Validate JSON")
 async def validate_json_nmdcdb(docs: dict, mdb: MongoDatabase = Depends(get_mongo_db)):
-    """
-
+    r"""
     Validate a NMDC JSON Schema "nmdc:Database" object.
 
+    This API endpoint validates the JSON payload in two steps. The first step is to check the format of each document
+    (e.g., the presence, name, and value of each field). If it encounters any violations during that step, it will not
+    proceed to the second step. The second step is to check whether all documents referenced by the document exist,
+    whether in the database or the same JSON payload. We call the second step a "referential integrity check."
     """
 
     return validate_json(docs, mdb, check_inter_document_references=True)

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -542,6 +542,13 @@ class OverlayDB(AbstractContextManager):
     overlay collection, that id is marked as "seen" and will not also be returned when
     subsequently scanning the (unmodified) base-database collection.
 
+    Note: The OverlayDB object does not provide a means to perform arbitrary MongoDB queries on the virtual "merged"
+          database. Callers can access the real database via `overlay_db._bottom_db` and the overlaying database via
+          `overlay_db._top_db` and perform arbitrary MongoDB queries on the individual databases that way. Access to
+          the virtual "merged" database is limited to the methods of the `OverlayDB` class, which simulates the
+          "merging" just-in-time to process the method invocation. You can see an example of this in the implementation
+          of the `merge_find` method, which internally accesses both the real database and the overlaying database.
+
     Mongo "update" commands (as the "apply_updates" method) are simulated by first copying affected
     documents from a base collection to the overlay, and then applying the updates to the overlay,
     so that again, base collections are unmodified, and a "merge_find" call will produce a result

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -708,6 +708,11 @@ def validate_json(
             #          JSON payload. If it does, then we "waive" (i.e. discard) that violation.
             #       The violations that remain after those two stages are the ones we return to the caller.
             #
+            # Note: The reason we do not insert documents into an `OverlayDB` and scan _that_, is that the `OverlayDB`
+            #       does not provide a means to perform arbitrary queries against its virtual "merged" database. It
+            #       is not a drop-in replacement for a pymongo's `Database` class, which is the only thing that
+            #       `refscan`'s `Finder` class accepts.
+            #
             finder = Finder(database=mdb)
             references = get_allowed_references()
             reference_field_names_by_source_class_name = (

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -570,13 +570,6 @@ class OverlayDB(AbstractContextManager):
     def __exit__(self, exc_type, exc_value, traceback):
         self._bottom_db.client.drop_database(self._top_db.name)
 
-    def get_collection(self, coll_name: str):
-        r"""Returns a reference to the specified collection."""
-        try:
-            return self._top_db[coll_name]
-        except OperationFailure as e:
-            raise OverlayDBError(str(e.details))
-
     def replace_or_insert_many(self, coll_name, documents: list):
         try:
             self._top_db[coll_name].insert_many(documents)

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -709,9 +709,13 @@ def validate_json(
 
             # Iterate over the collections in the JSON payload.
             for source_collection_name, documents in in_docs.items():
-                print(f"Checking inter-document references for {source_collection_name}")
+                print(
+                    f"Checking inter-document references for {source_collection_name}"
+                )
                 for document in documents:
-                    source_document = dict(document, _id=None)  # adds `_id` field, since `refscan` requires it to exist
+                    source_document = dict(
+                        document, _id=None
+                    )  # adds `_id` field, since `refscan` requires it to exist
                     violations = scan_outgoing_references(
                         document=source_document,
                         schema_view=nmdc_schema_view(),
@@ -725,19 +729,26 @@ def validate_json(
 
                     # For each violation, check whether the misplaced document is in the JSON payload, itself.
                     for violation in violations:
-                        print(f"Checking whether inter-document referential integrity violation can be waived.")
+                        print(
+                            f"Checking whether inter-document referential integrity violation can be waived."
+                        )
                         can_waive_violation = False
                         # Determine which collections can contain the referenced document, based upon
                         # the schema class of which this source document is an instance.
-                        target_collection_names = references.get_target_collection_names(
-                            source_class_name=violation.source_class_name,
-                            source_field_name=violation.source_field_name,
+                        target_collection_names = (
+                            references.get_target_collection_names(
+                                source_class_name=violation.source_class_name,
+                                source_field_name=violation.source_field_name,
+                            )
                         )
                         # Check whether the referenced document exists in any of those collections in the JSON payload.
                         for in_collection_name, in_collection_docs in in_docs.items():
                             if in_collection_name in target_collection_names:
                                 for in_collection_doc in in_collection_docs:
-                                    if in_collection_doc.get("id") == violation.target_id:
+                                    if (
+                                        in_collection_doc.get("id")
+                                        == violation.target_id
+                                    ):
                                         can_waive_violation = True
                                         break  # stop checking
                             if can_waive_violation:

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -709,13 +709,9 @@ def validate_json(
 
             # Iterate over the collections in the JSON payload.
             for source_collection_name, documents in in_docs.items():
-                print(
-                    f"Checking inter-document references for {source_collection_name}"
-                )
                 for document in documents:
-                    source_document = dict(
-                        document, _id=None
-                    )  # adds `_id` field, since `refscan` requires it to exist
+                    # Add an `_id` field to the document, since `refscan` requires the document to have one.
+                    source_document = dict(document, _id=None)
                     violations = scan_outgoing_references(
                         document=source_document,
                         schema_view=nmdc_schema_view(),
@@ -729,9 +725,6 @@ def validate_json(
 
                     # For each violation, check whether the misplaced document is in the JSON payload, itself.
                     for violation in violations:
-                        print(
-                            f"Checking whether inter-document referential integrity violation can be waived."
-                        )
                         can_waive_violation = False
                         # Determine which collections can contain the referenced document, based upon
                         # the schema class of which this source document is an instance.
@@ -742,13 +735,10 @@ def validate_json(
                             )
                         )
                         # Check whether the referenced document exists in any of those collections in the JSON payload.
-                        for in_collection_name, in_collection_docs in in_docs.items():
-                            if in_collection_name in target_collection_names:
-                                for in_collection_doc in in_collection_docs:
-                                    if (
-                                        in_collection_doc.get("id")
-                                        == violation.target_id
-                                    ):
+                        for json_coll_name, json_coll_docs in in_docs.items():
+                            if json_coll_name in target_collection_names:
+                                for json_coll_doc in json_coll_docs:
+                                    if json_coll_doc["id"] == violation.target_id:
                                         can_waive_violation = True
                                         break  # stop checking
                             if can_waive_violation:

--- a/tests/test_the_util/test_the_util.py
+++ b/tests/test_the_util/test_the_util.py
@@ -6,7 +6,7 @@ from nmdc_runtime.util import validate_json
 # Tip: At the time of this writing, you can run the tests in this file without running other tests in this repo,
 #      by issuing the following command from the root directory of the repository within the `fastapi` container:
 #      ```
-#      $ pytest tests/test_the_util/test_the_util.py
+#      $ pytest -vv tests/test_the_util/test_the_util.py
 #      ```
 
 # Define a reusable dictionary that matches the value the `validate_json` function
@@ -148,6 +148,23 @@ def test_validate_json_does_not_check_references_if_documents_are_schema_defiant
     assert len(result["detail"]["study_set"]) == 1  # not 2
 
 
+def test_validate_json_reports_multiple_broken_references_emanating_from_single_document(db):
+    database_dict = {
+        "study_set": [
+            {
+                "id": "nmdc:sty-00-000001",
+                "type": "nmdc:Study",
+                "study_category": "research_study",
+                "part_of": ["nmdc:sty-00-000008", "nmdc:sty-00-000009"],  # identifies 2 non-existent studies
+            },
+        ]
+    }
+    result = validate_json(in_docs=database_dict, mdb=db, **check_refs)
+    assert result["result"] == "errors"
+    assert "study_set" in result["detail"]
+    assert len(result["detail"]["study_set"]) == 2
+
+
 def test_validate_json_checks_referential_integrity_after_applying_all_collections_changes(db):
     r"""
     Note: This test targets the scenario where a single payload introduces both the source document and target document
@@ -170,3 +187,31 @@ def test_validate_json_checks_referential_integrity_after_applying_all_collectio
         ]
     }
     assert validate_json(in_docs=database_dict, mdb=db, **check_refs) == ok_result
+
+
+def test_validate_json_considers_existing_documents_when_checking_references(db):
+    r"""
+    Note: This test focuses on the case where the database already contains the to-be-referenced document;
+          as opposed to the to-be-referenced document being introduced via the same request payload.
+          For that reason, we will seed the database before calling the function-under-test.
+    """
+    existing_study_id = "nmdc:sty-00-000001"
+
+    db.get_collection("study_set").replace_one(
+        {"id": existing_study_id},
+        {"id": "nmdc:sty-00-000001", "type": "nmdc:Study", "study_category": "research_study"},
+        upsert=True
+    )
+    database_dict = {
+        "study_set": [
+            {
+                "id": "nmdc:sty-00-000002",
+                "type": "nmdc:Study",
+                "study_category": "research_study",
+                "part_of": [existing_study_id],  # identifies the existing study
+            },
+        ]
+    }
+    assert validate_json(in_docs=database_dict, mdb=db, **check_refs) == ok_result
+
+    db.get_collection("study_set").delete_one({"id": existing_study_id})

--- a/tests/test_the_util/test_the_util.py
+++ b/tests/test_the_util/test_the_util.py
@@ -199,7 +199,7 @@ def test_validate_json_considers_existing_documents_when_checking_references(db)
 
     db.get_collection("study_set").replace_one(
         {"id": existing_study_id},
-        {"id": "nmdc:sty-00-000001", "type": "nmdc:Study", "study_category": "research_study"},
+        {"id": existing_study_id, "type": "nmdc:Study", "study_category": "research_study"},
         upsert=True
     )
     database_dict = {


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "In this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I fixed a bug where the real-time referential integrity checker in the `validate_json` function was ignoring documents that were already in the database.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I changed the real-time referential integrity checker code to no longer use the `OverlayDB` class. When I first wrote the real-time referential integrity checker code, I had made an incorrect assumption about how the `OverlayDB` class worked.

Instead of it using the `OverlayDB` class, I updated the checker to use the real database directly and to use the JSON payload directly. Checking now happens in two stages (one for each of those potential "residences" of each referenced document).

The two stages are (in short—as a more detailed explanation is in the code comments):
1. Check the database
2. If the document isn't found there, check the JSON payload

With those changes in place, the checker no longer ignores documents that already exist in the database. I added a unit test that demonstrates this.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #860

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by adding some unit tests that target them, and ensuring that those tests pass. I will leave it to GitHub Actions to tell me whether all pre-existing tests still pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
