### PR TITLE
Update `/queries:run` API endpoint so only users having specific allowance can run aggregation command

### DIFF
--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -48,7 +48,6 @@ def check_can_update_and_delete(user: User):
 
 
 def check_can_aggregate(user: User):
-    # aggregate queries require same level of permissions
     if not check_action_permitted(
         user.username, "/queries:run(query_cmd:AggregateCommand)"
     ):

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -45,7 +45,16 @@ def check_can_update_and_delete(user: User):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only specific users are allowed to issue update and delete commands.",
         )
-
+    
+def check_can_aggregate(user: User):
+    # aggregate queries require same level of permissions
+    if not check_action_permitted(
+        user.username, "/queries:run(query_cmd:AggregateCommand)"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only specific users are allowed to issue aggregate commands.",
+        )
 
 # Note: We set `response_model_exclude_unset=True` so that all the properties of the `CommandResponseOptions` object
 #       that we don't explicitly assign values to while handling the HTTP request, are omitted from the HTTP response.
@@ -172,6 +181,11 @@ def run_query(
     # Note: The permission-checking function will raise an exception if the user lacks those permissions.
     if isinstance(cmd, (DeleteCommand, UpdateCommand)):
         check_can_update_and_delete(user)
+
+    # check if the user has permission to run aggregate commands
+    if isinstance(cmd, AggregateCommand):
+        check_can_aggregate(user)
+
     cmd_response = _run_mdb_cmd(cmd)
     return cmd_response
 

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -45,7 +45,8 @@ def check_can_update_and_delete(user: User):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only specific users are allowed to issue update and delete commands.",
         )
-    
+
+
 def check_can_aggregate(user: User):
     # aggregate queries require same level of permissions
     if not check_action_permitted(
@@ -55,6 +56,7 @@ def check_can_aggregate(user: User):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only specific users are allowed to issue aggregate commands.",
         )
+
 
 # Note: We set `response_model_exclude_unset=True` so that all the properties of the `CommandResponseOptions` object
 #       that we don't explicitly assign values to while handling the HTTP request, are omitted from the HTTP response.

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1559,7 +1559,13 @@ def test_run_query_aggregate__first_batch_and_its_cursor_id(api_user_client):
     faker = Faker()
     studies = faker.generate_studies(6, title=study_title)
     study_set.insert_many(studies)
-
+    mdb = get_mongo_db()
+    # give user permission to run aggregate queries
+    allow_spec = {
+        "username": api_user_client.username,
+        "action": "/queries:run(query_cmd:AggregateCommand)",
+    }
+    mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
     # Test case 1: When the first batch is empty, its `cursor.id` is null.
     response = api_user_client.request(
         "POST",
@@ -1676,7 +1682,12 @@ def test_run_query_aggregate__second_batch_and_its_cursor_id(api_user_client):
     faker = Faker()
     studies = faker.generate_studies(6, title=study_title)
     study_set.insert_many(studies)
-
+    # give user permission to run aggregate queries
+    allow_spec = {
+        "username": api_user_client.username,
+        "action": "/queries:run(query_cmd:AggregateCommand)",
+    }
+    mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
     # Test case 1: When the second batch is empty, its `cursor.id` is null.
     response = api_user_client.request(
         "POST",
@@ -1846,7 +1857,12 @@ def test_run_query_aggregate__three_batches_and_their_items(api_user_client):
     )
     study_set.insert_many(studies)
     biosample_set.insert_many(biosamples)
-
+    # give user permission to run aggregate queries
+    allow_spec = {
+        "username": api_user_client.username,
+        "action": "/queries:run(query_cmd:AggregateCommand)",
+    }
+    mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
     # Fetch the first batch of biosamples associated with the study.
     #
     # References:
@@ -1972,7 +1988,12 @@ def test_run_query_aggregate__cursor_id_is_null_when_any_document_lacks_undersco
     faker = Faker()
     studies = faker.generate_studies(6, title=study_title)
     study_set.insert_many(studies)
-
+    # give user permission to run aggregate queries
+    allow_spec = {
+        "username": api_user_client.username,
+        "action": "/queries:run(query_cmd:AggregateCommand)",
+    }
+    mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
     # Fetch the first batch of 5 and confirm the `cursor.id` is null,
     # even though we didn't receive all 6 items.
     response = api_user_client.request(

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1630,7 +1630,7 @@ def test_run_query_aggregate__first_batch_and_its_cursor_id(api_user_client):
     faker = Faker()
     studies = faker.generate_studies(6, title=study_title)
     study_set.insert_many(studies)
-    mdb = get_mongo_db()
+
     # give user permission to run aggregate queries
     allow_spec = {
         "username": api_user_client.username,
@@ -1753,6 +1753,7 @@ def test_run_query_aggregate__second_batch_and_its_cursor_id(api_user_client):
     faker = Faker()
     studies = faker.generate_studies(6, title=study_title)
     study_set.insert_many(studies)
+
     # give user permission to run aggregate queries
     allow_spec = {
         "username": api_user_client.username,
@@ -1928,6 +1929,7 @@ def test_run_query_aggregate__three_batches_and_their_items(api_user_client):
     )
     study_set.insert_many(studies)
     biosample_set.insert_many(biosamples)
+
     # give user permission to run aggregate queries
     allow_spec = {
         "username": api_user_client.username,
@@ -2059,6 +2061,7 @@ def test_run_query_aggregate__cursor_id_is_null_when_any_document_lacks_undersco
     faker = Faker()
     studies = faker.generate_studies(6, title=study_title)
     study_set.insert_many(studies)
+    
     # give user permission to run aggregate queries
     allow_spec = {
         "username": api_user_client.username,


### PR DESCRIPTION
On this branch, I edited /queries:run to check if a user trying to aggregate has the correct permissions. 

...

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->
Fixes #970 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running them locally and confirming they all pass. 

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
