### PR TITLE
Configure Dagster run `materialize_alldocs` op only after its dependent ops have finished 

### DIFF
--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -135,7 +135,7 @@ def ensure_jobs():
 def apply_changesheet():
     # Note: We use `_` as a "placeholder" variable.
     #       It's a variable to whose value we assign no significance. In this case, we use it to
-    #       tell Dagster that one op depends upon the output of the other (so Dagster  runs them
+    #       tell Dagster that one op depends upon the output of the other (so Dagster runs them
     #       in that order), without implying to maintainers that its value is significant to us.
     #       Reference (this strategy): https://docs.dagster.io/api/dagster/types#dagster.Nothing
     #       Reference (`_` variables): https://stackoverflow.com/a/47599668

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -133,17 +133,25 @@ def ensure_jobs():
 
 @graph
 def apply_changesheet():
+    # Note: We use `_` as a "placeholder" variable.
+    #       It's a variable we want to exist, but to whose value we assign no significance.
+    #       In this case, we are using the variable to tell Dagster that one op depends
+    #       upon the output of the other (so Dagster runs them in that order). In reality,
+    #       the later op only depends upon the earlier op having finished running
+    #       (i.e., it depends upon the earlier op's output _existing_).
+    #       Reference about this convention: https://stackoverflow.com/a/47599668
     sheet_in = get_changesheet_in()
     outputs = perform_changesheet_updates(sheet_in)
-    add_output_run_event(outputs)
-    materialize_alldocs()
+    _ = add_output_run_event(outputs)
+    materialize_alldocs(_)
 
 
 @graph
 def apply_metadata_in():
+    # Note: We use `_` as a "placeholder" variable.
     outputs = perform_mongo_updates(get_json_in())
-    add_output_run_event(outputs)
-    materialize_alldocs()
+    _ = add_output_run_event(outputs)
+    materialize_alldocs(_)
 
 
 @graph

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -134,16 +134,15 @@ def ensure_jobs():
 @graph
 def apply_changesheet():
     # Note: We use `_` as a "placeholder" variable.
-    #       It's a variable we want to exist, but to whose value we assign no significance.
-    #       In this case, we are using the variable to tell Dagster that one op depends
-    #       upon the output of the other (so Dagster runs them in that order), without
-    #       telling human readers that its value has any significance to us.
+    #       It's a variable to whose value we assign no significance. In this case, we use it to
+    #       tell Dagster that one op depends upon the output of the other (so Dagster  runs them
+    #       in that order), without implying to maintainers that its value is significant to us.
     #       Reference (this strategy): https://docs.dagster.io/api/dagster/types#dagster.Nothing
     #       Reference (`_` variables): https://stackoverflow.com/a/47599668
     sheet_in = get_changesheet_in()
     outputs = perform_changesheet_updates(sheet_in)
     _ = add_output_run_event(outputs)
-    materialize_alldocs(wait_for=_)
+    materialize_alldocs(waits_for=_)
 
 
 @graph
@@ -151,7 +150,7 @@ def apply_metadata_in():
     # Note: We use `_` as a "placeholder" variable.
     outputs = perform_mongo_updates(get_json_in())
     _ = add_output_run_event(outputs)
-    materialize_alldocs(wait_for=_)
+    materialize_alldocs(waits_for=_)
 
 
 @graph

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -136,14 +136,14 @@ def apply_changesheet():
     # Note: We use `_` as a "placeholder" variable.
     #       It's a variable we want to exist, but to whose value we assign no significance.
     #       In this case, we are using the variable to tell Dagster that one op depends
-    #       upon the output of the other (so Dagster runs them in that order). In reality,
-    #       the later op only depends upon the earlier op having finished running
-    #       (i.e., it depends upon the earlier op's output _existing_).
-    #       Reference about this convention: https://stackoverflow.com/a/47599668
+    #       upon the output of the other (so Dagster runs them in that order), without
+    #       telling human readers that its value has any significance to us.
+    #       Reference (this strategy): https://docs.dagster.io/api/dagster/types#dagster.Nothing
+    #       Reference (`_` variables): https://stackoverflow.com/a/47599668
     sheet_in = get_changesheet_in()
     outputs = perform_changesheet_updates(sheet_in)
     _ = add_output_run_event(outputs)
-    materialize_alldocs(_)
+    materialize_alldocs(wait_for=_)
 
 
 @graph
@@ -151,7 +151,7 @@ def apply_metadata_in():
     # Note: We use `_` as a "placeholder" variable.
     outputs = perform_mongo_updates(get_json_in())
     _ = add_output_run_event(outputs)
