### PR TITLE
Enable referential integrity checking for `/metadata/json:submit` API endpoint

### DIFF
--- a/nmdc_runtime/api/endpoints/metadata.py
+++ b/nmdc_runtime/api/endpoints/metadata.py
@@ -196,7 +196,10 @@ async def submit_json_nmdcdb(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only specific users are allowed to submit json at this time.",
         )
-    rv = validate_json(docs, mdb)
+    
+    # Validate the JSON payload, both (a) the format of each document and
+    # (b) the integrity of any inter-document references being introduced.
+    rv = validate_json(docs, mdb, check_inter_document_references=True)
     if rv["result"] == "errors":
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/nmdc_runtime/api/endpoints/metadata.py
+++ b/nmdc_runtime/api/endpoints/metadata.py
@@ -196,7 +196,7 @@ async def submit_json_nmdcdb(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only specific users are allowed to submit json at this time.",
         )
-    
+
     # Validate the JSON payload, both (a) the format of each document and
     # (b) the integrity of any inter-document references being introduced.
     rv = validate_json(docs, mdb, check_inter_document_references=True)

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -361,7 +361,7 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(
     )[0]
 
     # 👤 Give the user permission to use this API endpoint if it doesn't already have
-    # such permission (i.e. do an upsert).
+    # such permission.
     allowances_collection = mdb.get_collection("_runtime.api.allow")
     user_allowance = {
         "username": api_user_client.username,

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -370,8 +370,8 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(api_u
 
     # Submit an API request whose payload contains the study.
     #
-    # Note: The `api_user_client.request` helper method raises an exception
-    #       when the response is not a success response.
+    # Note: The `api_user_client.request` method raises an exception when
+    #       the HTTP response is not a "success" response.
     #
     with pytest.raises(requests.exceptions.HTTPError) as exc:
         api_user_client.request(
@@ -381,8 +381,8 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(api_u
         )
     assert exc.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    # Assert that the "detail" property of the exception contains the words "errors",
-    # "study_set" (i.e. the collection name), and "part_of" (i.e. the field name).
+    # Assert that the top-level "detail" property of the exception contains the words "errors",
+    # "study_set" (i.e. the problematic collection), and "part_of" (i.e. the problematic field).
     #
     # Note: The "detail" value is a string representation of a Python dictionary
     #       (its keys are wrapped in single quotes, not double quotes). It is not

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -379,19 +379,20 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(api_u
             "/metadata/json:submit",
             {"study_set": [my_study]},
         )
-    assert exc.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    response = exc.value.response
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    # Assert that the "detail" property of the exception contains the words "errors",
+    # Assert that the "detail" property of the response payload contains the words "errors",
     # "study_set" (i.e. the problematic collection), and "part_of" (i.e. the problematic field).
     #
-    # Note: The "detail" value is a string representation of a Python dictionary
-    #       (its keys are wrapped in single quotes, not double quotes). It is not
-    #       a valid JSON string, so we cannot use `json.loads()` to parse it.
-    #       I do not know whether that was by design. Maybe I am not accessing
-    #       the exception's content in the way its author intended.
+    # Note: The "detail" value is a string representation of the Python dictionary returned
+    #       by the `validate_json` function (i.e. its keys are wrapped in single quotes,
+    #       not double quotes). It is not a valid JSON string, so we cannot use `json.loads()`
+    #       to parse it. I do not know whether that was by design. Maybe I am not accessing
+    #       the exception's content in the way its designer intended.
     #
-    assert "detail" in exc.value.response.json()
-    detail_str = exc.value.response.json()["detail"]
+    assert "detail" in response.json()
+    detail_str = response.json()["detail"]
     assert isinstance(detail_str, str)
     assert "errors" in detail_str
     assert "study_set" in detail_str

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -381,11 +381,17 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(api_u
         )
     assert exc.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    # Assert that the "detail" property of the exception mentions
-    # "errors", the "study_set" collection, and the "part_of" field.
-    # Note: The "detail" property is a string, not a dictionary.
+    # Assert that the "detail" property of the exception contains the words "errors",
+    # "study_set" (i.e. the collection name), and "part_of" (i.e. the field name).
+    #
+    # Note: The "detail" value is a string representation of a Python dictionary
+    #       (its keys are wrapped in single quotes, not double quotes). It is not
+    #       a valid JSON string, so we cannot use `json.loads()` to parse it.
+    #       I do not know whether that was by design.
+    #
     assert "detail" in exc.value.response.json()
-    detail_str: str = exc.value.response.json()["detail"]
+    detail_str = exc.value.response.json()["detail"]
+    assert isinstance(detail_str, str)
     assert "errors" in detail_str
     assert "study_set" in detail_str
     assert "part_of" in detail_str

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -381,13 +381,14 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(api_u
         )
     assert exc.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    # Assert that the top-level "detail" property of the exception contains the words "errors",
+    # Assert that the "detail" property of the exception contains the words "errors",
     # "study_set" (i.e. the problematic collection), and "part_of" (i.e. the problematic field).
     #
     # Note: The "detail" value is a string representation of a Python dictionary
     #       (its keys are wrapped in single quotes, not double quotes). It is not
     #       a valid JSON string, so we cannot use `json.loads()` to parse it.
-    #       I do not know whether that was by design.
+    #       I do not know whether that was by design. Maybe I am not accessing
+    #       the exception's content in the way its author intended.
     #
     assert "detail" in exc.value.response.json()
     detail_str = exc.value.response.json()["detail"]


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I enabled referential integrity checking for the `/metadata/json:submit` API endpoint.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

It's the same referential integrity checking that was enabled for the `/metadata/json:validate` API endpoint a few months ago, in Release 2025.1 (tag [v2.3.0](https://github.com/microbiomedata/nmdc-runtime/releases/tag/v2.3.0)).

I also added an automated **test** targeting the referential integrity check in the context of the `/metadata/json:submit` endpoint. It is currently the only test targeting the endpoint.

I also added a `TODO` comment about testing other aspects of the endpoint.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #954 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I added an automated test that targets the new functionality, and confirmed it passes locally and on GHA.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
