### PR TITLE
Update `Faker` methods to validate documents before returning them

### DIFF
--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -1,4 +1,6 @@
 from typing import List
+
+from linkml_runtime.dumpers import json_dumper
 from nmdc_schema.nmdc import (
     Biosample,
     ControlledIdentifiedTermValue,
@@ -89,17 +91,17 @@ class Faker:
         >>> len(studies)
         2
         >>> studies[0]
-        {'id': 'nmdc:sty-00-000001', 'study_category': 'research_study', 'type': 'nmdc:Study'}
+        {'id': 'nmdc:sty-00-000001', 'type': 'nmdc:Study', 'study_category': 'research_study'}
         >>> studies[1]
-        {'id': 'nmdc:sty-00-000002', 'study_category': 'research_study', 'type': 'nmdc:Study'}
+        {'id': 'nmdc:sty-00-000002', 'type': 'nmdc:Study', 'study_category': 'research_study'}
 
         # Test: Overriding a default value and adding an optional field.
         >>> f.generate_studies(1, study_category='consortium', title='My Study')[0]
-        {'id': 'nmdc:sty-00-000003', 'study_category': 'consortium', 'type': 'nmdc:Study', 'title': 'My Study'}
+        {'id': 'nmdc:sty-00-000003', 'type': 'nmdc:Study', 'study_category': 'consortium', 'title': 'My Study'}
 
         # Test: Generating a study with a referencing field (referential integrity is not checked).
         >>> f.generate_studies(1, part_of=['nmdc:sty-00-no_such_study'])[0]
-        {'id': 'nmdc:sty-00-000004', 'study_category': 'research_study', 'type': 'nmdc:Study', 'part_of': ['nmdc:sty-00-no_such_study']}
+        {'id': 'nmdc:sty-00-000004', 'type': 'nmdc:Study', 'study_category': 'research_study', 'part_of': ['nmdc:sty-00-no_such_study']}
         
         # Test: Generating an invalid document.
         >>> f.generate_studies(1, study_category='no_such_category')
@@ -111,7 +113,7 @@ class Faker:
         documents = []
         for i in range(quantity):
             # Apply any overrides passed in.
-            document = {
+            params = {
                 "id": self.make_unique_id("nmdc:sty-00-"),
                 "study_category": StudyCategoryEnum.research_study.text,
                 "type": Study.class_class_curie,
@@ -120,18 +122,14 @@ class Faker:
 
             # Validate the parameters by attempting to instantiate a `Study`.
             #
-            # Note: The `Study` instance construction process changes the `study_category` value into a
-            #       `StudyCategoryEnum` instance (which, when the `Study` instance is dumped as a dict,
-            #       is, itself, a dict), so we don't dump the `Study` instance to a dictionary and return
-            #       that as our study document. :(
-            #
             # Note: Here are some caveats I've noticed so far as I've experimented with this validation:
             #       1. Pydantic doesn't complain when I populate an `Optional[str]` field with
             #          a number, a list, or a dict.
             #
-            _ = Study(**document)
-            
-            # Make the document.
+            instance = Study(**params)
+
+            # Dump the instance to a `dict` (technically, to a `JsonObj`).
+            document = json_dumper.to_dict(instance)
             documents.append(document)
 
         return documents
@@ -174,7 +172,7 @@ class Faker:
         documents = []
         for i in range(quantity):
             # Apply any overrides passed in.
-            document = {
+            params = {
                 "id": self.make_unique_id("nmdc:bsm-00-"),
                 "type": Biosample.class_class_curie,
                 "associated_studies": associated_studies,
@@ -209,9 +207,10 @@ class Faker:
             }
 
             # Validate the parameters by attempting to instantiate a `Biosample`.
-            _ = Biosample(**document)
+            instance = Biosample(**params)
             
-            # Make the document.
+            # Dump the instance to a `dict` (technically, to a `JsonObj`).
+            document = json_dumper.to_dict(instance)
             documents.append(document)
 
         return documents
@@ -254,7 +253,7 @@ class Faker:
         documents = []
         for i in range(quantity):
             # Apply any overrides passed in.
-            document = {
+            params = {
                 "id": self.make_unique_id(f"nmdc:wfmgan-00-") + ".1",
                 "type": MetagenomeAnnotation.class_class_curie,
                 "execution_resource": ExecutionResourceEnum.JGI.text,
@@ -266,9 +265,10 @@ class Faker:
             }
 
             # Validate the parameters by attempting to instantiate a `MetagenomeAnnotation`.
-            _ = MetagenomeAnnotation(**document)
+            instance = MetagenomeAnnotation(**params)
             
-            # Make the document.
+            # Dump the instance to a `dict` (technically, to a `JsonObj`).
+            document = json_dumper.to_dict(instance)
             documents.append(document)
 
         return documents
@@ -317,7 +317,7 @@ class Faker:
         documents = []
         for i in range(quantity):
             # Apply any overrides passed in.
-            document = {
+            params = {
                 "id": self.make_unique_id(f"nmdc:dgns-00-"),
                 "type": NucleotideSequencing.class_class_curie,
                 "analyte_category": NucleotideSequencingEnum.metagenome.text,
@@ -327,9 +327,10 @@ class Faker:
             }
 
             # Validate the parameters by attempting to instantiate a `NucleotideSequencing`.
-            _ = NucleotideSequencing(**document)
+            instance = NucleotideSequencing(**params)
             
-            # Make the document.
+            # Dump the instance to a `dict` (technically, to a `JsonObj`).
+            document = json_dumper.to_dict(instance)
             documents.append(document)
 
         return documents
@@ -372,7 +373,7 @@ class Faker:
         documents = []
         for i in range(quantity):
             # Apply any overrides passed in.
-            document = {
+            params = {
                 "id": self.make_unique_id(f"nmdc:dobj-00-"),
                 "type": "nmdc:DataObject",
                 "name": "arbitrary_string",
@@ -383,9 +384,10 @@ class Faker:
             }
 
             # Validate the parameters by attempting to instantiate a `DataObject`.
-            _ = DataObject(**document)
+            instance = DataObject(**params)
             
-            # Make the document.
+            # Dump the instance to a `dict` (technically, to a `JsonObj`).
+            document = json_dumper.to_dict(instance)
             documents.append(document)
 
         return documents

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -31,7 +31,7 @@ class Faker:
           dictionaries, we may have methods that return the schema class
           instances, themselves.
 
-    TODO: Try to leverage the type hints present on the Pydantic models, for
+    TODO: Try to leverage the type hints defined on the Pydantic models, for
           the signatures of the methods of this class (rather than hard-coding
           type hints in those methods' signatures).
     """
@@ -109,7 +109,7 @@ class Faker:
         """
 
         documents = []
-        for n in range(1, quantity + 1):
+        for i in range(quantity):
             # Apply any overrides passed in.
             document = {
                 "id": self.make_unique_id("nmdc:sty-00-"),
@@ -172,7 +172,7 @@ class Faker:
         """
 
         documents = []
-        for n in range(1, quantity + 1):
+        for i in range(quantity):
             # Apply any overrides passed in.
             document = {
                 "id": self.make_unique_id("nmdc:bsm-00-"),
@@ -252,7 +252,7 @@ class Faker:
         """
 
         documents = []
-        for n in range(1, quantity + 1):
+        for i in range(quantity):
             # Apply any overrides passed in.
             document = {
                 "id": self.make_unique_id(f"nmdc:wfmgan-00-") + ".1",
@@ -315,7 +315,7 @@ class Faker:
         """
 
         documents = []
-        for n in range(1, quantity + 1):
+        for i in range(quantity):
             # Apply any overrides passed in.
             document = {
                 "id": self.make_unique_id(f"nmdc:dgns-00-"),
@@ -370,7 +370,7 @@ class Faker:
         """
 
         documents = []
-        for n in range(1, quantity + 1):
+        for i in range(quantity):
             # Apply any overrides passed in.
             document = {
                 "id": self.make_unique_id(f"nmdc:dobj-00-"),

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -1,5 +1,13 @@
 from typing import List
-from nmdc_schema.nmdc import Biosample, ControlledIdentifiedTermValue, OntologyClass, Study, StudyCategoryEnum
+from nmdc_schema.nmdc import (
+    Biosample,
+    ControlledIdentifiedTermValue,
+    ExecutionResourceEnum,
+    MetagenomeAnnotation,
+    OntologyClass,
+    Study,
+    StudyCategoryEnum,
+)
 
 class Faker:
     r"""
@@ -17,6 +25,10 @@ class Faker:
           In the future, instead of only having methods that return
           dictionaries, we may have methods that return the schema class
           instances, themselves.
+
+    TODO: Try to leverage the type hints present on the Pydantic models, for
+          the signatures of the methods of this class (rather than hard-coding
+          type hints in those methods' signatures).
     """
     
     def __init__(self):
@@ -226,21 +238,36 @@ class Faker:
         'nmdc:bsm-00-000001'
         >>> metagenome_annotations[0]['type']
         'nmdc:MetagenomeAnnotation'
+
+        # Test: Omitting required parameters.
+        >>> f.generate_metagenome_annotations(1)
+        Traceback (most recent call last):
+            ...
+        TypeError: Faker.generate_metagenome_annotations() missing 2 required positional arguments: 'was_informed_by' and 'has_input'
         """
 
-        return [
-            {
+        documents = []
+        for n in range(1, quantity + 1):
+            # Apply any overrides passed in.
+            document = {
                 "id": self.make_unique_id(f"nmdc:wfmgan-00-") + ".1",
-                "type": "nmdc:MetagenomeAnnotation",
-                "execution_resource": "JGI",
+                "type": MetagenomeAnnotation.class_class_curie,
+                "execution_resource": ExecutionResourceEnum.JGI.text,
                 "git_url": "https://www.example.com",
                 "started_at_time": "2000-01-01 12:00:00",
                 "was_informed_by": was_informed_by,
                 "has_input": has_input,
                 **overrides,
             }
-            for n in range(1, quantity + 1)
-        ]
+
+            # Validate the parameters by attempting to instantiate a `MetagenomeAnnotation`.
+            _ = MetagenomeAnnotation(**document)
+            
+            # Make the document.
+            documents.append(document)
+
+        return documents
+
 
     def generate_nucleotide_sequencings(self, quantity: int, associated_studies: List[str], has_input: List[str], **overrides) -> List[dict]:
         """

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -2,7 +2,10 @@ from typing import List
 from nmdc_schema.nmdc import (
     Biosample,
     ControlledIdentifiedTermValue,
+    DataCategoryEnum,
+    DataObject,
     ExecutionResourceEnum,
+    FileTypeEnum,
     MetagenomeAnnotation,
     NucleotideSequencing,
     NucleotideSequencingEnum,
@@ -98,7 +101,7 @@ class Faker:
         >>> f.generate_studies(1, part_of=['nmdc:sty-00-no_such_study'])[0]
         {'id': 'nmdc:sty-00-000004', 'study_category': 'research_study', 'type': 'nmdc:Study', 'part_of': ['nmdc:sty-00-no_such_study']}
         
-        # Test: Generating an invalid study.
+        # Test: Generating an invalid document.
         >>> f.generate_studies(1, study_category='no_such_category')
         Traceback (most recent call last):
             ...
@@ -161,7 +164,7 @@ class Faker:
             ...
         TypeError: Faker.generate_biosamples() missing 1 required positional argument: 'associated_studies'
 
-        # Test: Generating an invalid biosample.
+        # Test: Generating an invalid document.
         >>> f.generate_biosamples(1, associated_studies=['nmdc:sty-00-000001'], depth=123)
         Traceback (most recent call last):
             ...
@@ -304,7 +307,7 @@ class Faker:
             ...
         TypeError: Faker.generate_nucleotide_sequencings() missing 2 required positional arguments: 'associated_studies' and 'has_input'
 
-        # Test: Generating an invalid nucleotide sequencing.
+        # Test: Generating an invalid document.
         >>> f.generate_nucleotide_sequencings(1, associated_studies=['nmdc:sty-00-000001'], has_input=['nmdc:bsm-00-000001'], analyte_category='no_such_category')
         Traceback (most recent call last):
             ...
@@ -358,17 +361,31 @@ class Faker:
         True
         >>> 'data_object_type' in data_objects[0]
         True
+
+        # Test: Generating an invalid document.
+        >>> f.generate_data_objects(1, data_category='no_such_category')
+        Traceback (most recent call last):
+            ...
+        ValueError: Unknown DataCategoryEnum enumeration code: no_such_category
         """
 
-        return [
-            {
+        documents = []
+        for n in range(1, quantity + 1):
+            # Apply any overrides passed in.
+            document = {
                 "id": self.make_unique_id(f"nmdc:dobj-00-"),
                 "type": "nmdc:DataObject",
                 "name": "arbitrary_string",
                 "description": "arbitrary_string",
-                "data_category": "processed_data",  # any `DataCategoryEnum` value
-                "data_object_type": "Annotation Info File",  # any `FileTypeEnum` value
+                "data_category": DataCategoryEnum.processed_data.text,
+                "data_object_type": FileTypeEnum["Protein Report"].text,
                 **overrides,
             }
-            for n in range(1, quantity + 1)
-        ]
+
+            # Validate the parameters by attempting to instantiate a `DataObject`.
+            _ = DataObject(**document)
+            
+            # Make the document.
+            documents.append(document)
+
+        return documents

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -4,6 +4,8 @@ from nmdc_schema.nmdc import (
     ControlledIdentifiedTermValue,
     ExecutionResourceEnum,
     MetagenomeAnnotation,
+    NucleotideSequencing,
+    NucleotideSequencingEnum,
     OntologyClass,
     Study,
     StudyCategoryEnum,
@@ -295,19 +297,39 @@ class Faker:
         'nmdc:bsm-00-000001'
         >>> nucleotide_sequencings[0]['type']
         'nmdc:NucleotideSequencing'
+
+        # Test: Omitting required parameters.
+        >>> f.generate_nucleotide_sequencings(1)
+        Traceback (most recent call last):
+            ...
+        TypeError: Faker.generate_nucleotide_sequencings() missing 2 required positional arguments: 'associated_studies' and 'has_input'
+
+        # Test: Generating an invalid nucleotide sequencing.
+        >>> f.generate_nucleotide_sequencings(1, associated_studies=['nmdc:sty-00-000001'], has_input=['nmdc:bsm-00-000001'], analyte_category='no_such_category')
+        Traceback (most recent call last):
+            ...
+        ValueError: Unknown NucleotideSequencingEnum enumeration code: no_such_category
         """
 
-        return [
-            {
+        documents = []
+        for n in range(1, quantity + 1):
+            # Apply any overrides passed in.
+            document = {
                 "id": self.make_unique_id(f"nmdc:dgns-00-"),
-                "type": "nmdc:NucleotideSequencing",
-                "analyte_category": "arbitrary_string",
+                "type": NucleotideSequencing.class_class_curie,
+                "analyte_category": NucleotideSequencingEnum.metagenome.text,
                 "associated_studies": associated_studies,
                 "has_input": has_input,
                 **overrides,
             }
-            for n in range(1, quantity + 1)
-        ]
+
+            # Validate the parameters by attempting to instantiate a `NucleotideSequencing`.
+            _ = NucleotideSequencing(**document)
+            
+            # Make the document.
+            documents.append(document)
+
+        return documents
 
     def generate_data_objects(self, quantity: int, **overrides) -> List[dict]:
         """

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -736,11 +736,10 @@ def fake_studies_and_biosamples_in_mdb():
     """
     mdb = get_mongo_db()
     faker = Faker()
-    study_a, study_b = faker.generate_studies(2)
-    biosample_a, biosample_b = faker.generate_biosamples(2, associated_studies=[])
-    study_b["part_of"] = [study_a["id"]]
-    biosample_a["associated_studies"] = [study_a["id"]]
-    biosample_b["associated_studies"] = [study_b["id"]]
+    study_a = faker.generate_studies(1)[0]
+    study_b = faker.generate_studies(1, part_of=[study_a["id"]])[0]
+    biosample_a = faker.generate_biosamples(1, associated_studies=[study_a["id"]])[0]
+    biosample_b = faker.generate_biosamples(1, associated_studies=[study_b["id"]])[0]
     study_ids = [study_a["id"], study_b["id"]]
     biosample_ids = [biosample_a["id"], biosample_b["id"]]
     study_set = mdb.get_collection(name="study_set")
@@ -1475,7 +1474,7 @@ def test_find_related_resources_for_workflow_execution__returns_related_workflow
 
     # Create a second `WorkflowExecution` that is related to the first one.
     data_object_b = faker.generate_data_objects(
-        1, has_output=workflow_execution_a["id"]
+        1, was_generated_by=data_generation_a["id"]
     )[0]
     workflow_execution_b = faker.generate_metagenome_annotations(
         1,


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the methods of the `Faker` class so they validate the documents they generate, before returning them. They delegate the validation to the Pydantic models, so the validation is subject to whatever caveats apply (some are listed in a `Note:` comment in the diff).

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I think this change will decrease the likelihood that the methods fall out of sync with the schema.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1026 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

This is related to the test suite.

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by (a) confirmed their existing doctests still pass and (b) adding new doctests and confirmed _those_ also pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
