### PR TITLE
Add referential integrity check to `POST /workflows/workflow_executions` API endpoint

### DIFF
--- a/nmdc_runtime/api/endpoints/workflows.py
+++ b/nmdc_runtime/api/endpoints/workflows.py
@@ -92,7 +92,7 @@ async def post_workflow_execution(
     _ = site  # must be authenticated
     try:
         # validate request JSON
-        rv = validate_json(workflow_execution_set, mdb)
+        rv = validate_json(workflow_execution_set, mdb, check_inter_document_references=True)
         if rv["result"] == "errors":
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/nmdc_runtime/api/endpoints/workflows.py
+++ b/nmdc_runtime/api/endpoints/workflows.py
@@ -92,7 +92,9 @@ async def post_workflow_execution(
     _ = site  # must be authenticated
     try:
         # validate request JSON
-        rv = validate_json(workflow_execution_set, mdb, check_inter_document_references=True)
+        rv = validate_json(
+            workflow_execution_set, mdb, check_inter_document_references=True
+        )
         if rv["result"] == "errors":
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -171,7 +171,7 @@ class Faker:
         >>> len(metagenome_annotations)
         1
         >>> metagenome_annotations[0]['id']
-        'nmdc:wfmgan-00-000001'
+        'nmdc:wfmgan-00-000001.1'
         >>> metagenome_annotations[0]['was_informed_by']
         'nmdc:dgns-00-000001'
         >>> metagenome_annotations[0]['has_input'][0]
@@ -182,7 +182,7 @@ class Faker:
 
         return [
             {
-                "id": self.make_unique_id(f"nmdc:wfmgan-00-"),
+                "id": self.make_unique_id(f"nmdc:wfmgan-00-") + ".1",
                 "type": "nmdc:MetagenomeAnnotation",
                 "execution_resource": "JGI",
                 "git_url": "https://www.example.com",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -507,8 +507,12 @@ def test_post_workflows_workflow_executions_rejects_document_containing_broken_r
     # (a) that `data_object_set` document and (b) a non-existent `data_generation_set` document.
     faker = Faker()
     nonexistent_data_generation_id = "nmdc:dgns-00-000001"
-    data_object = faker.generate_data_objects(1)[0]
-    workflow_execution = faker.generate_metagenome_annotations(1, was_informed_by=nonexistent_data_generation_id, has_input=[data_object["id"]])[0]
+    data_object = faker.generate_data_objects(quantity=1)[0]
+    workflow_execution = faker.generate_metagenome_annotations(
+        quantity=1,
+        has_input=[data_object["id"]],
+        was_informed_by=nonexistent_data_generation_id,  # intentionally-broken reference
+    )[0]
     
     # Make sure the `workflow_execution_set`, `data_generation_set`, and `data_object_set` collections
     # don't already contain documents like the ones involved in this test.

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -455,10 +455,10 @@ def test_submit_changesheet():
     assert True
 
 
-def test_submit_workflow_activities(api_site_client):
+def test_post_workflows_workflow_executions_inserts_submitted_document(api_site_client):
     r"""
     In this test, we submit a workflow execution to the `/workflows/workflow_executions` API endpoint,
-    and confirm the endpoint returns a success response.
+    and then confirm that that workflow execution has been inserted into the database.
     """
 
     # Generate a `workflow_execution_set` document and the other kinds of documents necessary
@@ -566,8 +566,8 @@ def test_post_workflows_workflow_executions_rejects_document_containing_broken_r
 
     # Assert that the "detail" property of the response payload contains the words "errors",
     # "workflow_execution_set" (i.e. the problematic collection), and "was_informed_by"
-    # (i.e. the problematic field), but not "has_input" or "has_output" (i.e. a referring
-    # fields having no referential integrity issues).
+    # (i.e. the problematic field), but not "has_input" or "has_output" (i.e. referring
+    # fields that do not have any referential integrity issues).
     assert "detail" in response.json()
     detail_str = response.json()["detail"]
     assert isinstance(detail_str, str)

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -456,45 +456,68 @@ def test_submit_changesheet():
 
 
 def test_submit_workflow_activities(api_site_client):
-    test_collection, test_id = (
-        "workflow_execution_set",
-        "nmdc:wfrqc-11-t0tvnp52.2",
-    )
-    test_payload = {
-        test_collection: [
-            {
-                "id": test_id,
-                "name": "Read QC Activity for nmdc:wfrqc-11-t0tvnp52.1",
-                "started_at_time": "2024-01-11T20:48:30.718133+00:00",
-                "ended_at_time": "2024-01-11T21:11:44.884260+00:00",
-                "was_informed_by": "nmdc:omprc-11-9mvz7z22",
-                "execution_resource": "NERSC-Perlmutter",
-                "git_url": "https://github.com/microbiomedata/ReadsQC",
-                "has_input": ["nmdc:dobj-11-gpthnj64"],
-                "has_output": [
-                    "nmdc:dobj-11-w5dak635",
-                    "nmdc:dobj-11-g6d71n77",
-                    "nmdc:dobj-11-bds7qq03",
-                ],
-                "type": "nmdc:ReadQcAnalysis",
-                "version": "v1.0.8",
-            }
-        ]
-    }
+    r"""
+    In this test, we submit a workflow execution to the `/workflows/workflow_executions` API endpoint,
+    and confirm the endpoint returns a success response.
+    """
+
+    # Generate a `workflow_execution_set` document and the other kinds of documents necessary
+    # in order to have referential integrity (i.e. generate all "referenced" documents).
+    faker = Faker()
+    study = faker.generate_studies(quantity=1)[0]
+    biosample = faker.generate_biosamples(quantity=1, associated_studies=[study["id"]])[0]
+    data_object_a, data_object_b = faker.generate_data_objects(quantity=2)
+    data_generation = faker.generate_nucleotide_sequencings(
+        quantity=1,
+        associated_studies=[study["id"]],
+        has_input=[biosample["id"]]
+    )[0]
+    workflow_execution = faker.generate_metagenome_annotations(
+        quantity=1,
+        has_input=[data_object_a["id"]],
+        has_output=[data_object_b["id"]],  # schema says field optional; but validator complains when absent
+        was_informed_by=data_generation["id"],
+    )[0]
+
+    # Make sure the `study_set`, `biosample_set`, `data_object_set`, `data_generation_set`, and
+    # `workflow_execution_set` collections don't already contain documents having those IDs.
     mdb = get_mongo_db()
-    if doc_to_restore := mdb[test_collection].find_one({"id": test_id}):
-        mdb[test_collection].delete_one({"id": test_id})
-    rv = api_site_client.request(
+    study_set = mdb.get_collection("study_set")
+    biosample_set = mdb.get_collection("biosample_set")
+    data_object_set = mdb.get_collection("data_object_set")
+    data_generation_set = mdb.get_collection("data_generation_set")
+    workflow_execution_set = mdb.get_collection("workflow_execution_set")
+    assert study_set.count_documents({"id": study["id"]}) == 0
+    assert biosample_set.count_documents({"id": biosample["id"]}) == 0
+    assert data_object_set.count_documents({"id": {"$in": [data_object_a["id"], data_object_b["id"]]}}) == 0
+    assert data_generation_set.count_documents({"id": data_generation["id"]}) == 0
+    assert workflow_execution_set.count_documents({"id": workflow_execution["id"]}) == 0
+
+    # Insert the "referenced" documents into the database.
+    study_set.insert_one(study)
+    biosample_set.insert_one(biosample)
+    data_object_set.insert_many([data_object_a, data_object_b])
+    data_generation_set.insert_one(data_generation)
+
+    # Submit an API request whose payload contains the `workflow_execution_set` document.
+    request_payload = {"workflow_execution_set": [workflow_execution]}
+    response = api_site_client.request(
         "POST",
         "/workflows/workflow_executions",
-        test_payload,
+        request_payload,
     )
-    assert rv.json() == {"message": "jobs accepted"}
-    rv = api_site_client.request("GET", f"/nmdcschema/ids/{test_id}")
-    mdb[test_collection].delete_one({"id": test_id})
-    if doc_to_restore:
-        mdb[test_collection].insert_one(doc_to_restore)
-    assert "id" in rv.json() and "input_read_count" not in rv.json()
+    assert response.status_code == 200
+    assert response.json() == {"message": "jobs accepted"}
+
+    # Assert that the `workflow_execution_set` collection now contains the document we submitted.
+    assert workflow_execution_set.count_documents({"id": workflow_execution["id"]}) == 1
+
+    # 🧹 Clean up.
+    study_set.delete_many({"id": study["id"]})
+    biosample_set.delete_many({"id": biosample["id"]})
+    data_object_set.delete_many({"id": {"$in": [data_object_a["id"], data_object_b["id"]]}})
+    data_generation_set.delete_many({"id": data_generation["id"]})
+    workflow_execution_set.delete_many({"id": workflow_execution["id"]})
 
 
 def test_post_workflows_workflow_executions_rejects_document_containing_broken_reference(api_site_client):
@@ -507,10 +530,11 @@ def test_post_workflows_workflow_executions_rejects_document_containing_broken_r
     # (a) that `data_object_set` document and (b) a non-existent `data_generation_set` document.
     faker = Faker()
     nonexistent_data_generation_id = "nmdc:dgns-00-000001"
-    data_object = faker.generate_data_objects(quantity=1)[0]
+    data_object_a, data_object_b = faker.generate_data_objects(quantity=2)
     workflow_execution = faker.generate_metagenome_annotations(
         quantity=1,
-        has_input=[data_object["id"]],
+        has_input=[data_object_a["id"]],
+        has_output=[data_object_b["id"]],  # schema says field optional; but validator complains when absent
         was_informed_by=nonexistent_data_generation_id,  # intentionally-broken reference
     )[0]
     
@@ -521,12 +545,12 @@ def test_post_workflows_workflow_executions_rejects_document_containing_broken_r
     data_object_set = mdb.get_collection("data_object_set")
     workflow_execution_set = mdb.get_collection("workflow_execution_set")
     assert data_generation_set.count_documents({"id": nonexistent_data_generation_id}) == 0
-    assert data_object_set.count_documents({"id": data_object["id"]}) == 0
+    assert data_object_set.count_documents({"id": {"$in": [data_object_a["id"], data_object_b["id"]]}}) == 0
     assert workflow_execution_set.count_documents({"id": workflow_execution["id"]}) == 0
 
-    # Insert the referenced `data_object_set` document into the database. Notice that we are
+    # Insert the referenced `data_object_set` documents into the database. Notice that we are
     # not inserting any `data_generation_set` documents into the database.
-    data_object_set.insert_one(data_object)
+    data_object_set.insert_many([data_object_a, data_object_b])
 
     # Submit an API request whose payload contains the `workflow_execution_set` document, which
     # contains a broken reference.
@@ -541,20 +565,23 @@ def test_post_workflows_workflow_executions_rejects_document_containing_broken_r
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # Assert that the "detail" property of the response payload contains the words "errors",
-    # "workflow_execution_set" (i.e. the problematic collection),
-    # and "was_informed_by" (i.e. the problematic field).
+    # "workflow_execution_set" (i.e. the problematic collection), and "was_informed_by"
+    # (i.e. the problematic field), but not "has_input" or "has_output" (i.e. a referring
+    # fields having no referential integrity issues).
     assert "detail" in response.json()
     detail_str = response.json()["detail"]
     assert isinstance(detail_str, str)
     assert "errors" in detail_str
     assert "workflow_execution_set" in detail_str
     assert "was_informed_by" in detail_str
+    assert "has_input" not in detail_str
+    assert "has_output" not in detail_str
 
     # Assert that the `workflow_execution_set` collection still does not contain the document we submitted.
     assert workflow_execution_set.count_documents({"id": workflow_execution["id"]}) == 0
 
     # 🧹 Clean up.
-    data_object_set.delete_many({"id": data_object["id"]})
+    data_object_set.delete_many({"id": {"$in": [data_object_a["id"], data_object_b["id"]]}})
 
 
 def test_get_class_name_and_collection_names_by_doc_id():


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I added referential integrity checking to the request validation performed by the `POST /workflows/workflow_executions` API endpoint.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I also added a test that targets this referential integrity checking, and updated the existing test so that it would no longer insert a document having broken references. Indeed, most of the changed lines on this branch are test-related.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #960 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by ensuring the newly-added test passes locally.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
