### PR TITLE
Create "release jobs" endpoint

### DIFF
--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -2,7 +2,7 @@ import json
 from typing import Optional, Annotated
 
 import pymongo
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException, Path
 from pymongo.errors import ConnectionFailure, OperationFailure
 from starlette import status
 
@@ -63,7 +63,14 @@ def claim_job(
     "/jobs/{job_id}:release", response_model=Job, response_model_exclude_unset=True
 )
 def release_job(
-    job_id: str,
+    job_id: Annotated[
+        str,
+        Path(
+            title="Job ID",
+            description="The `id` of the job you want to release.\n\n_Example_: `nmdc:f81d4fae-7dec-11d0-a765-00a0c91e6bf6`",
+            examples=["nmdc:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"],
+        ),
+    ],
     mdb: pymongo.database.Database = Depends(get_mongo_db),
     site: Site = Depends(get_current_client_site),
 ):

--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -67,7 +67,7 @@ def release_job(
         str,
         Path(
             title="Job ID",
-            description="The `id` of the job you want to release.\n\n_Example_: `nmdc:f81d4fae-7dec-11d0-a765-00a0c91e6bf6`",
+            description="The `id` of the job.\n\n_Example_: `nmdc:f81d4fae-7dec-11d0-a765-00a0c91e6bf6`",
             examples=["nmdc:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"],
         ),
     ],

--- a/nmdc_runtime/api/models/job.py
+++ b/nmdc_runtime/api/models/job.py
@@ -16,6 +16,8 @@ class JobBase(BaseModel):
 class JobClaim(BaseModel):
     op_id: str
     site_id: str
+    done: Optional[bool] = None
+    cancelled: Optional[bool] = None
 
 
 class Job(JobBase):

--- a/nmdc_runtime/api/models/operation.py
+++ b/nmdc_runtime/api/models/operation.py
@@ -48,6 +48,7 @@ class EmptyResult(Result):
 class Metadata(BaseModel):
     # XXX alternative: set model field using __class__ on __init__()?
     model: Optional[PythonImportPath] = None
+    cancelled: Optional[bool] = None
 
 
 class PausedOrNot(Metadata):


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I add a `POST /jobs/{job_id}:release` endpoint that:
- cancels the (authenticated) requesting `site`'s `claims` for a `job`, i.e. marks `operations` identified by `op_id` in the job's claims array as `cancelled`
- updates the contents of job's document-local claims array to reflect the cancellation (aka release) of these claims.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Executes a MongoDB transaction to ensure atomic change of the job document along with the relevant set of operations documents.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Closes #951

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by adding `test_release_job` to `tests/test_api/test_endpoints.py`.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
