### PR TITLE
Add test coverage to pytest  

### DIFF
--- a/nmdc_runtime/test.Dockerfile
+++ b/nmdc_runtime/test.Dockerfile
@@ -40,4 +40,4 @@ ENV PYTHONFAULTHANDLER=1
 
 # uncomment line below to stop after first test failure:
 # https://docs.pytest.org/en/6.2.x/usage.html#stopping-after-the-first-or-n-failures
-ENTRYPOINT [ "./wait-for-it.sh", "fastapi:8000" , "--strict" , "--timeout=300" , "--" , "pytest"]
+ENTRYPOINT [ "./wait-for-it.sh", "fastapi:8000" , "--strict" , "--timeout=300" , "--" , "pytest", "--cov=nmdc_runtime"]


### PR DESCRIPTION
Addresses #124 using pytest-cov by adding flag to the test runner (which is already a dev dependency in runtime)
