### PR TITLE
Create indexes on `has_input`/`has_output` in `workflow_execution_set`

### DIFF
--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -319,6 +319,20 @@ def ensure_initial_resources_on_boot():
 
 
 def ensure_attribute_indexes():
+    r"""
+    Ensures that the MongoDB collection identified by each key (i.e. collection name) in the
+    `entity_attributes_to_index` dictionary, has an index on each field identified by the value
+    (i.e. set of field names) associated with that key.
+
+    Example dictionary (notice each item's value is a _set_, not a _dict_):
+    ```
+    {
+        "coll_name_1": {"field_name_1"},
+        "coll_name_2": {"field_name_1", "field_name_2"},
+    }
+    ```
+    """
+
     mdb = get_mongo_db()
     for collection_name, index_specs in entity_attributes_to_index.items():
         for spec in index_specs:

--- a/nmdc_runtime/api/models/util.py
+++ b/nmdc_runtime/api/models/util.py
@@ -210,6 +210,9 @@ entity_attributes_to_index = {
         "md5_checksum",
         "url",
     },
+    # TODO: Refrain from ensuring indexes exist in the `omics_processing_set` collection,
+    #       since that collection was deleted as part of the "Berkeley schema" refactor.
+    #       Reference: https://microbiomedata.github.io/nmdc-schema/v10-vs-v11-retrospective/#slots-removed-from-database
     "omics_processing_set": {
         "has_input",
         "has_output",
@@ -217,4 +220,8 @@ entity_attributes_to_index = {
         "alternative_identifiers",
     },
     "functional_annotation_agg": {"was_generated_by"},
+    "workflow_execution_set": {
+        "has_input",
+        "has_output",
+    },
 }


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the Runtime's bootup code so that it would ensure that MongoDB indexes exist on the `has_input` and `has_output` fields in the `workflow_execution_set` collection.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I also added a `TODO` comment about removing code related to an obsolete collection. Finally, I added a docstring to a function that lacked one.

Note: I made a typo (i.e. "createrd" instead of "create") in the commit message.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #971 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I manually created the `has_output` index in the MongoDB database (both in the development environment and the production environment) via Studio 3T as part of a recent urgent task and found that it drastically sped up [this aggregation query](https://github.com/microbiomedata/issues/issues/1159#issuecomment-2831521710).

I did not test the creation of the `has_input` index. However, since the Runtime creates the indexes with the `background=True` kwarg, I don't expect the initial index creation process to "block" anything.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
