### PR TITLE
Refactor to avoid separate build step for `test` service container

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -83,9 +83,7 @@ jobs:
 #      run: |
 #        pip install flake8
 #        make lint
-    - name: Build and run containers upon which test runner depends
+    - name: Build and start containers upon which test runner depends
       run: make up-test
-    - name: Build container image for test runner
-      run: make test-build
     - name: Run tests
-      run: make test-run
+      run: make run-test

--- a/Makefile
+++ b/Makefile
@@ -38,41 +38,55 @@ update: update-deps init
 up-dev:
 	docker compose up --build --force-recreate --detach --remove-orphans
 
+down-dev:
+	docker compose down
+
 # Restores the MongoDB dump residing in `./tests/nmdcdb` on the Docker host, into the MongoDB server in the dev stack.
-dev-reset-db:
+reset-db-dev:
 	docker compose \
 		exec mongo /bin/bash -c "/mongorestore-nmdc-testdb.sh"
 
 # Uses Docker Compose to build and spin up the stack upon which the `test` container (i.e. the test runner) depends.
-#
-# Note: This does not build or spin up the `test` container, itself, since the `test` container's Docker Compose service
-#       has the "donotstart" profile specified for it in `docker-compose.test.yml`.
-#
 up-test:
 	docker compose --file docker-compose.test.yml \
 		up --build --force-recreate --detach --remove-orphans
 
-# Uses Docker Compose to build the container image for the `test` container (i.e. the test runner).
-test-build:
-	docker compose --file docker-compose.test.yml build test
+# Tears down the `test` stack, including removing data volumes such as that for the test MongoDB database.
+down-test:
+	docker compose --file docker-compose.test.yml down --volumes
 
 # Restores the MongoDB dump residing in `./tests/nmdcdb` on the Docker host, into the MongoDB server in the test stack.
-test-reset-db:
+reset-db-test:
 	docker compose --file docker-compose.test.yml \
 		exec mongo /bin/bash -c "/mongorestore-nmdc-testdb.sh"
 
-# Uses Docker Compose to spin up the `test` container (i.e. the test runner), effectively running the tests.
+# Run tests on the started `test` stack, passing `ARGS` to `pytest` (see Tip below).
 #
 # Tip: If you append `ARGS=` and a file path to the `make` command, pytest will run only the tests defined in that file.
-#      For example, to run only the tests defined in `tests/test_api/test_endpoints.py`:
+#
+#      Some examples, using `make test`:
+#      (You can also use `make run-test` if are sure you don't need to reset global state)
+#
+#      To run only the tests defined in `tests/test_api/test_endpoints.py`:
 #      ```
-#      $ make test-run ARGS="tests/test_api/test_endpoints.py"
+#      $ make test ARGS="tests/test_api/test_endpoints.py"
 #      ```
 #
-test-run:
-	docker compose --file docker-compose.test.yml run test $(ARGS)
+#      To run only the test `test_find_data_objects_for_study_having_one` in `tests/test_api/test_endpoints.py`:
+#      ```
+#      $ make test ARGS="-k 'test_find_data_objects_for_study_having_one'"
+#      ```
+#
+run-test:
+	docker compose --file docker-compose.test.yml exec -it test \
+		./.docker/wait-for-it.sh fastapi:8000 --strict --timeout=300 -- pytest --cov=nmdc_runtime \
+		$(ARGS)
 
-test: test-build test-run
+# Uses Docker Compose to
+# 1. Ensure the `test` stack is torn down, including data volumes such as that of the test MongoDB database.
+# 2. Build and spin up the stack upon which the `test` container (i.e. the test runner) depends.
+# 3. Run tests on the `test` container, passing `ARGS` to `pytest` (see Tip in comment above for `run-test` target).
+test: down-test up-test run-test
 
 black:
 	black nmdc_runtime
