### PR TITLE
Move endpoint definition and add guard clause; improve exception detail readability; add utility endpoint

### DIFF
--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -40,7 +40,7 @@ def ensure_collection_name_is_known_to_schema(collection_name: str):
     if collection_name not in names:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Collection name must be one of {names}",
+            detail=f"Collection name must be one of {sorted(names)}",
         )
 
 
@@ -107,55 +107,6 @@ def get_nmdc_database_collection_stats(
         ):
             stats.append(doc)
     return stats
-
-
-@router.get(
-    "/nmdcschema/{collection_name}",
-    response_model=ListResponse[Doc],
-    response_model_exclude_unset=True,
-)
-def list_from_collection(
-    collection_name: Annotated[
-        str,
-        Path(
-            title="Collection name",
-            description="The name of the collection.\n\n_Example_: `biosample_set`",
-            examples=["biosample_set"],
-        ),
-    ],
-    req: Annotated[ListRequest, Query()],
-    mdb: MongoDatabase = Depends(get_mongo_db),
-):
-    r"""
-    Retrieves resources that match the specified filter criteria and reside in the specified collection.
-
-    Searches the specified collection for documents matching the specified `filter` criteria.
-    If the `projection` parameter is used, each document in the response will only include
-    the fields specified by that parameter (plus the `id` field).
-
-    You can get all the valid collection names from the [Database class](https://microbiomedata.github.io/nmdc-schema/Database/)
-    page of the NMDC Schema documentation.
-
-    Note: If the specified maximum page size is a number greater than zero, and _more than that number of resources_
-          in the collection match the filter criteria, this endpoint will paginate the resources. Pagination can take
-          a long time—especially for collections that contain a lot of documents (e.g. millions).
-
-    **Tips:**
-    1. When the filter includes a regex and you're using that regex to match the beginning of a string, try to ensure
-       the regex is a [prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use),
-       That will allow MongoDB to optimize the way it uses the regex, making this API endpoint respond faster.
-    """
-
-    # TODO: The note about collection names above is currently accurate, but will not necessarily always be accurate,
-    #       since the `Database` class could eventually have slots that aren't `multivalued` and `inlined_as_list`,
-    #       which are traits a `Database` slot must have in order for it to represent a MongoDB collection.
-    #
-    # TODO: Implement an API endpoint that returns all valid collection names (it can get them via a `SchemaView`),
-    #       Then replace the note above with a suggestion that the user access that API endpoint.
-
-    rv = list_resources(req, mdb, collection_name)
-    rv["resources"] = [strip_oid(d) for d in rv["resources"]]
-    return rv
 
 
 @router.get(
@@ -290,6 +241,48 @@ def get_collection_name_by_doc_id(
 
 
 @router.get(
+    "/nmdcschema/{collection_name}",
+    response_model=ListResponse[Doc],
+    response_model_exclude_unset=True,
+)
+def list_from_collection(
+    collection_name: Annotated[
+        str,
+        Path(
+            title="Collection name",
+            description="The name of the collection.\n\n_Example_: `biosample_set`",
+            examples=["biosample_set"],
+        ),
+    ],
+    req: Annotated[ListRequest, Query()],
+    mdb: MongoDatabase = Depends(get_mongo_db),
+):
+    r"""
+    Retrieves resources that match the specified filter criteria and reside in the specified collection.
+
+    Searches the specified collection for documents matching the specified `filter` criteria.
+    If the `projection` parameter is used, each document in the response will only include
+    the fields specified by that parameter (plus the `id` field).
+
+    Note: If the specified maximum page size is a number greater than zero, and _more than that number of resources_
+          in the collection match the filter criteria, this endpoint will paginate the resources. Pagination can take
+          a long time—especially for collections that contain a lot of documents (e.g. millions).
+
+    **Tips:**
+    1. When the filter includes a regex and you're using that regex to match the beginning of a string, try to ensure
+       the regex is a [prefix expression](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use),
+       That will allow MongoDB to optimize the way it uses the regex, making this API endpoint respond faster.
+    """
+
+    # raise HTTP_400_BAD_REQUEST on invalid collection_name
+    ensure_collection_name_is_known_to_schema(collection_name)
+
+    rv = list_resources(req, mdb, collection_name)
+    rv["resources"] = [strip_oid(d) for d in rv["resources"]]
+    return rv
+
+
+@router.get(
     "/nmdcschema/{collection_name}/{doc_id}",
     response_model=Doc,
     response_model_exclude_unset=True,
@@ -328,7 +321,7 @@ def get_from_collection_by_id(
     Retrieves the document having the specified `id`, from the specified collection; optionally, including only the
     fields specified via the `projection` parameter.
     """
-    # Note: This helper function will raise an exception if the collection name is invalid.
+    # raise HTTP_400_BAD_REQUEST on invalid collection_name
     ensure_collection_name_is_known_to_schema(collection_name)
 
     projection = comma_separated_values(projection) if projection else None

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -241,6 +241,19 @@ def get_collection_name_by_doc_id(
 
 
 @router.get(
+    "/nmdcschema/collection_names",
+    response_model=List[str],
+    status_code=status.HTTP_200_OK,
+)
+def get_collection_names():
+    """
+    Return all valid NMDC Schema collection names, i.e. the names of the slots of [the nmdc:Database class](
+    https://w3id.org/nmdc/Database/) that describe database collections.
+    """
+    return sorted(get_collection_names_from_schema())
+
+
+@router.get(
     "/nmdcschema/{collection_name}",
     response_model=ListResponse[Doc],
     response_model_exclude_unset=True,
@@ -263,6 +276,10 @@ def list_from_collection(
     Searches the specified collection for documents matching the specified `filter` criteria.
     If the `projection` parameter is used, each document in the response will only include
     the fields specified by that parameter (plus the `id` field).
+
+    Use the [`GET /nmdcschema/collection_names`](/nmdcschema/collection_names) API endpoint to return all valid
+    collection names, i.e. the names of the slots of [the nmdc:Database class](https://w3id.org/nmdc/Database/) that
+    describe database collections.
 
     Note: If the specified maximum page size is a number greater than zero, and _more than that number of resources_
           in the collection match the filter criteria, this endpoint will paginate the resources. Pagination can take


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I move the definition of `GET /nmdcschema/{collection_name}` lower in its module, I add a small utility endpoint `GET /nmdcschema/collection_names`, and I add a guard clause to the body of `GET/nmdcschema/{collection_name}` for early exit in case the collection name given is invalid.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Motivation in #975. Also, addressed outstanding `TODO`s in `GET /nmdcschema/{collection_name}`.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Closes #975.

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by inspection of e.g.
```zsh
curl 'http://localhost:8000/nmdcschema/studies' | jq
```

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [x] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
