### PR TITLE
Add referential integrity check to "delete" command of `POST /queries:run` API endpoint

### DIFF
--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -293,14 +293,23 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
                             f"Deleting the former will leave behind a broken reference."
                         )
                     else:
+                        # TODO: Consider reporting _all_ would-be-broken references instead of
+                        #       only the _first_ one we encounter. That would make the response
+                        #       more informative to the user in cases where there are multiple
+                        #       such references; but it would also take longer to compute and
+                        #       would increase the response size (consider the case where the
+                        #       user-specified filter matches many, many documents).
                         raise HTTPException(
                             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                             detail=(
-                                f"Cannot delete the document having 'id'='{target_document_id}' from "
-                                f"the collection '{collection_name}' because it is referenced by "
+                                f"The operation was not performed, because performing it would "
+                                f"have left behind one or more broken references. For example: "
+                                f"The document having 'id'='{target_document_id}' in "
+                                f"the collection '{collection_name}' is referenced by "
                                 f"the document having 'id'='{source_document_id}' in "
                                 f"the collection '{source_collection_name}'. "
-                                f"Deleting it would leave behind a broken reference."
+                                f"Deleting the former would leave behind a broken reference. "
+                                f"Update or delete referring document(s) and try again."
                             ),
                         )
 

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -224,15 +224,19 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
         #       not occur within a transaction. The database may change between the
         #       two events (i.e. there's a race condition).
         #
-        target_document_descriptors = list(mdb.get_collection(collection_name).find(
-            filter={"$or": [spec["filter"] for spec in delete_specs]},
-            projection={"_id": 1, "id": 1, "type": 1},
-        ))
+        target_document_descriptors = list(
+            mdb.get_collection(collection_name).find(
+                filter={"$or": [spec["filter"] for spec in delete_specs]},
+                projection={"_id": 1, "id": 1, "type": 1},
+            )
+        )
         finder = Finder(database=mdb)
 
         # Make a list of all of the (distinct) `_id` values up front, which we can consult
         # when processing _each_ target document descriptor later.
-        target_document_object_ids = list(set([tdd["_id"] for tdd in target_document_descriptors]))
+        target_document_object_ids = list(
+            set([tdd["_id"] for tdd in target_document_descriptors])
+        )
 
         for target_document_descriptor in target_document_descriptors:
             # If the document descriptor lacks the "id" field, we already know that no
@@ -250,7 +254,10 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
             # to delete, then we know that performing the deletion would leave behind
             # broken references. In that case, we abort with an HTTP 422 error response.
             for referring_document_descriptor in referring_document_descriptors:
-                if referring_document_descriptor["_id"] not in target_document_object_ids:
+                if (
+                    referring_document_descriptor["_id"]
+                    not in target_document_object_ids
+                ):
                     source_document_id = referring_document_descriptor[
                         "source_document_id"
                     ]

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -219,10 +219,12 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
         #       not occur within a transaction. The database may change between the
         #       two events (i.e. there's a race condition).
         #
-        target_document_descriptors = list(mdb[collection_name].find(
-            filter={"$or": [spec["filter"] for spec in delete_specs]},
-            projection={"_id": 1, "id": 1, "type": 1},
-        ))
+        target_document_descriptors = list(
+            mdb[collection_name].find(
+                filter={"$or": [spec["filter"] for spec in delete_specs]},
+                projection={"_id": 1, "id": 1, "type": 1},
+            )
+        )
 
         # Make a set of the `_id` values of the target documents so that (later) we can
         # check whether a given _referring_ document is also one of the _target_ documents

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -238,7 +238,9 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
 
         # Make a list of all of the `_id` values up front, which we will consult
         # later (when processing _each_ target document descriptor).
-        target_document_object_ids = [tdd["_id"] for tdd in distinct_target_document_descriptors]
+        target_document_object_ids = [
+            tdd["_id"] for tdd in distinct_target_document_descriptors
+        ]
 
         finder = Finder(database=mdb)
         for target_document_descriptor in distinct_target_document_descriptors:

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -256,7 +256,7 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                         detail=(
                             f"Cannot delete the document having 'id'='{target_document_id}' from "
-                            f"from the collection '{collection_name}' because it is referenced by "
+                            f"the collection '{collection_name}' because it is referenced by "
                             f"the document having 'id'='{source_document_id}' "
                             f"in the collection '{source_collection_name}'."
                         ),

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -251,7 +251,7 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
             # broken reference(s). In that case, we abort with an HTTP 422 error response.
             for referring_document_descriptor in referring_document_descriptors:
                 if (
-                    referring_document_descriptor["_id"]
+                    referring_document_descriptor["source_document_object_id"]
                     not in target_document_object_ids
                 ):
                     source_document_id = referring_document_descriptor[
@@ -266,8 +266,8 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
                         detail=(
                             f"Cannot delete the document having 'id'='{target_document_id}' from "
                             f"the collection '{collection_name}' because it is referenced by "
-                            f"the document having 'id'='{source_document_id}' "
-                            f"in the collection '{source_collection_name}'."
+                            f"the document having 'id'='{source_document_id}' in "
+                            f"the collection '{source_collection_name}'."
                         ),
                     )
 

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -235,7 +235,7 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
             )
             # If _any_ referring document is _not_ among the documents the user wants
             # to delete, then we know that performing the deletion would leave behind
