### PR TITLE
Add depth units when translating submission records

### DIFF
--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -666,6 +666,11 @@ class SubmissionPortalTranslator(Translator):
                 logging.warning(f"No slot '{slot_name}' on class '{class_name}'")
                 continue
 
+            # This step handles cases where the submission portal/schema instructs a user to
+            # provide a value in a specific unit. The unit cannot be parsed out of the raw value
+            # in these cases, so we have to manually set it via UNIT_OVERRIDES. This part can
+            # go away once units are encoded in the schema itself.
+            # See: https://github.com/microbiomedata/nmdc-schema/issues/2517
             if class_name in UNIT_OVERRIDES:
                 # If the class has unit overrides, check if the slot is in the overrides
                 unit_overrides = UNIT_OVERRIDES[class_name]

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -47,6 +47,12 @@ DATA_URL_SET_AND_ANALYTE_TO_DATA_OBJECT_TYPE: dict[tuple[DataUrlSet, str], str] 
     (INTERLEAVED, str(METATRANSCRIPTOME)): "Metatranscriptome Raw Reads",
 }
 
+UNIT_OVERRIDES: dict[str, dict[str, str]] = {
+    "Biosample": {
+        "depth": "m",
+    }
+}
+
 
 class EnvironmentPackage(Enum):
     r"""
@@ -659,6 +665,12 @@ class SubmissionPortalTranslator(Translator):
             if slot_name not in slot_names:
                 logging.warning(f"No slot '{slot_name}' on class '{class_name}'")
                 continue
+
+            if class_name in UNIT_OVERRIDES:
+                # If the class has unit overrides, check if the slot is in the overrides
+                unit_overrides = UNIT_OVERRIDES[class_name]
+                if slot_name in unit_overrides:
+                    unit = unit_overrides[slot_name]
 
             slot_definition = self.schema_view.induced_slot(slot_name, class_name)
             if slot_definition.multivalued:

--- a/tests/test_data/data/nucleotide_sequencing_mapping_output.yaml
+++ b/tests/test_data/data/nucleotide_sequencing_mapping_output.yaml
@@ -32,6 +32,7 @@ biosample_set:
     depth:
       has_raw_value: '0'
       has_numeric_value: 0.0
+      has_unit: m
       type: nmdc:QuantityValue
     ecosystem: Environmental
     ecosystem_category: Terrestrial

--- a/tests/test_data/data/plant_air_jgi_output.yaml
+++ b/tests/test_data/data/plant_air_jgi_output.yaml
@@ -32,6 +32,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -96,6 +97,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -160,6 +162,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -224,6 +227,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -288,6 +292,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -352,6 +357,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -416,6 +422,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -480,6 +487,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -544,6 +552,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:
@@ -608,6 +617,7 @@ biosample_set:
   depth:
     has_raw_value: '0'
     has_numeric_value: 0.0
+    has_unit: m
     type: nmdc:QuantityValue
   elev: 286.0
   env_package:

--- a/tests/test_data/data/sequencing_data_input.yaml
+++ b/tests/test_data/data/sequencing_data_input.yaml
@@ -79,6 +79,7 @@ metadata_submission:
           env_broad_scale: mixed forest biome [ENVO:01000198]
           env_local_scale: area of evergreen forest [ENVO:01000843]
           samp_store_temp: -80 Cel
+          slope_gradient: 8%
         - elev: 1325
           depth: 0 - 0.1
           lat_lon: 43 -120
@@ -94,6 +95,7 @@ metadata_submission:
           env_broad_scale: mixed forest biome [ENVO:01000198]
           env_local_scale: area of evergreen forest [ENVO:01000843]
           samp_store_temp: -80 Cel
+          slope_gradient: 0%
         - elev: 1325
           depth: 0 - 0.1
           lat_lon: 43 -120
@@ -108,6 +110,7 @@ metadata_submission:
           env_broad_scale: mixed forest biome [ENVO:01000198]
           env_local_scale: area of evergreen forest [ENVO:01000843]
           samp_store_temp: -80 Cel
+          slope_gradient: 0.5%
       metagenome_sequencing_non_interleaved_data:
         - model: hiseq_1500
           samp_name: "001"

--- a/tests/test_data/data/sequencing_data_output.yaml
+++ b/tests/test_data/data/sequencing_data_output.yaml
@@ -60,6 +60,11 @@ biosample_set:
     has_raw_value: frozen
   analysis_type:
   - metagenomics
+  slope_gradient:
+    type: nmdc:QuantityValue
+    has_raw_value: '8%'
+    has_numeric_value: 8
+    has_unit: '%'
 - id: nmdc:bsm-00-q8jtgev4
   type: nmdc:Biosample
   name: '002'
@@ -122,6 +127,11 @@ biosample_set:
   analysis_type:
   - metagenomics
   - metatranscriptomics
+  slope_gradient:
+    type: nmdc:QuantityValue
+    has_raw_value: '0%'
+    has_numeric_value: 0
+    has_unit: '%'
 - id: nmdc:bsm-00-9gw1un94
   type: nmdc:Biosample
   name: '003'
@@ -183,6 +193,11 @@ biosample_set:
     has_raw_value: frozen
   analysis_type:
   - metatranscriptomics
+  slope_gradient:
+    type: nmdc:QuantityValue
+    has_raw_value: '0.5%'
+    has_numeric_value: 0.5
+    has_unit: '%'
 data_generation_set:
 - id: nmdc:dgns-00-27qd9afz
   type: nmdc:NucleotideSequencing

--- a/tests/test_data/data/sequencing_data_output.yaml
+++ b/tests/test_data/data/sequencing_data_output.yaml
@@ -34,6 +34,7 @@ biosample_set:
     has_raw_value: 0 - 0.1
     has_maximum_numeric_value: 0.1
     has_minimum_numeric_value: 0.0
+    has_unit: m
   elev: 1325.0
   env_package:
     type: nmdc:TextValue
@@ -94,6 +95,7 @@ biosample_set:
     has_raw_value: 0 - 0.1
     has_maximum_numeric_value: 0.1
     has_minimum_numeric_value: 0.0
+    has_unit: m
   elev: 1325.0
   env_package:
     type: nmdc:TextValue
@@ -155,6 +157,7 @@ biosample_set:
     has_raw_value: 0 - 0.1
     has_maximum_numeric_value: 0.1
     has_minimum_numeric_value: 0.0
+    has_unit: m
   elev: 1325.0
   env_package:
     type: nmdc:TextValue


### PR DESCRIPTION
On this branch, I updated the submission data translator to handle cases where the submission schema has an implicit unit on a slot.

### Details

The submission schema enforces a pattern like `{number}` or `{number} - {number}` on the `depth` slot, and it instructs the user (via the slot title and description) that the numbers should have unit meters. This runs counter to the submission data translator's existing logic of expecting to be able to extract a unit from the raw value provided by the user (i.e. something like `{number} {unit}`. The fix here to handle `depth` a special case where we will always set the `has_unit` value to `m`. 

### Related issue(s)

Fixes #1048 
Fixes https://github.com/microbiomedata/issues/issues/236

The special casing introduced here should be able to be removed after https://github.com/microbiomedata/nmdc-schema/issues/2517 is implemented. 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by updating and running existing unit tests.

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
