### PR TITLE
Update `related_resources` API response to include subject `workflow_execution_set` document

### DIFF
--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -663,7 +663,9 @@ def find_related_objects_for_workflow_execution(
 
     response = {
         "workflow_execution_id": workflow_execution_id,  # `WorkflowExecution` `id` provided by user
-        "workflow_execution": strip_oid(workflow_execution),  # the specified `WorkflowExecution`
+        "workflow_execution": strip_oid(
+            workflow_execution
+        ),  # the specified `WorkflowExecution`
         "data_objects": data_objects,  # related `DataObject`s
         "related_workflow_executions": related_workflow_executions,  # related `WorkflowExecution`s
         "biosamples": biosamples,  # related `Biosample`s

--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -394,11 +394,12 @@ def find_planned_process_by_id(
         "related to the specified `WorkflowExecution`."
         "<br /><br />"  # newlines
         "This endpoint returns a JSON object that contains "
-        "(a) all the `DataObject`s that are inputs to — or outputs from — the specified `WorkflowExecution`, "
-        "(b) all the `DataGeneration`s that generated those `DataObject`s, "
-        "(c) all the `Biosample`s that were inputs to those `DataGeneration`s, "
-        "(d) all the `Study`s with which those `Biosample`s are associated, and "
-        "(e) all the other `WorkflowExecution`s that are part of the same processing pipeline "
+        "(a) the specified `WorkflowExecution`, "
+        "(b) all the `DataObject`s that are inputs to — or outputs from — the specified `WorkflowExecution`, "
+        "(c) all the `DataGeneration`s that generated those `DataObject`s, "
+        "(d) all the `Biosample`s that were inputs to those `DataGeneration`s, "
+        "(e) all the `Study`s with which those `Biosample`s are associated, and "
+        "(f) all the other `WorkflowExecution`s that are part of the same processing pipeline "
         "as the specified `WorkflowExecution`."
         "<br /><br />"  # newlines
         "**Note:** The data returned by this API endpoint can be up to 24 hours out of date "
@@ -662,6 +663,7 @@ def find_related_objects_for_workflow_execution(
 
     response = {
         "workflow_execution_id": workflow_execution_id,  # `WorkflowExecution` `id` provided by user
+        "workflow_execution": strip_oid(workflow_execution),  # the specified `WorkflowExecution`
         "data_objects": data_objects,  # related `DataObject`s
         "related_workflow_executions": related_workflow_executions,  # related `WorkflowExecution`s
         "biosamples": biosamples,  # related `Biosample`s

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -19,8 +19,7 @@ from nmdc_runtime.api.db.mongo import (
     get_collection_names_from_schema,
     mongorestore_collection,
 )
-from nmdc_runtime.api.endpoints.find import find_related_objects_for_workflow_execution
-from nmdc_runtime.api.endpoints.util import persist_content_and_get_drs_object
+from nmdc_runtime.api.endpoints.util import persist_content_and_get_drs_object, strip_oid
 from nmdc_runtime.api.models.job import Job, JobOperationMetadata
 from nmdc_runtime.api.models.metadata import ChangesheetIn
 from nmdc_runtime.api.models.site import SiteInDB, SiteClientInDB
@@ -1345,7 +1344,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(
     assert response.json()["n"] == 2
 
 
-def test_find_related_objects_for_workflow_execution__returns_404_if_wfe_nonexistent(
+def test_find_related_resources_for_workflow_execution__returns_404_if_wfe_nonexistent(
     base_url: str,
 ):
     r"""
@@ -1368,7 +1367,7 @@ def test_find_related_objects_for_workflow_execution__returns_404_if_wfe_nonexis
     assert response.status_code == 404
 
 
-def test_find_related_objects_for_workflow_execution__returns_related_objects(
+def test_find_related_resources_for_workflow_execution__returns_related_resources(
     base_url: str,
 ):
     # Generate interrelated documents.
@@ -1429,6 +1428,7 @@ def test_find_related_objects_for_workflow_execution__returns_related_objects(
     assert response.status_code == 200
     response_payload = response.json()
     assert response_payload["workflow_execution_id"] == workflow_execution["id"]
+    assert response_payload["workflow_execution"] == strip_oid(workflow_execution)
     assert len(response_payload["data_objects"]) == 1
     assert response_payload["data_objects"][0]["id"] == data_object["id"]
     assert len(response_payload["related_workflow_executions"]) == 0
@@ -1449,7 +1449,7 @@ def test_find_related_objects_for_workflow_execution__returns_related_objects(
     workflow_execution_set.delete_many({"id": workflow_execution["id"]})
 
 
-def test_find_related_objects_for_workflow_execution__returns_related_workflow_exections(
+def test_find_related_resources_for_workflow_execution__returns_related_workflow_executions(
     base_url: str,
 ):
     """
@@ -1526,6 +1526,7 @@ def test_find_related_objects_for_workflow_execution__returns_related_workflow_e
     assert response.status_code == 200
     response_payload = response.json()
     assert response_payload["workflow_execution_id"] == workflow_execution_a["id"]
+    assert response_payload["workflow_execution"] == strip_oid(workflow_execution_a)
     assert len(response_payload["data_objects"]) == 2
     returned_data_object_ids = [do["id"] for do in response_payload["data_objects"]]
     assert set(returned_data_object_ids) == {


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the `/workflow_executions/{id}/related_resources` API endpoint's response so that, in addition to including resources _related_ to the specified `workflow_execution_set` document, it also includes the specified `workflow_execution_set` document, itself.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I also standardized names of tests and fixed a typo in the name of a test.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #995

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running `make test` locally and confirming all tests pass, including the tests that target the endpoint I made changes to in this PR.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
