### PR TITLE
Use `nmdc-schema`-provided function to get typecode from slot pattern

### DIFF
--- a/nmdc_runtime/minter/config.py
+++ b/nmdc_runtime/minter/config.py
@@ -2,8 +2,9 @@ import os
 from functools import lru_cache
 from typing import List
 
-from nmdc_runtime.util import get_nmdc_jsonschema_dict
+from nmdc_schema.id_helpers import get_typecode_for_future_ids
 
+from nmdc_runtime.util import get_nmdc_jsonschema_dict
 from nmdc_runtime.api.db.mongo import get_mongo_db
 
 
@@ -12,55 +13,24 @@ def minting_service_id() -> str | None:
     return os.getenv("MINTING_SERVICE_ID")
 
 
-def extract_typecode_from_pattern(pattern: str) -> str:
-    r"""
-    Returns the typecode portion of the specified string.
-
-    >>> extract_typecode_from_pattern("foo-123-456$")  # original behavior
-    'foo'
-    >>> extract_typecode_from_pattern("(foo)-123-456$")  # returns first and only typecode
-    'foo'
-    >>> extract_typecode_from_pattern("(foo|bar)-123-456$")  # returns first of 2 typecodes
-    'foo'
-    >>> extract_typecode_from_pattern("(foo|bar|baz)-123-456$")  # returns first of > 2 typecodes
-    'foo'
-    """
-
-    # Get the portion of the pattern preceding the first hyphen.
-    # e.g. "foo-bar-baz" → ["foo", "bar-baz"] → "foo"
-    typecode_sub_pattern = pattern.split("-", maxsplit=1)[0]
-
-    # If that portion of the pattern is enclosed in parentheses, get the portion between the parentheses.
-    # e.g. "(apple|banana|carrot)" → "apple|banana|carrot"
-    if typecode_sub_pattern.startswith("(") and typecode_sub_pattern.endswith(")"):
-        inner_pattern = typecode_sub_pattern[1:-1]
-
-        # Finally, get everything before the first `|`, if any.
-        # e.g. "apple|banana|carrot" → "apple"
-        # e.g. "apple" → "apple"
-        typecode = inner_pattern.split("|", maxsplit=1)[0]
-    else:
-        # Note: This is the original behavior, before we added support for multi-typecode patterns.
-        # e.g. "apple" → "apple"
-        typecode = typecode_sub_pattern
-
-    return typecode
-
-
 @lru_cache()
 def typecodes() -> List[dict]:
     r"""
     Returns a list of dictionaries containing typecodes and associated information derived from the schema.
 
-    Preconditions about the schema:
-    - The typecode portion of the pattern is between the pattern prefix and the first subsequent hyphen.
-    - The typecode portion of the pattern either consists of a single typecode verbatim (e.g. "foo");
-      or consists of multiple typecodes in a pipe-delimited list enclosed in parentheses (e.g. "(foo|bar|baz)").
-    - The typecode portion of the pattern does not, itself, contain any hyphens.
+    Note: In this function, we rely on a helper function provided by the `nmdc-schema` package to extract—from a given
+          class's `id` slot's pattern—the typecode that the minter would use when generating an ID for an instance of
+          that class _today_; regardless of what it may have used in the past.
 
-    TODO: Get the typecodes in a different way than by extracting them from a larger string, which seems brittle to me.
-          Getting them a different way may require schema authors to _define_ them a different way (e.g. defining them
-          in a dedicated property of a class; for example, one named `typecode`).
+    >>> typecode_descriptors = typecodes()
+    # Test #1: We get the typecode we expect, for a class whose pattern contains only one typecode.
+    >>> any((td["name"] == "sty" and td["schema_class"] == "nmdc:Study") for td in typecode_descriptors)
+    True
+    # Tests #2 and #3: We get only the typecode we expect, for a class whose pattern contains multiple typecodes.
+    >>> any((td["name"] == "dgms" and td["schema_class"] == "nmdc:MassSpectrometry") for td in typecode_descriptors)
+    True
+    >>> any((td["name"] == "omprc" and td["schema_class"] == "nmdc:MassSpectrometry") for td in typecode_descriptors)
+    False
     """
     id_pattern_prefix = r"^(nmdc):"
 
@@ -69,16 +39,14 @@ def typecodes() -> List[dict]:
     for cls_name, defn in schema_dict["$defs"].items():
         match defn.get("properties"):
             case {"id": {"pattern": p}} if p.startswith(id_pattern_prefix):
-                # Get the portion of the pattern following the prefix.
-                # e.g. "^(nmdc):foo-bar-baz" → "foo-bar-baz"
-                index_of_first_character_following_prefix = len(id_pattern_prefix)
-                pattern_without_prefix = p[index_of_first_character_following_prefix:]
+                # Extract the typecode from the pattern.
+                typecode_for_future_ids = get_typecode_for_future_ids(slot_pattern=p)
 
                 rv.append(
                     {
                         "id": "nmdc:" + cls_name + "_" + "typecode",
                         "schema_class": "nmdc:" + cls_name,
-                        "name": extract_typecode_from_pattern(pattern_without_prefix),
+                        "name": typecode_for_future_ids,
                     }
                 )
             case _:


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I changed how the minter gets typecodes from the schema.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Previously, the minter would use a locally-defined function (named `extract_typecode_from_pattern`) to extract typecodes from `id` slot patterns. That ran the risk of falling out of sync with how the same thing is done in the `nmdc-schema` package. On this branch, I deleted the locally-defined function and updated the calling code to call an equivalent function (named `get_typecode_for_future_ids`) provided by the `nmdc-schema` package.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #866 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [x] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by implementing a basic doctest and running it locally via:

```py
docker compose run --rm --no-deps fastapi sh -c 'pip install nmdc-schema==11.3.0 && python -m doctest -v nmdc_runtime/minter/config.py'
```

> Note: I included `pip install nmdc-schema==11.3.0 &&` in the command because I am currently unable to rebuild my `fastapi` container via `make up-dev`. This is a separate problem, predating this PR branch.

🙋 _Question: Does the GHA test process run doctests?_

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
