### PR TITLE
Fix bug where `/data_objects/study/{study_id}` does not return all related data objects

### DIFF
--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -810,115 +810,118 @@ def test_get_related_ids_returns_related_ids(
     assert {study_a["id"]} == set([r["id"] for r in response_resource["influenced"]])
 
 
-def test_find_data_objects_for_nonexistent_study(api_site_client):
+class TestFindDataObjectsForStudy:
     r"""
-    Confirms the endpoint returns an unsuccessful status code when no `Study` having the specified `id` exists.
-    Reference: https://docs.pytest.org/en/stable/reference/reference.html#pytest.raises
-
-    Note: The `api_site_client` fixture's `request` method will raise an exception if the server responds with
-          an unsuccessful status code.
+    Tests targeting the `/data_objects/study/{study_id}` API endpoint.
     """
-    ensure_alldocs_collection_has_been_materialized()
-    with pytest.raises(requests.exceptions.HTTPError):
-        api_site_client.request(
-            "GET",
-            "/data_objects/study/nmdc:sty-11-fake",
-        )
 
+    def test_returns_404_error_for_nonexistent_study(self, api_site_client):
+        r"""
+        Confirms the endpoint returns an unsuccessful status code when no `Study` having the specified `id` exists.
+        Reference: https://docs.pytest.org/en/stable/reference/reference.html#pytest.raises
 
-def test_find_data_objects_for_study_having_none(api_site_client):
-    # Seed the test database with a study having no associated data objects.
-    mdb = get_mongo_db()
-    study_id = "nmdc:sty-00-beeeeeef"
-    study_dict = {
-        "id": study_id,
-        "type": "nmdc:Study",
-        "study_category": "research_study",
-    }
-    assert validate_json({"study_set": [study_dict]}, mdb)["result"] != "errors"
+        Note: The `api_site_client` fixture's `request` method will raise an exception if the server responds with
+            an unsuccessful status code.
+        """
+        ensure_alldocs_collection_has_been_materialized()
+        mdb = get_mongo_db()
+        study_set = mdb.get_collection(name="study_set")
+        nonexistent_study_id = "nmdc:sty-11-fake"
+        assert study_set.count_documents({"id": nonexistent_study_id}) == 0
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            api_site_client.request(
+                "GET",
+                f"/data_objects/study/{nonexistent_study_id}",
+            )
+        assert exc_info.value.response.status_code == status.HTTP_404_NOT_FOUND
 
-    mdb.get_collection(name="study_set").replace_one(
-        {"id": study_id}, study_dict, upsert=True
-    )
+    def test_it_returns_empty_list_for_study_having_no_data_objects(self, api_site_client):
+        # Seed the test database with a study having no associated data objects.
+        mdb = get_mongo_db()
+        study_set = mdb.get_collection(name="study_set")
+        alldocs = mdb.get_collection(name="alldocs")
+        faker = Faker()
+        study = faker.generate_studies(quantity=1)[0]
+        assert study_set.count_documents({"id": study["id"]}) == 0
+        study_set.insert_many([study])
 
-    # Update the `alldocs` collection, which is a cache used by the endpoint under test.
-    ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
+        # Update the `alldocs` collection, which is a cache used by the endpoint under test.
+        ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
 
-    # Confirm the endpoint responds with no data objects.
-    response = api_site_client.request("GET", f"/data_objects/study/{study_id}")
-    assert response.status_code == 200
-    data_objects_by_biosample = response.json()
-    assert len(data_objects_by_biosample) == 0
+        # Confirm the endpoint responds with no data objects.
+        response = api_site_client.request("GET", f"/data_objects/study/{study['id']}")
+        assert response.status_code == 200
+        data_objects_by_biosample = response.json()
+        assert len(data_objects_by_biosample) == 0
 
-    # Clean up: Delete the documents we created within this test, from the database.
-    mdb.get_collection(name="study_set").delete_one({"id": study_id})
-    mdb.get_collection(name="alldocs").delete_many({})
+        # Clean up: Delete the documents we created within this test, from the database.
+        study_set.delete_many({"id": study["id"]})
+        alldocs.delete_many({})
 
+    def test_it_returns_one_data_object_for_study_having_one(self, api_site_client):
+        # Seed the database with the following interrelated documents (represented
+        # here as a Mermaid graph/flowchart within a Markdown fenced code block):
+        # Docs: https://mermaid.js.org/syntax/flowchart.html
+        # TODO: Move this seeding to a test fixture that cleans up after itself.
+        r"""
+        ```mermaid
+        graph BT
+            study
+            biosample --> |associated_studies| study
+            data_generation --> |associated_studies| study
+            data_generation --> |has_input| biosample
+            data_object
+            workflow_execution --> |has_input| biosample
+            workflow_execution --> |has_output| data_object
+            workflow_execution --> |was_informed_by| data_generation
+        ```
+        """
+        faker = Faker()
+        study = faker.generate_studies(quantity=1)[0]
+        biosample = faker.generate_biosamples(quantity=1, associated_studies=[study["id"]])[0]
+        data_generation = faker.generate_nucleotide_sequencings(quantity=1, associated_studies=[study["id"]], has_input=[biosample["id"]])[0]
+        data_object = faker.generate_data_objects(quantity=1)[0]
+        workflow_execution = faker.generate_metagenome_annotations(quantity=1, has_input=[biosample["id"]], has_output=[data_object["id"]], was_informed_by=data_generation["id"])[0]
+        
+        mdb = get_mongo_db()
+        study_set = mdb.get_collection(name="study_set")
+        biosample_set = mdb.get_collection(name="biosample_set")
+        data_generation_set = mdb.get_collection(name="data_generation_set")
+        data_object_set = mdb.get_collection(name="data_object_set")
+        workflow_execution_set = mdb.get_collection(name="workflow_execution_set")
+        alldocs = mdb.get_collection(name="alldocs")
+        assert study_set.count_documents({"id": study["id"]}) == 0
+        assert biosample_set.count_documents({"id": biosample["id"]}) == 0
+        assert data_generation_set.count_documents({"id": data_generation["id"]}) == 0
+        assert data_object_set.count_documents({"id": data_object["id"]}) == 0
+        assert workflow_execution_set.count_documents({"id": workflow_execution["id"]}) == 0
+        study_set.insert_many([study])
+        biosample_set.insert_many([biosample])
+        data_generation_set.insert_many([data_generation])
+        data_object_set.insert_many([data_object])
+        workflow_execution_set.insert_many([workflow_execution])
 
-def test_find_data_objects_for_study_having_one(api_site_client):
-    # Seed the database with the following interrelated documents (represented
-    # here as a Mermaid graph/flowchart within a Markdown fenced code block):
-    # Docs: https://mermaid.js.org/syntax/flowchart.html
-    # TODO: Move this seeding to a test fixture that cleans up after itself.
-    r"""
-    ```mermaid
-    graph BT
-        study
-        biosample --> |associated_studies| study
-        data_generation --> |associated_studies| study
-        data_generation --> |has_input| biosample
-        data_object
-        workflow_execution --> |has_input| biosample
-        workflow_execution --> |has_output| data_object
-        workflow_execution --> |was_informed_by| data_generation
-    ```
-    """
-    faker = Faker()
-    study = faker.generate_studies(quantity=1)[0]
-    biosample = faker.generate_biosamples(quantity=1, associated_studies=[study["id"]])[0]
-    data_generation = faker.generate_nucleotide_sequencings(quantity=1, associated_studies=[study["id"]], has_input=[biosample["id"]])[0]
-    data_object = faker.generate_data_objects(quantity=1)[0]
-    workflow_execution = faker.generate_metagenome_annotations(quantity=1, has_input=[biosample["id"]], has_output=[data_object["id"]], was_informed_by=data_generation["id"])[0]
-    
-    mdb = get_mongo_db()
-    study_set = mdb.get_collection(name="study_set")
-    biosample_set = mdb.get_collection(name="biosample_set")
-    data_generation_set = mdb.get_collection(name="data_generation_set")
-    data_object_set = mdb.get_collection(name="data_object_set")
-    workflow_execution_set = mdb.get_collection(name="workflow_execution_set")
-    alldocs = mdb.get_collection(name="alldocs")
-    assert study_set.count_documents({"id": study["id"]}) == 0
-    assert biosample_set.count_documents({"id": biosample["id"]}) == 0
-    assert data_generation_set.count_documents({"id": data_generation["id"]}) == 0
-    assert data_object_set.count_documents({"id": data_object["id"]}) == 0
-    assert workflow_execution_set.count_documents({"id": workflow_execution["id"]}) == 0
-    study_set.insert_many([study])
-    biosample_set.insert_many([biosample])
-    data_generation_set.insert_many([data_generation])
-    data_object_set.insert_many([data_object])
-    workflow_execution_set.insert_many([workflow_execution])
+        # Update the `alldocs` collection, which is a cache used by the endpoint under test.
+        ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
 
-    # Update the `alldocs` collection, which is a cache used by the endpoint under test.
-    ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
+        # Confirm the endpoint responds with the data object we inserted above.
+        response = api_site_client.request("GET", f"/data_objects/study/{study['id']}")
+        assert response.status_code == 200
+        data_objects_by_biosample = response.json()
+        assert len(data_objects_by_biosample) == 1
+        received_biosample = data_objects_by_biosample[0]
+        assert received_biosample["biosample_id"] == biosample["id"]
+        assert len(received_biosample["data_objects"]) == 1
+        received_data_object = received_biosample["data_objects"][0]
+        assert received_data_object["id"] == data_object["id"]
 
-    # Confirm the endpoint responds with the data object we inserted above.
-    response = api_site_client.request("GET", f"/data_objects/study/{study['id']}")
-    assert response.status_code == 200
-    data_objects_by_biosample = response.json()
-    assert len(data_objects_by_biosample) == 1
-    received_biosample = data_objects_by_biosample[0]
-    assert received_biosample["biosample_id"] == biosample["id"]
-    assert len(received_biosample["data_objects"]) == 1
-    received_data_object = received_biosample["data_objects"][0]
-    assert received_data_object["id"] == data_object["id"]
-
-    # Clean up: Delete the documents we created within this test, from the database.
-    study_set.delete_many({"id": study["id"]})
-    biosample_set.delete_many({"id": biosample["id"]})
-    data_generation_set.delete_many({"id": data_generation["id"]})
-    data_object_set.delete_many({"id": data_object["id"]})
-    workflow_execution_set.delete_many({"id": workflow_execution["id"]})
-    alldocs.delete_many({})
+        # Clean up: Delete the documents we created within this test, from the database.
+        study_set.delete_many({"id": study["id"]})
+        biosample_set.delete_many({"id": biosample["id"]})
+        data_generation_set.delete_many({"id": data_generation["id"]})
+        data_object_set.delete_many({"id": data_object["id"]})
+        workflow_execution_set.delete_many({"id": workflow_execution["id"]})
+        alldocs.delete_many({})
 
 
 def test_find_planned_processes(api_site_client):

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -815,16 +815,12 @@ class TestFindDataObjectsForStudy:
     Tests targeting the `/data_objects/study/{study_id}` API endpoint.
     """
 
-    def __init__(self):
-        r"""
-        Defines some constant IDs that the seeder can use and that seeded
-        database-dependent tests can "expect."
-        """
-        self.study_id = "nmdc:sty-00-000001"
-        self.biosample_id = "nmdc:bsm-00-000001"
-        self.data_generation_id = "nmdc:dgns-00-000001"
-        self.data_object_ids = ["nmdc:dobj-00-000001", "nmdc:dobj-00-000002"]
-        self.workflow_execution_id = "nmdc:wfmgan-00-000001"
+    # Constant IDs that the seeder can use and that seeded database-dependent tests can "expect."
+    study_id = "nmdc:sty-00-000001"
+    biosample_id = "nmdc:bsm-00-000001"
+    data_generation_id = "nmdc:dgns-00-000001"
+    data_object_ids = ["nmdc:dobj-00-000001", "nmdc:dobj-00-000002", "nmdc:dobj-00-000003"]
+    workflow_execution_id = "nmdc:wfmgan-00-000001"
 
     @pytest.fixture()
     def seeded_db(self):
@@ -970,7 +966,10 @@ class TestFindDataObjectsForStudy:
         assert received_biosample["biosample_id"] == self.biosample_id
         assert len(received_biosample["data_objects"]) == 2
         received_data_objects = received_biosample["data_objects"]
-        assert set(self.data_object_ids) == set([dobj["id"] for dobj in received_data_objects])
+        assert set([
+            self.data_object_ids[0],
+            self.data_object_ids[1],
+        ]) == set([dobj["id"] for dobj in received_data_objects])
 
 
 def test_find_planned_processes(api_site_client):

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1007,6 +1007,7 @@ class TestFindDataObjectsForStudy:
         # Clean up: Delete the documents we created within this fixture, from the database.
         workflow_execution_set.delete_many({"id": workflow_execution_b["id"]})
         data_object_set.delete_many({"id": data_object_c["id"]})
+        ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)        
 
     def test_it_traverses_multiple_stages_of_workflow_executions(
         self,

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -859,6 +859,8 @@ class TestFindDataObjectsForStudy:
         data_object_a, data_object_b = faker.generate_data_objects(quantity=2)
         data_object_a["id"] = self.data_object_ids[0]
         data_object_b["id"] = self.data_object_ids[1]
+        data_object_a["data_category"] = "instrument_data"
+        data_object_b["data_category"] = "processed_data"
         workflow_execution = faker.generate_metagenome_annotations(quantity=1, id=self.workflow_execution_id, has_input=[biosample["id"]], has_output=[data_object_a["id"], data_object_b["id"]], was_informed_by=data_generation["id"])[0]
         
         mdb = get_mongo_db()
@@ -947,7 +949,7 @@ class TestFindDataObjectsForStudy:
         # Update the `alldocs` collection, which is a cache used by the endpoint under test.
         ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
 
-        # Confirm the endpoint responds with the data object we inserted above.
+        # Confirm the endpoint responds with the data object we expect.
         response = api_site_client.request("GET", f"/data_objects/study/{self.study_id}")
         assert response.status_code == 200
         data_objects_by_biosample = response.json()
@@ -959,7 +961,7 @@ class TestFindDataObjectsForStudy:
         assert received_data_object["id"] == self.data_object_ids[0]
 
     def test_it_returns_data_objects_for_study_having_multiple(self, api_site_client, seeded_db):
-        # Confirm the endpoint responds with the data object we inserted above.
+        # Confirm the endpoint responds with the data objects we expect.
         response = api_site_client.request("GET", f"/data_objects/study/{self.study_id}")
         assert response.status_code == 200
         data_objects_by_biosample = response.json()


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, we updated the `/data_objects/study/{study_id}` endpoint to accommodate some recent changes to the `alldocs` collection (a cache-like collection that is not described by the schema), refactored the tests that targeted the endpoint, and added more such tests (including one that reproduces a previously-failing-now-working scenario).

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

The "refactoring" involved replacing literal dictionaries with invocations of `Faker` methods, and encapsulating all the tests into a common class.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

#1049 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

We tested these changes by confirming `make test` passes locally and the tests all pass when run by GHA.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