-    materialize_alldocs(_)
+    materialize_alldocs(wait_for=_)
 
 
 @graph

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1257,7 +1257,7 @@ def _add_related_ids_to_alldocs(
 
 
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)
-#       pass an argument the op (in order to specify the order of the ops in the graph)
+#       pass an argument to the op (in order to specify the order of the ops in the graph)
 #       while also telling Dagster that this op doesn't need the _value_ of that argument.
 #       This is the approach shown on: https://docs.dagster.io/api/dagster/types#dagster.Nothing
 #       Reference: https://docs.dagster.io/guides/build/ops/graphs#defining-nothing-dependencies

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -39,7 +39,7 @@ from dagster import (
     Field,
     Permissive,
     In,
-    Nothing
+    Nothing,
 )
 from gridfs import GridFS
 from linkml_runtime.utils.dictutils import as_simple_dict

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1263,7 +1263,7 @@ def _add_related_ids_to_alldocs(
 #       - https://docs.dagster.io/api/dagster/types#dagster.Nothing
 #
 @op(required_resource_keys={"mongo"}, ins={"wait_for": In(dagster_type=Nothing)})
-def materialize_alldocs(context, wait_for) -> int:
+def materialize_alldocs(context) -> int:
     """
     This function (re)builds the `alldocs` collection to reflect the current state of the MongoDB database by:
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -38,7 +38,8 @@ from dagster import (
     Optional,
     Field,
     Permissive,
-    Bool,
+    In,
+    Nothing
 )
 from gridfs import GridFS
 from linkml_runtime.utils.dictutils import as_simple_dict
@@ -1255,8 +1256,14 @@ def _add_related_ids_to_alldocs(
     context.log.info("Successfully created {`_inbound`,`_outbound`} indexes")
 
 
-@op(required_resource_keys={"mongo"})
-def materialize_alldocs(context) -> int:
+# Note: Here, we define a so-called "Nothing dependency," which allows us to pass "nothing" to
+#       the op, while still using inputs/outputs to specify the order of the ops in a graph.
+#       References:
+#       - https://docs.dagster.io/guides/build/ops/graphs#defining-nothing-dependencies
+#       - https://docs.dagster.io/api/dagster/types#dagster.Nothing
+#
+@op(required_resource_keys={"mongo"}, ins={"wait_for": In(dagster_type=Nothing)})
+def materialize_alldocs(context, wait_for) -> int:
     """
     This function (re)builds the `alldocs` collection to reflect the current state of the MongoDB database by:
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1256,13 +1256,13 @@ def _add_related_ids_to_alldocs(
     context.log.info("Successfully created {`_inbound`,`_outbound`} indexes")
 
 
-# Note: Here, we define a so-called "Nothing dependency," which allows us to pass "nothing" to
-#       the op, while still using inputs/outputs to specify the order of the ops in a graph.
-#       References:
-#       - https://docs.dagster.io/guides/build/ops/graphs#defining-nothing-dependencies
-#       - https://docs.dagster.io/api/dagster/types#dagster.Nothing
+# Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)
+#       pass an argument the op (in order to specify the order of the ops in the graph)
+#       while also telling Dagster that this op doesn't need the _value_ of that argument.
+#       This is the approach shown on: https://docs.dagster.io/api/dagster/types#dagster.Nothing
+#       Reference: https://docs.dagster.io/guides/build/ops/graphs#defining-nothing-dependencies
 #
-@op(required_resource_keys={"mongo"}, ins={"wait_for": In(dagster_type=Nothing)})
+@op(required_resource_keys={"mongo"}, ins={"waits_for": In(dagster_type=Nothing)})
 def materialize_alldocs(context) -> int:
     """
     This function (re)builds the `alldocs` collection to reflect the current state of the MongoDB database by:


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the two Dagster graphs that include the `materialize_alldocs` op, so that Dagster will not run the `materialize_alldocs` op until the "previous" op has finished running.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Here's one of those graphs on `main` (notice there is no "dependency" line connected to the `materialize_alldocs` op):

![image](https://github.com/user-attachments/assets/e87160b5-d014-45a2-8620-ac3875e5a161)

Here's the same graph on this branch (notice the new "dependency" line):

![image](https://github.com/user-attachments/assets/0e134672-8616-463e-bb19-60690eb7ac3a)

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1011 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming that, on Dagit, the two affected graphs look the way I expect. I also tested the changes by confirming the GHA checks (including tests) all pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
