### PR TITLE
Make it easier to maintain Swagger/OpenAPI tags

### DIFF
--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -52,6 +52,7 @@ from nmdc_runtime.api.endpoints.util import BASE_URL_EXTERNAL
 from nmdc_runtime.api.models.site import SiteClientInDB, SiteInDB
 from nmdc_runtime.api.models.user import UserInDB
 from nmdc_runtime.api.models.util import entity_attributes_to_index
+from nmdc_runtime.api.openapi import ordered_tag_descriptors
 from nmdc_runtime.api.v1.router import router_v1
 from nmdc_runtime.minter.bootstrap import bootstrap as minter_bootstrap
 from nmdc_runtime.minter.entrypoints.fastapi_app import router as minter_router
@@ -73,191 +74,6 @@ api_router.include_router(find.router, tags=["find"])
 api_router.include_router(runs.router, tags=["runs"])
 api_router.include_router(router_v1, tags=["v1"])
 api_router.include_router(minter_router, prefix="/pids", tags=["minter"])
-
-tags_metadata = [
-    {
-        "name": "sites",
-        "description": (
-            """A site corresponds to a physical place that may participate in job execution.
-
-A site may register data objects and capabilties with NMDC. It may claim jobs to execute, and it may
-update job operations with execution info.
-
-A site must be able to service requests for any data objects it has registered.
-
-A site may expose a "put object" custom method for authorized users. This method facilitates an
-operation to upload an object to the site and have the site register that object with the runtime
-system.
-
-"""
-        ),
-    },
-    {
-        "name": "users",
-        "description": (
-            """Endpoints for user identification.
-
-Currently, accounts for use of the runtime API are created manually by system administrators.
-
-          """
-        ),
-    },
-    {
-        "name": "workflows",
-        "description": (
-            """A workflow is a template for creating jobs.
-
-Workflow jobs are typically created by the system via trigger associations between
-workflows and object types. A workflow may also require certain capabilities of sites
-in order for those sites to claim workflow jobs.
-            """
-        ),
-    },
-    {
-        "name": "capabilities",
-        "description": (
-            """A workflow may require an executing site to have particular capabilities.
-
-These capabilities go beyond the simple ability to access the data object resources registered with
-the runtime system. Sites register their capabilities, and sites are only able to claim workflow
-jobs if they are known to have the capabilities required by the workflow.
-
-"""
-        ),
-    },
-    {
-        "name": "object types",
-        "description": (
-            """An object type is an object annotation that is useful for triggering workflows.
-
-A data object may be annotated with one or more types, which in turn can be associated with
-workflows through trigger resources.
-
-The data-object type system may be used to trigger workflow jobs on a subset of data objects when a
-new version of a workflow is deployed. This could be done by minting a special object type for the
-occasion, annotating the subset of data objects with that type, and registering the association of
-object type to workflow via a trigger resource.
-            """
-        ),
-    },
-    {
-        "name": "triggers",
-        "description": (
-            """A trigger is an association between a workflow and a data object type.
-
-When a data object is annotated with a type, perhaps shortly after object registration, the NMDC
-Runtime will check, via trigger associations, for potential new jobs to create for any workflows.
-
-            """
-        ),
-    },
-    {
-        "name": "jobs",
-        "description": """A job is a resource that isolates workflow configuration from execution.
-
-Rather than directly creating a workflow operation by supplying a workflow ID along with
-configuration, NMDC creates a job that pairs a workflow with configuration. Then, a site can claim a
-job ID, allowing the site to execute the intended workflow without additional configuration.
-
-A job can have multiple executions, and a workflow's executions are precisely the executions of all
-jobs created for that workflow.
-
-A site that already has a compatible job execution result can preempt the unnecessary creation of a
-job by pre-claiming it. This will return like a claim, and now the site can register known data
-object inputs for the job without the risk of the runtime system creating a claimable job of the
-pre-claimed type.
-
-""",
-    },
-    {
-        "name": "objects",
-        "description": (
-            """\
-A [Data Repository Service (DRS)
-object](https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.1.0/docs/#_drs_datatypes)
-represents content necessary for a workflow job to execute, and/or output from a job execution.
-
-An object may be a *blob*, analogous to a file, or a *bundle*, analogous to a folder. Sites register
-objects, and sites must ensure that these objects are accessible to the NMDC data broker.
-
-An object may be associated with one or more object types, useful for triggering workflows.
-
-"""
-        ),
-    },
-    {
-        "name": "operations",
-        "description": """An operation is a resource for tracking the execution of a job.
-
-When a job is claimed by a site for execution, an operation resource is created.
-
-An operation is akin to a "promise" or "future" in that it should eventually resolve to either a
-successful result, i.e. an execution resource, or to an error.
-
-An operation is parameterized to return a result type, and a metadata type for storing progress
-information, that are both particular to the job type.
-
-Operations may be paused, resumed, and/or cancelled.
-
-Operations may expire, i.e. not be stored indefinitely. In this case, it is recommended that
-execution resources have longer lifetimes / not expire, so that information about successful results
-of operations are available.
-        """,
-    },
-    {
-        "name": "queries",
-        "description": (
-            """A query is an operation (find, update, etc.) against the metadata store.
-
-Metadata -- for studies, biosamples, omics processing, etc. -- is used by sites to execute jobs,
-as the parameterization of job executions may depend not only on the content of data objects, but
-also on objects' associated metadata.
-
-Also, the function of many workflows is to extract or produce new metadata. Such metadata products
-should be registered as data objects, and they may also be supplied by sites to the runtime system
-as an update query (if the latter is not done, the runtime system will sense the new metadata and
-issue an update query).
-
-            """
-        ),
-    },
-    {
-        "name": "metadata",
-        "description": """
-The [metadata endpoints](https://api.microbiomedata.org/docs#/metadata) can be used to get and filter metadata from collection set types (including 
-[studies](https://w3id.org/nmdc/Study/), 
-[biosamples](https://w3id.org/nmdc/Biosample/), 
-[planned processes](https://w3id.org/nmdc/PlannedProcess/), and 
-[data objects](https://w3id.org/nmdc/DataObject/) 
-as discussed in the __find__ section).
-<br/>
- 
-The __metadata__ endpoints allow users to retrieve metadata from the data portal using the various GET endpoints 
-that are slightly different than the __find__ endpoints, but some can be used similarly. As with the __find__ endpoints, 
-parameters for the __metadata__ endpoints that do not have a red ___* required___ next to them are optional. <br/>
-
-Unlike the compact syntax used in the __find__  endpoints, the syntax for the filter parameter of the metadata endpoints 
-uses [MongoDB-like language querying](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
-        """,
-    },
-    {
-        "name": "find",
-        "description": """
-The [find endpoints](https://api.microbiomedata.org/docs#/find) are provided with NMDC metadata entities already specified - where metadata about [studies](https://w3id.org/nmdc/Study), [biosamples](https://w3id.org/nmdc/Biosample), [data objects](https://w3id.org/nmdc/DataObject/), and [planned processes](https://w3id.org/nmdc/PlannedProcess/) can be retrieved using GET requests. 
-<br/>
-
-Each endpoint is unique and requires the applicable attribute names to be known in order to structure a query in a meaningful way. 
-Parameters that do not have a red ___* required___ label next to them are optional.
-""",
-    },
-    {
-        "name": "runs",
-        "description": (
-            "[WORK IN PROGRESS] Run simple jobs. "
-            "For off-site job runs, keep the Runtime appraised of run events."
-        ),
-    },
-]
 
 
 def ensure_initial_resources_on_boot():
