### PR TITLE
Implement "on/off" switch for `/nmdcschema/related_ids` endpoint (and turn it "off")

### DIFF
--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -13,7 +13,11 @@ from nmdc_runtime.api.endpoints.lib.path_segments import (
 from nmdc_runtime.api.models.nmdc_schema import RelatedIDs
 from nmdc_runtime.config import DATABASE_CLASS_NAME, IS_RELATED_IDS_ENDPOINT_ENABLED
 from nmdc_runtime.minter.config import typecodes
-from nmdc_runtime.util import decorate_if, nmdc_database_collection_names, nmdc_schema_view
+from nmdc_runtime.util import (
+    decorate_if,
+    nmdc_database_collection_names,
+    nmdc_schema_view,
+)
 from pymongo.database import Database as MongoDatabase
 from starlette import status
 from linkml_runtime.utils.schemaview import SchemaView

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -11,9 +11,9 @@ from nmdc_runtime.api.endpoints.lib.path_segments import (
     ParsedPathSegment,
 )
 from nmdc_runtime.api.models.nmdc_schema import RelatedIDs
-from nmdc_runtime.config import DATABASE_CLASS_NAME
+from nmdc_runtime.config import DATABASE_CLASS_NAME, IS_RELATED_IDS_ENDPOINT_ENABLED
 from nmdc_runtime.minter.config import typecodes
-from nmdc_runtime.util import nmdc_database_collection_names, nmdc_schema_view
+from nmdc_runtime.util import decorate_if, nmdc_database_collection_names, nmdc_schema_view
 from pymongo.database import Database as MongoDatabase
 from starlette import status
 from linkml_runtime.utils.schemaview import SchemaView
@@ -143,10 +143,12 @@ def _parse_postfilter(
     return parse_path_segment("postfilter;" + postfilter)
 
 
-@router.get(
-    "/nmdcschema/related_ids/{prefilter}/{postfilter}",
-    response_model=ListResponse[RelatedIDs],
-    response_model_exclude_unset=True,
+@decorate_if(condition=IS_RELATED_IDS_ENDPOINT_ENABLED)(
+    router.get(
+        "/nmdcschema/related_ids/{prefilter}/{postfilter}",
+        response_model=ListResponse[RelatedIDs],
+        response_model_exclude_unset=True,
+    )
 )
 def get_related_ids(
     prefilter_parsed: ParsedPathSegment = Depends(_parse_prefilter),

--- a/nmdc_runtime/config.py
+++ b/nmdc_runtime/config.py
@@ -1,1 +1,5 @@
 DATABASE_CLASS_NAME = "Database"
+
+# Feature flag that can be used to enable/disable the `/nmdcschema/related_ids`
+# endpoint and the tests that target it.
+IS_RELATED_IDS_ENDPOINT_ENABLED = False

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -11,7 +11,7 @@ from io import BytesIO
 from itertools import chain
 from pathlib import Path
 from uuid import uuid4
-from typing import List, Optional, Set, Dict
+from typing import Callable, List, Optional, Set, Dict
 
 import fastjsonschema
 import requests
@@ -796,3 +796,34 @@ def validate_json(
         return {"result": "All Okay!"}
     else:
         return {"result": "errors", "detail": validation_errors}
+
+
+def decorate_if(condition: bool = True) -> Callable:
+    r"""
+    Decorator that applies another decorator only when `condition` is `True`.
+    
+    Note: We implemented this so we could conditionally register
+          endpoints with FastAPI's `@router`.
+
+    Example usages:
+    A. Apply the `@router.get` decorator:
+       ```python
+       @decorate_if(True)(router.get("/me"))
+       def get_me(...):
+           ...
+       ```
+    B. Bypass the `@router.get` decorator:
+       ```python
+       @decorate_if(False)(router.get("/me"))
+       def get_me(...):
+           ...
+       ```
+    """
+    def apply_original_decorator(original_decorator: Callable) -> Callable:
+        def check_condition(original_function: Callable) -> Callable:
+            if condition:
+                return original_decorator(original_function)
+            else:
+                return original_function
+        return check_condition
+    return apply_original_decorator

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -798,7 +798,7 @@ def validate_json(
         return {"result": "errors", "detail": validation_errors}
 
 
-def decorate_if(condition: bool = True) -> Callable:
+def decorate_if(condition: bool = False) -> Callable:
     r"""
     Decorator that applies another decorator only when `condition` is `True`.
 

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -801,7 +801,7 @@ def validate_json(
 def decorate_if(condition: bool = True) -> Callable:
     r"""
     Decorator that applies another decorator only when `condition` is `True`.
-    
+
     Note: We implemented this so we could conditionally register
           endpoints with FastAPI's `@router`.
 
@@ -819,11 +819,14 @@ def decorate_if(condition: bool = True) -> Callable:
            ...
        ```
     """
+
     def apply_original_decorator(original_decorator: Callable) -> Callable:
         def check_condition(original_function: Callable) -> Callable:
             if condition:
                 return original_decorator(original_function)
             else:
                 return original_function
+
         return check_condition
+
     return apply_original_decorator

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from dagster import build_op_context
+from nmdc_runtime.config import IS_RELATED_IDS_ENDPOINT_ENABLED
 from starlette import status
 from tenacity import wait_random_exponential, stop_after_attempt, retry
 from toolz import get_in
@@ -666,6 +667,7 @@ def fake_study_nonexistent_in_mdb():
     yield nonexistent_study_id
 
 
+@pytest.mark.skipif(not IS_RELATED_IDS_ENDPOINT_ENABLED, reason="Target endpoint is disabled")
 def test_get_related_ids_returns_unsuccessful_status_code_when_any_subject_does_not_exist(
     api_user_client, fake_study_in_mdb, fake_study_nonexistent_in_mdb
 ):
@@ -699,6 +701,7 @@ def test_get_related_ids_returns_unsuccessful_status_code_when_any_subject_does_
         )
 
 
+@pytest.mark.skipif(not IS_RELATED_IDS_ENDPOINT_ENABLED, reason="Target endpoint is disabled")
 def test_get_related_ids_returns_empty_resources_list_for_isolated_subject(
     api_user_client, fake_study_in_mdb
 ):
@@ -758,6 +761,7 @@ def fake_studies_and_biosamples_in_mdb():
     ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
 
 
+@pytest.mark.skipif(not IS_RELATED_IDS_ENDPOINT_ENABLED, reason="Target endpoint is disabled")
 def test_get_related_ids_returns_related_ids(
     api_user_client, fake_studies_and_biosamples_in_mdb
 ):

--- a/tests/test_the_util/test_the_util.py
+++ b/tests/test_the_util/test_the_util.py
@@ -10,13 +10,17 @@ by issuing the following command from the root directory of the repository withi
 import doctest
 
 import pytest
-
 from refscan.lib.Finder import Finder
 from refscan.scanner import scan_outgoing_references
 
 from nmdc_runtime.api.db.mongo import get_collection_names_from_schema, get_mongo_db
 from nmdc_runtime.api.endpoints.lib import path_segments
-from nmdc_runtime.util import get_allowed_references, nmdc_schema_view, validate_json
+from nmdc_runtime.util import (
+    decorate_if,
+    get_allowed_references,
+    nmdc_schema_view,
+    validate_json,
+)
 from tests.lib.faker import Faker
 
 # Define a reusable dictionary that matches the value the `validate_json` function
@@ -337,3 +341,35 @@ def test_path_segments():
     """Test all doctests in `nmdc_runtime.api.endpoints.lib.path_segments`."""
     failure_count, test_count = doctest.testmod(path_segments, verbose=True)
     assert failure_count == 0, f"{failure_count} doctests failed out of {test_count}"
+
+
+def test_decorate_if():
+    """Demonstrates usages of the `@decorate_if` decorator."""
+
+    def parenthesize(func):
+        """Decorator that wraps the function's output in parentheses."""
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            return f"({result})"
+        return wrapper
+
+    @parenthesize  # regular decoration
+    def get_apple() -> str:
+        return "apple"
+    
+    @decorate_if()(parenthesize)  # condition defaults to `False`
+    def get_banana() -> str:
+        return "banana"
+    
+    @decorate_if(True)(parenthesize)
+    def get_carrot() -> str:
+        return "carrot"
+    
+    @decorate_if(False)(parenthesize)
+    def get_daikon() -> str:
+        return "daikon"
+
+    assert get_apple() == "(apple)"
+    assert get_banana() == "banana"
+    assert get_carrot() == "(carrot)"
+    assert get_daikon() == "daikon"


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I disabled the "preliminary" `/nmdcschema/related_ids` endpoint and the tests that target it.

As discussed during today's infrastructure meeting, we will omit the endpoint (which has never been deployed to production before) from the upcoming production release, and then promptly reintroduce it back into the development environment. 

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I disabled the endpoint and tests without commenting them out (which would have affected the commented lines' Git history) and without wrapping them in `if False:` blocks (which, similarly, would have affected their Git history due to the intending).

This branch introduces a new decorator named `@decorate_if`, which can be used to conditionally  decorate a function.

FYI: @aclum and @kheal

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1031 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming all tests (excluding the ones that are being skipped) still pass. I also confirmed that the endpoint still appears on Swagger UI when the flag is set to `True`, and does _not_ appear on Swagger UI when the flag is set to `False`.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")

Explanation: The functions defined _within_ the `decorate_if` function lack docstrings (and have only ~~generic~~ _minimal_ type hints).