### PR TITLE
Add test showing referential integrity check during pending transaction

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -1,3 +1,20 @@
+# This file contains a list of the direct (as opposed to transitive) production dependencies of
+# the `nmdc_runtime` package. We use `pip-compile` (typically via `$ make update-deps`) to derive
+# the "requirements.txt" file from this file.
+#
+# Reference: https://github.com/jazzband/pip-tools?tab=readme-ov-file#requirements-from-requirementsin
+#
+# Note: To specify that a Python package be built from the contents of a GitHub repository (which can
+#       be useful for integration testing before that Python package gets published to PyPI), you can
+#       use the following syntax in this file:
+#       ```
+#       {package_name} @ git+https://github.com/{owner}/{repo}.git@{commit}
+#       ```
+#       For example:
+#       ```
+#       refscan @ git+https://github.com/microbiomedata/refscan.git@b4f6bab138d2158ece7ea2423a27d8b8493d02f5
+#       ```
+#
 base32-lib
 beautifulsoup4
 beanie>=1.16.0
@@ -39,7 +56,7 @@ python-multipart>=0.0.18
 pyyaml
 # Note: We use `refscan` to get information about inter-document references from the schema and database.
 #       Reference: https://pypi.org/project/refscan/
-refscan==0.2.0
+refscan==0.2.4
 requests
 semver
 setuptools-scm

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -21,8 +21,6 @@ anyio==4.8.0
     #   jupyter-server
     #   starlette
     #   watchfiles
-appnope==0.1.4
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -204,6 +202,8 @@ graphql-relay==3.2.0
     # via graphene
 graphviz==0.20.3
     # via linkml
+greenlet==3.2.1
+    # via sqlalchemy
 grpcio==1.71.0
     # via
     #   dagster
@@ -655,7 +655,7 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-refscan==0.2.0
+refscan==0.2.4
     # via -r requirements/main.in
 requests==2.32.3
     # via


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I implemented a test **demonstrating** how someone can determine whether changes to the database being made via a transaction would introduce a referential integrity violation, and then abort the transaction if they would.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Specifically, in the test, I create two studies—one that is `part_of` the other—and then I start a transaction. In the transaction, I "stage" the deletion of the _referenced_ study and perform a referential integrity check. Finally, when I see that there is a referential integrity violation, I abort the transaction and confirm the referenced study did not really get deleted.

I also updated the `refscan` package to a version that supports transactions. It was released earlier today.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #974 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running the following sequence of commands and confirming the newly-added test passes.

```shell
make up-test && make test-build
docker compose -f docker-compose.test.yml down --volumes mongo
make test-run ARGS='tests/test_the_util/test_the_util.py -k test_referential_integrity_checker_supports_pending_mongo_transactions'
```

I will also confirm that all tests run by GHA pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