-            # broken references.
+            # broken references. In that case, we abort with an HTTP 422 error response.
             for referring_document_descriptor in referring_document_descriptors:
                 if referring_document_descriptor["_id"] not in {
                     d["_id"] for d in target_document_descriptors

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -235,12 +235,17 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
         #          a descriptor for a given document the user wants to delete.
         #       2. Later, so we can quickly check whether a _referring_ document
         #          is among the documents the user wants to delete.
-        # 
+        #
         distinct_target_document_descriptors = []
         distinct_target_document_object_ids = set()
         for target_document_descriptor in target_document_descriptors:
-            if target_document_descriptor["_id"] not in distinct_target_document_object_ids:
-                distinct_target_document_object_ids.add(target_document_descriptor["_id"])
+            if (
+                target_document_descriptor["_id"]
+                not in distinct_target_document_object_ids
+            ):
+                distinct_target_document_object_ids.add(
+                    target_document_descriptor["_id"]
+                )
                 distinct_target_document_descriptors.append(target_document_descriptor)
 
         finder = Finder(database=mdb)

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -224,11 +224,13 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
         # by any documents that are _not_ among those documents. If any of them are,
         # it means that performing the deletion would leave behind a broken reference(s).
         #
-        # TODO: Account for the "limit" property of the delete specs.
+        # TODO: Consider accounting for the "limit" property of the delete specs.
+        #       Currently, we ignore it and—instead—perform the validation as though
+        #       the user wants to delete _all_ matching documents.
         #
-        # TODO: Account for the fact that this validation and the actual deletion do
-        #       not occur within a transaction. The database may change between the
-        #       two events (i.e. there's a race condition).
+        # TODO: Account for the fact that this validation step and the actual deletion
+        #       step do not occur within a transaction; so, the database may change
+        #       between the two events (i.e. there's a race condition).
         #
         target_document_descriptors = list(
             mdb[collection_name].find(

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -33,7 +33,12 @@ from nmdc_runtime.api.models.query import (
     CursorYieldingCommand,
 )
 from nmdc_runtime.api.models.user import get_current_active_user, User
-from nmdc_runtime.util import OverlayDB, validate_json, get_allowed_references, nmdc_schema_view
+from nmdc_runtime.util import (
+    OverlayDB,
+    validate_json,
+    get_allowed_references,
+    nmdc_schema_view,
+)
 
 router = APIRouter()
 
@@ -240,8 +245,12 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
                 if referring_document_descriptor["_id"] not in {
                     d["_id"] for d in target_document_descriptors
                 }:
-                    source_document_id = referring_document_descriptor["source_document_id"]
-                    source_collection_name = referring_document_descriptor["source_collection_name"]
+                    source_document_id = referring_document_descriptor[
+                        "source_document_id"
+                    ]
+                    source_collection_name = referring_document_descriptor[
+                        "source_collection_name"
+                    ]
                     target_document_id = target_document_descriptor["id"]
                     raise HTTPException(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -262,8 +262,8 @@ def _run_mdb_cmd(cmd: Cmd, mdb: MongoDatabase = _mdb) -> CommandResponse:
                 finder=finder,
             )
             # If _any_ referring document is _not_ among the documents the user wants
-            # to delete, then we know that performing the deletion would leave behind
-            # broken references. In that case, we abort with an HTTP 422 error response.
+            # to delete, then we know that performing the deletion would leave behind a
+            # broken reference(s). In that case, we abort with an HTTP 422 error response.
             for referring_document_descriptor in referring_document_descriptors:
                 if (
                     referring_document_descriptor["_id"]

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -56,7 +56,7 @@ python-multipart>=0.0.18
 pyyaml
 # Note: We use `refscan` to get information about inter-document references from the schema and database.
 #       Reference: https://pypi.org/project/refscan/
-refscan==0.2.4
+refscan==0.2.5
 requests
 semver
 setuptools-scm

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -647,7 +647,7 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-refscan==0.2.4
+refscan==0.2.5
     # via -r requirements/main.in
 requests==2.32.3
     # via

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -728,12 +728,18 @@ def test_get_related_ids_returns_empty_resources_list_for_isolated_subject(
 
 @pytest.fixture
 def fake_studies_and_biosamples_in_mdb():
-    # Seed the database with the following interrelated documents:
-    # - `study_a`
-    # - `study_b` --[part_of]-> `study_a`
-    # - `biosample_a` --[associated_studies]-> `study_a`
-    # - `biosample_b` --[associated_studies]-> `study_b`
-    #
+    # Seed the database with the following interrelated documents (represented
+    # here as a Mermaid graph/flowchart within a Markdown fenced code block):
+    # Docs: https://mermaid.js.org/syntax/flowchart.html
+    r"""
+    ```mermaid
+    graph BT
+        study_a
+        study_b --> |part_of| study_a
+        biosample_a --> |associated_studies| study_a
+        biosample_b --> |associated_studies| study_b
+    ```
+    """
     mdb = get_mongo_db()
     faker = Faker()
     study_a, study_b = faker.generate_studies(2)

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -990,6 +990,10 @@ def test_run_query_update_as_user(api_user_client):
 
 def test_queries_run_rejects_deletions_that_would_leave_broken_references(api_user_client):
     # Generate interrelated documents.
+    #
+    # TODO: Migrate these seed/cleanup steps to the pytest fixture-based seed/yield/cleanup
+    #       pattern established in https://github.com/microbiomedata/nmdc-runtime/pull/972
+    #
     faker = Faker()
     study_a = faker.generate_studies(1)[0]
     bsm_a, bsm_b = faker.generate_biosamples(2, associated_studies=[study_a["id"]])

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -912,7 +912,7 @@ def _test_run_query_delete_as(client):
     biosample_id = "nmdc:bsm-12-deleteme"
 
     if not mdb.biosample_set.find_one({"id": biosample_id}):
-        mdb.biosample_set.insert_one({"id": biosample_id})
+        mdb.biosample_set.insert_one({"id": biosample_id, "type": "nmdc:Biosample"})
 
     # Access should not work without permissions
     mdb["_runtime"].api.allow.delete_many(

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1253,7 +1253,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(
             ],
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["n"] == 2
 
     # Case 4: Now, we _can_ delete both Study A and Study B because, although Study A is still
@@ -1272,7 +1272,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(
             ],
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json()["n"] == 2
 
 

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1016,7 +1016,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(api_us
     }
     mdb["_runtime.api.allow"].replace_one(allow_spec, allow_spec, upsert=True)
 
-    # Case 1: We cannot delete the study because some biosamples are referencing them.
+    # Case 1: We cannot delete the study because some biosamples are referencing it.
     with pytest.raises(requests.HTTPError):
         api_user_client.request(
             "POST",
@@ -1049,7 +1049,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(api_us
     assert response.status_code == 200
     assert response.json()["n"] == 2  # both biosamples were deleted
 
-    # Case 3: Now that the biosamples have been deleted, we can delete the study.
+    # Case 3: We can delete the study because nothing is referencing it anymore.
     response = api_user_client.request(
         "POST",
         "/queries:run",


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I added a real-time referential integrity check to the `POST /queries:run` API endpoint; specifically, to a branch of code that handles the "delete" command.

Before, the endpoint allowed users to delete documents that other documents referred to, even when those other documents were not also being deleted as part of the same request. When that happens, it leaves behind "broken references" in the database.

Now (in this PR), the endpoint disallows that. If the user tries to delete a document that other documents reference, and those other documents aren't also being deleted as part of the same request, the endpoint returns an HTTP 422 response and does not perform any deletions.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I updated the `refscan` package version (a dependency of the Runtime) from `0.2.4` to `0.2.5` so that the Runtime could take advantage of a recently-introduced function named `identify_referring_documents`.

Also, to facilitate transitioning to this new "strict" check, I added a boolean flag that a developer can use to switch to a more "lenient" check, where the deletion still happens, but a warning gets logged to the server console (accessible on Rancher). By default, though, this new "strict" mode is enabled.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1000 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I implemented a test that targets this newly-introduced referential integrity checking. I confirmed the test passes locally and on GHA.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

I confirmed the API endpoint's user-facing documentation doesn't say anything that this new change would render inaccurate.

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