@@ -91,24 +105,8 @@ init-lint-and-black:
 	pip install $(PIP_PINNED_FLAKE8)
 	pip install $(PIP_PINNED_BLACK)
 
-down-dev:
-	docker compose down
-
-down-test:
-	docker compose --file docker-compose.test.yml down --volumes
-
 follow-fastapi:
 	docker compose logs fastapi -f
-
-fastapi-deploy-spin:
-	rancher kubectl rollout restart deployment/runtime-fastapi --namespace=nmdc-dev
-
-dagster-deploy-spin:
-	rancher kubectl rollout restart deployment/dagit --namespace=nmdc-dev
-	rancher kubectl rollout restart deployment/dagster-daemon --namespace=nmdc-dev
-
-publish:
-	invoke publish
 
 docs-dev:
 	mkdocs serve -a localhost:8080
@@ -139,7 +137,14 @@ mongorestore-nmdc-db:
 	# export MONGO_REMOTE_DUMP_DIR=$(ssh -i ~/.ssh/nersc -q ${NERSC_USERNAME}@dtn01.nersc.gov 'bash -s ' < util/get_latest_nmdc_prod_dump_dir.sh 2>/dev/null)
 	# ```
 	# Rsync the remote dump directory items of interest:
-	rsync -av --no-perms --exclude='_*' --exclude='fs\.*' \
+	rsync -av --no-perms \
+		--exclude='*_agg\.*' \
+		--exclude='operations\.*' \
+		--exclude='_*' \
+		--exclude='ids_nmdc_sys0\.*' \
+		--exclude='query_runs\.*' \
+		--exclude='fs\.*' \
+		--exclude="alldocs\.*" \
 		-e "ssh -i ~/.ssh/nersc" \
 		${NERSC_USERNAME}@dtn01.nersc.gov:${MONGO_REMOTE_DUMP_DIR}/nmdc/ \
 		/tmp/remote-mongodump/nmdc

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -117,21 +117,17 @@ services:
 
   # Test runner.
   test:
-    # Prevent Docker Compose from starting this service automatically.
-    # Reference: https://stackoverflow.com/a/65957695
-    profiles:
-      - donotstart
     build:
       context: .
       dockerfile: nmdc_runtime/Dockerfile
       target: test
-    env_file: .env.test
     depends_on:
       mongo-init: { condition: service_completed_successfully }
       mongo: { condition: service_started }
       fastapi: { condition: service_started }
       dagster-daemon: { condition: service_started }
       dagster-dagit: { condition: service_started }
+    env_file: .env.test
     volumes:
       - .:/code
 

--- a/nmdc_runtime/Dockerfile
+++ b/nmdc_runtime/Dockerfile
@@ -122,6 +122,9 @@ RUN cd /code && \
 # Make `wait-for-it.sh` executable.
 RUN chmod +x /code/.docker/wait-for-it.sh
 
-# Use `wait-for-it.sh` to run `pytest` as soon as the FastAPI server is accessible.
 WORKDIR /code
-ENTRYPOINT ["./.docker/wait-for-it.sh", "fastapi:8000", "--strict", "--timeout=300", "--", "pytest", "--cov=nmdc_runtime"]
+
+# Ensure started container does not exit, so that a subsequent `docker exec` command can run tests.
+# For an example `docker exec` command, see `Makefile`'s `test-exec` target.
+# Such a command should use `wait-for-it.sh` to run `pytest` no earlier than when the FastAPI server is accessible.
+ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I refactor `nmdc_runtime/Dockerfile`, `Makefile`, `docker-comppose.test.yml`, and `.github/workflows/python-app.yml` to avoid a separate build step for the `test` service container. I also remove `nmdc_runtime/test.Dockerfile` (which is empty).


### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Close #978

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

Testing apparatus.

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running `make test [ARGS="..."]` and ensuring GH CI performs as expected automatically for this PR.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [x] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

Inline `Makefile` and `Dockerfile` documentation.

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