@@ -428,7 +244,7 @@ app = FastAPI(
         " (note: this link is static; if you are logged in, you will see a 'locked' lock icon"
         " in the below-right 'Authorized' button.)"
     ),
-    openapi_tags=tags_metadata,
+    openapi_tags=ordered_tag_descriptors,
     lifespan=lifespan,
     docs_url=None,
 )

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -52,7 +52,7 @@ from nmdc_runtime.api.endpoints.util import BASE_URL_EXTERNAL
 from nmdc_runtime.api.models.site import SiteClientInDB, SiteInDB
 from nmdc_runtime.api.models.user import UserInDB
 from nmdc_runtime.api.models.util import entity_attributes_to_index
-from nmdc_runtime.api.openapi import ordered_tag_descriptors
+from nmdc_runtime.api.openapi import ordered_tag_descriptors, make_api_description
 from nmdc_runtime.api.v1.router import router_v1
 from nmdc_runtime.minter.bootstrap import bootstrap as minter_bootstrap
 from nmdc_runtime.minter.entrypoints.fastapi_app import router as minter_router
@@ -228,21 +228,9 @@ async def get_versions():
 app = FastAPI(
     title="NMDC Runtime API",
     version=get_version(),
-    description=(
-        "The NMDC Runtime API, via on-demand functions "
-        "and via schedule-based and sensor-based automation, "
-        "supports validation and submission of metadata, as well as "
-        "orchestration of workflow executions."
-        "\n\n"
-        "Dependency versions:\n\n"
-        f'nmdc-schema={version("nmdc_schema")}\n\n'
-        "<a href='https://microbiomedata.github.io/nmdc-runtime/'>Documentation</a>\n\n"
-        '<img src="/static/ORCIDiD_icon128x128.png" height="18" width="18"/> '
-        f'<a href="{ORCID_BASE_URL}/oauth/authorize?client_id={ORCID_NMDC_CLIENT_ID}'
-        "&response_type=code&scope=openid&"
-        f'redirect_uri={BASE_URL_EXTERNAL}/orcid_code">Login with ORCiD</a>'
-        " (note: this link is static; if you are logged in, you will see a 'locked' lock icon"
-        " in the below-right 'Authorized' button.)"
+    description=make_api_description(
+        schema_version=version("nmdc_schema"),
+        orcid_login_url=f"{ORCID_BASE_URL}/oauth/authorize?client_id={ORCID_NMDC_CLIENT_ID}&response_type=code&scope=openid&redirect_uri={BASE_URL_EXTERNAL}/orcid_code",
     ),
     openapi_tags=ordered_tag_descriptors,
     lifespan=lifespan,

--- a/nmdc_runtime/api/openapi.py
+++ b/nmdc_runtime/api/openapi.py
@@ -1,0 +1,187 @@
+r"""
+This module contains the definitions of constants and functions related to
+generating the API's OpenAPI schema (a.k.a. Swagger schema).
+
+References:
+- FastAPI Documentation: https://fastapi.tiangolo.com/tutorial/metadata/
+
+Notes:
+- The tag descriptions in this file were cut/pasted from `nmdc_runtime/api/main.py`.
+  Now that they are in a separate module, we will be able to edit them more easily.
+"""
+
+from typing import List, Dict
+
+# Mapping from tag names to their (Markdown-formatted) descriptions.
+tag_descriptions: Dict[str, str] = {}
+
+tag_descriptions["sites"] = r"""
+A site corresponds to a physical place that may participate in job execution.
+
+A site may register data objects and capabilities with NMDC. It may claim jobs to execute, and it may
+update job operations with execution info.
+
+A site must be able to service requests for any data objects it has registered.
+
+A site may expose a "put object" custom method for authorized users. This method facilitates an
+operation to upload an object to the site and have the site register that object with the runtime
+system.
+"""
+
+tag_descriptions["workflows"] = r"""
+A workflow is a template for creating jobs.
+
+Workflow jobs are typically created by the system via trigger associations between
+workflows and object types. A workflow may also require certain capabilities of sites
+in order for those sites to claim workflow jobs.
+"""
+
+tag_descriptions["users"] = r"""
+Endpoints for user identification.
+
+Currently, accounts for use with the Runtime API are created manually by system administrators.
+"""
+
+tag_descriptions["capabilities"] = r"""
+A workflow may require an executing site to have particular capabilities.
+
+These capabilities go beyond the simple ability to access the data object resources registered with
+the runtime system. Sites register their capabilities, and sites are only able to claim workflow
+jobs if they are known to have the capabilities required by the workflow.
+"""
+
+tag_descriptions["object types"] = r"""
+An object type is an object annotation that is useful for triggering workflows.
+
+A data object may be annotated with one or more types, which in turn can be associated with
+workflows through trigger resources.
+
+The data-object type system may be used to trigger workflow jobs on a subset of data objects when a
+new version of a workflow is deployed. This could be done by minting a special object type for the
+occasion, annotating the subset of data objects with that type, and registering the association of
+object type to workflow via a trigger resource.
+"""
+
+tag_descriptions["triggers"] = r"""
+A trigger is an association between a workflow and a data object type.
+
+When a data object is annotated with a type, perhaps shortly after object registration, the NMDC
+Runtime will check, via trigger associations, for potential new jobs to create for any workflows.
+"""
+
+tag_descriptions["jobs"] = r"""
+A job is a resource that isolates workflow configuration from execution.
+
+Rather than directly creating a workflow operation by supplying a workflow ID along with
+configuration, NMDC creates a job that pairs a workflow with configuration. Then, a site can claim a
+job ID, allowing the site to execute the intended workflow without additional configuration.
+
+A job can have multiple executions, and a workflow's executions are precisely the executions of all
+jobs created for that workflow.
+
+A site that already has a compatible job execution result can preempt the unnecessary creation of a
+job by pre-claiming it. This will return like a claim, and now the site can register known data
+object inputs for the job without the risk of the runtime system creating a claimable job of the
+pre-claimed type.
+"""
+
+tag_descriptions["objects"] = r"""
+A [Data Repository Service (DRS)
+object](https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.1.0/docs/#_drs_datatypes)
+represents content necessary for a workflow job to execute, and/or output from a job execution.
+
+An object may be a *blob*, analogous to a file, or a *bundle*, analogous to a folder. Sites register
+objects, and sites must ensure that these objects are accessible to the NMDC data broker.
+
+An object may be associated with one or more object types, useful for triggering workflows.
+"""
+
+tag_descriptions["operations"] = r"""
+An operation is a resource for tracking the execution of a job.
+
+When a job is claimed by a site for execution, an operation resource is created.
+
+An operation is akin to a "promise" or "future" in that it should eventually resolve to either a
+successful result, i.e. an execution resource, or to an error.
+
+An operation is parameterized to return a result type, and a metadata type for storing progress
+information, that are both particular to the job type.
+
+Operations may be paused, resumed, and/or cancelled.
+
+Operations may expire, i.e. not be stored indefinitely. In this case, it is recommended that
+execution resources have longer lifetimes / not expire, so that information about successful results
+of operations are available.
+"""
+
+tag_descriptions["queries"] = r"""
+A query is an operation (find, update, etc.) against the metadata store.
+
+Metadata -- for studies, biosamples, omics processing, etc. -- is used by sites to execute jobs,
+as the parameterization of job executions may depend not only on the content of data objects, but
+also on objects' associated metadata.
+
+Also, the function of many workflows is to extract or produce new metadata. Such metadata products
+should be registered as data objects, and they may also be supplied by sites to the runtime system
+as an update query (if the latter is not done, the runtime system will sense the new metadata and
+issue an update query).
+"""
+
+tag_descriptions["metadata"] = r"""
+The [metadata endpoints](https://api.microbiomedata.org/docs#/metadata) can be used to get and filter
+metadata from collection set types (including 
+[studies](https://w3id.org/nmdc/Study/), 
+[biosamples](https://w3id.org/nmdc/Biosample/), 
+[planned processes](https://w3id.org/nmdc/PlannedProcess/), and 
+[data objects](https://w3id.org/nmdc/DataObject/) 
+as discussed in the __find__ section).
+<br/>
+ 
+The __metadata__ endpoints allow users to retrieve metadata from the data portal using the various
+GET endpoints  that are slightly different than the __find__ endpoints, but some can be used similarly.
+As with the __find__ endpoints,  parameters for the __metadata__ endpoints that do not have a
+red ___* required___ next to them are optional. <br/>
+
+Unlike the compact syntax used in the __find__  endpoints, the syntax for the filter parameter of
+the metadata endpoints
+uses [MongoDB-like language querying](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
+"""
+
+tag_descriptions["find"] = r"""
+The [find endpoints](https://api.microbiomedata.org/docs#/find) are provided with NMDC metadata entities
+already specified - where metadata about [studies](https://w3id.org/nmdc/Study),
+[biosamples](https://w3id.org/nmdc/Biosample), [data objects](https://w3id.org/nmdc/DataObject/),
+and [planned processes](https://w3id.org/nmdc/PlannedProcess/) can be retrieved using GET requests.
+<br/>
+
+Each endpoint is unique and requires the applicable attribute names to be known in order to structure a query
+in a meaningful way.  Parameters that do not have a red ___* required___ label next to them are optional.
+"""
+
+tag_descriptions["runs"] = r"""
+**WORK IN PROGRESS**
+
+Run simple jobs.
+
+For off-site job runs, keep the Runtime appraised of run events.
+"""
+
+# Remove leading and trailing whitespace from each description.
+for name, description in tag_descriptions.items():
+    tag_descriptions[name] = description.strip()
+
+ordered_tag_descriptors: List[Dict[str, str]] = [
+    {"name": "sites", "description": tag_descriptions["sites"]},
+    {"name": "users", "description": tag_descriptions["users"]},
+    {"name": "workflows", "description": tag_descriptions["workflows"]},
+    {"name": "capabilities", "description": tag_descriptions["capabilities"]},
+    {"name": "object types", "description": tag_descriptions["object types"]},
+    {"name": "triggers", "description": tag_descriptions["triggers"]},
+    {"name": "jobs", "description": tag_descriptions["jobs"]},
+    {"name": "objects", "description": tag_descriptions["objects"]},
+    {"name": "operations", "description": tag_descriptions["operations"]},
+    {"name": "queries", "description": tag_descriptions["queries"]},
+    {"name": "metadata", "description": tag_descriptions["metadata"]},
+    {"name": "find", "description": tag_descriptions["find"]},
+    {"name": "runs", "description": tag_descriptions["runs"]},
+]

--- a/nmdc_runtime/api/openapi.py
+++ b/nmdc_runtime/api/openapi.py
@@ -15,7 +15,9 @@ from typing import List, Dict
 # Mapping from tag names to their (Markdown-formatted) descriptions.
 tag_descriptions: Dict[str, str] = {}
 
-tag_descriptions["sites"] = r"""
+tag_descriptions[
+    "sites"
+] = r"""
 A site corresponds to a physical place that may participate in job execution.
 
 A site may register data objects and capabilities with NMDC. It may claim jobs to execute, and it may
@@ -28,7 +30,9 @@ operation to upload an object to the site and have the site register that object
 system.
 """
 
-tag_descriptions["workflows"] = r"""
+tag_descriptions[
+    "workflows"
+] = r"""
 A workflow is a template for creating jobs.
 
 Workflow jobs are typically created by the system via trigger associations between
@@ -36,13 +40,17 @@ workflows and object types. A workflow may also require certain capabilities of 
 in order for those sites to claim workflow jobs.
 """
 
-tag_descriptions["users"] = r"""
+tag_descriptions[
+    "users"
+] = r"""
 Endpoints for user identification.
 
 Currently, accounts for use with the Runtime API are created manually by system administrators.
 """
 
-tag_descriptions["capabilities"] = r"""
+tag_descriptions[
+    "capabilities"
+] = r"""
 A workflow may require an executing site to have particular capabilities.
 
 These capabilities go beyond the simple ability to access the data object resources registered with
@@ -50,7 +58,9 @@ the runtime system. Sites register their capabilities, and sites are only able t
 jobs if they are known to have the capabilities required by the workflow.
 """
 
-tag_descriptions["object types"] = r"""
+tag_descriptions[
+    "object types"
+] = r"""
 An object type is an object annotation that is useful for triggering workflows.
 
 A data object may be annotated with one or more types, which in turn can be associated with
@@ -62,14 +72,18 @@ occasion, annotating the subset of data objects with that type, and registering 
 object type to workflow via a trigger resource.
 """
 
-tag_descriptions["triggers"] = r"""
+tag_descriptions[
+    "triggers"
+] = r"""
 A trigger is an association between a workflow and a data object type.
 
 When a data object is annotated with a type, perhaps shortly after object registration, the NMDC
 Runtime will check, via trigger associations, for potential new jobs to create for any workflows.
 """
 
-tag_descriptions["jobs"] = r"""
+tag_descriptions[
+    "jobs"
+] = r"""
 A job is a resource that isolates workflow configuration from execution.
 
 Rather than directly creating a workflow operation by supplying a workflow ID along with
@@ -85,7 +99,9 @@ object inputs for the job without the risk of the runtime system creating a clai
 pre-claimed type.
 """
 
-tag_descriptions["objects"] = r"""
+tag_descriptions[
+    "objects"
+] = r"""
 A [Data Repository Service (DRS)
 object](https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.1.0/docs/#_drs_datatypes)
 represents content necessary for a workflow job to execute, and/or output from a job execution.
@@ -96,7 +112,9 @@ objects, and sites must ensure that these objects are accessible to the NMDC dat
 An object may be associated with one or more object types, useful for triggering workflows.
 """
 
-tag_descriptions["operations"] = r"""
+tag_descriptions[
+    "operations"
+] = r"""
 An operation is a resource for tracking the execution of a job.
 
 When a job is claimed by a site for execution, an operation resource is created.
@@ -114,7 +132,9 @@ execution resources have longer lifetimes / not expire, so that information abou
 of operations are available.
 """
 
-tag_descriptions["queries"] = r"""
+tag_descriptions[
+    "queries"
+] = r"""
 A query is an operation (find, update, etc.) against the metadata store.
 
 Metadata -- for studies, biosamples, omics processing, etc. -- is used by sites to execute jobs,
@@ -127,7 +147,9 @@ as an update query (if the latter is not done, the runtime system will sense the
 issue an update query).
 """
 
-tag_descriptions["metadata"] = r"""
+tag_descriptions[
+    "metadata"
+] = r"""
 The [metadata endpoints](https://api.microbiomedata.org/docs#/metadata) can be used to get and filter
 metadata from collection set types (including 
 [studies](https://w3id.org/nmdc/Study/), 
@@ -147,7 +169,9 @@ the metadata endpoints
 uses [MongoDB-like language querying](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
 """
 
-tag_descriptions["find"] = r"""
+tag_descriptions[
+    "find"
+] = r"""
 The [find endpoints](https://api.microbiomedata.org/docs#/find) are provided with NMDC metadata entities
 already specified - where metadata about [studies](https://w3id.org/nmdc/Study),
 [biosamples](https://w3id.org/nmdc/Biosample), [data objects](https://w3id.org/nmdc/DataObject/),
@@ -158,7 +182,9 @@ Each endpoint is unique and requires the applicable attribute names to be known 
 in a meaningful way.  Parameters that do not have a red ___* required___ label next to them are optional.
 """
 
-tag_descriptions["runs"] = r"""
+tag_descriptions[
+    "runs"
+] = r"""
 **WORK IN PROGRESS**
 
 Run simple jobs.

--- a/nmdc_runtime/api/openapi.py
+++ b/nmdc_runtime/api/openapi.py
@@ -212,6 +212,7 @@ ordered_tag_descriptors: List[Dict[str, str]] = [
     {"name": "runs", "description": tag_descriptions["runs"]},
 ]
 
+
 def make_api_description(schema_version: str, orcid_login_url: str) -> str:
     r"""
     Returns an API description into which the specified schema version and

--- a/nmdc_runtime/api/openapi.py
+++ b/nmdc_runtime/api/openapi.py
@@ -211,3 +211,29 @@ ordered_tag_descriptors: List[Dict[str, str]] = [
     {"name": "find", "description": tag_descriptions["find"]},
     {"name": "runs", "description": tag_descriptions["runs"]},
 ]
+
+def make_api_description(schema_version: str, orcid_login_url: str) -> str:
+    r"""
+    Returns an API description into which the specified schema version and
+    ORCID login URL have been incorporated.
+
+    Args:
+        schema_version (str): The version of `nmdc-schema` the Runtime is using.
+        orcid_login_url (str): The URL at which a user could login via ORCID.
+
+    Returns:
+        str: The Markdown-formatted API description.
+    """
+    result = f"""
+The NMDC Runtime API, via on-demand functions and via schedule-based and sensor-based automation, 
+supports validation and submission of metadata, as well as orchestration of workflow executions.
+
+[NMDC Schema](https://microbiomedata.github.io/nmdc-schema/) version: `{schema_version}`
+
+[Documentation](https://docs.microbiomedata.org/runtime/)
+
+<img src="/static/ORCIDiD_icon128x128.png" height="18" width="18"/>
+[Login with ORCID]({orcid_login_url}) (if you are logged in, you will see a _closed_ padlock icon
+in the below-right "Authorized" button.)
+""".strip()
+    return result

--- a/nmdc_runtime/api/swagger_ui/assets/script.js
+++ b/nmdc_runtime/api/swagger_ui/assets/script.js
@@ -12,13 +12,13 @@ window.addEventListener("nmdcInit", (event) => {{
         if (tokenEl.dataset.state == "masked") {{
             console.debug("Unmasking token");
             tokenEl.dataset.state = "unmasked";
-            tokenEl.innerHTML = tokenEl.dataset.tokenValue;
-            event.target.innerHTML = "Hide token";
+            tokenEl.textContent = tokenEl.dataset.tokenValue;
+            event.target.textContent = "Hide token";
         }} else {{
             console.debug("Masking token");
             tokenEl.dataset.state = "masked";
-            tokenEl.innerHTML = "***";
-            event.target.innerHTML = "Show token";
+            tokenEl.textContent = "***";
+            event.target.textContent = "Show token";
         }}
     }});
 
@@ -26,7 +26,7 @@ window.addEventListener("nmdcInit", (event) => {{
     // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText
     console.debug("Setting up token copier");
     tokenCopierEl.addEventListener("click", async (event) => {{
-        tokenCopierMessageEl.innerHTML = "";
+        tokenCopierMessageEl.textContent = "";
         try {{                            
             await navigator.clipboard.writeText(tokenEl.dataset.tokenValue);
             tokenCopierMessageEl.innerHTML = "<span class='nmdc-success'>Copied to clipboard</span>";

--- a/nmdc_runtime/api/swagger_ui/assets/script.js
+++ b/nmdc_runtime/api/swagger_ui/assets/script.js
@@ -1,0 +1,38 @@
+console.debug("Listening for event: nmdcInit");
+window.addEventListener("nmdcInit", (event) => {{
+    // Get the DOM elements we'll be referencing below. 
+    const tokenMaskTogglerEl = document.getElementById("token-mask-toggler");
+    const tokenEl = document.getElementById("token");
+    const tokenCopierEl = document.getElementById("token-copier");
+    const tokenCopierMessageEl = document.getElementById("token-copier-message");
+    
+    // Set up the token visibility toggler.
+    console.debug("Setting up token visibility toggler");
+    tokenMaskTogglerEl.addEventListener("click", (event) => {{
+        if (tokenEl.dataset.state == "masked") {{
+            console.debug("Unmasking token");
+            tokenEl.dataset.state = "unmasked";
+            tokenEl.innerHTML = tokenEl.dataset.tokenValue;
+            event.target.innerHTML = "Hide token";
+        }} else {{
+            console.debug("Masking token");
+            tokenEl.dataset.state = "masked";
+            tokenEl.innerHTML = "***";
+            event.target.innerHTML = "Show token";
+        }}
+    }});
+
+    // Set up the token copier.
+    // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText
+    console.debug("Setting up token copier");
+    tokenCopierEl.addEventListener("click", async (event) => {{
+        tokenCopierMessageEl.innerHTML = "";
+        try {{                            
+            await navigator.clipboard.writeText(tokenEl.dataset.tokenValue);
+            tokenCopierMessageEl.innerHTML = "<span class='nmdc-success'>Copied to clipboard</span>";
+        }} catch (error) {{
+            console.error(error.message);
+            tokenCopierMessageEl.innerHTML = "<span class='nmdc-error'>Copying failed</span>";
+        }}
+    }})
+}});

--- a/nmdc_runtime/api/swagger_ui/assets/style.css
+++ b/nmdc_runtime/api/swagger_ui/assets/style.css
@@ -1,0 +1,14 @@
+.nmdc-info {
+    padding: 1em;
+    background-color: #448aff1a;
+    border: .075rem solid #448aff;
+}
+.nmdc-info-token code {
+    font-size: x-small;
+}
+.nmdc-success {
+    color: green;
+}
+.nmdc-error {
+    color: red;
+}


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I extracted several things related to OpenAPI from the `nmdc_runtime/api/main.py` file into other files. This was in an attempt to make the OpenAPI aspects of the code base easier for people to maintain.

Specifically, I:
- Extracted the tag descriptions and tag order specifier into a separate Python module, `openapi.py`
- Extracted the API description into that same Python module, `openapi.py`
- Extracted a literal CSS snippet into a new CSS file, `style.css`
- Extracted a literal JavaScript snippet into a new JS file, `script.js`

There are other JavaScript snippets in `main.py` which I did not extract. The reason I haven't extracted those yet is that there is a custom quote conversion happening with them that I didn't want to get into today.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

The [ticket](https://github.com/microbiomedata/nmdc-runtime/issues/681) for doing this was created last September. I opted to implement this now, specifically, because some team members are planning to discuss the reordering of the tags (i.e. sections) on Swagger UI later this week (which can be achieved by reordering the items in the `ordered_tag_descriptors` list).

Here's a before-and-after screenshot showing the impact these changes have on the Swagger UI web page. The "NMDC Schema" link points to the schema docs website.

![image](https://github.com/user-attachments/assets/9eaee1bb-5265-4f11-8390-e4eda6127cb4)

Refining the tag descriptions is **out of scope** of this PR. This PR is focused on code maintainability.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #681

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by viewing Swagger UI in my local development environment.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

I didn't make any changes that impact documentation.

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
