### PR TITLE
Update `ensure_default_api_perms` function to include aggregation permission

### DIFF
--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,5 +1,3 @@
-import pytest
-import os
 from nmdc_runtime.api.db.mongo import get_mongo_db
 from nmdc_runtime.api.main import ensure_default_api_perms
 

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,0 +1,31 @@
+import pytest
+import os
+from nmdc_runtime.api.db.mongo import get_mongo_db
+from nmdc_runtime.api.main import ensure_default_api_perms
+
+def test_admin_user_perms():
+    """Test that the admin user has all the expected allowances."""
+    
+    mdb = get_mongo_db()
+    # get the collection
+    allowances_collection = mdb.get_collection("_runtime.api.allow")
+    # dump into a list
+    original_allowances = list(allowances_collection.find({}))
+    # empty the collection
+    allowances_collection.delete_many({})
+    assert allowances_collection.count_documents({}) == 0, "Allowances collection should be empty"
+    # call the function to ensure default API permissions
+    ensure_default_api_perms()
+    # assert that the admin user has the expected allowances
+    allowances_after = list(allowances_collection.find({}))
+
+    expected_allowances = set(
+        ["/metadata/changesheets:submit", "/queries:run(query_cmd:DeleteCommand)", "/queries:run(query_cmd:AggregateCommand)", "/metadata/json:submit"]
+    )
+    actual_allowances = set(
+        allowance["action"] for allowance in allowances_after if allowance["username"] == "admin"
+    )
+    assert actual_allowances == expected_allowances, "Admin user should have the expected allowances"
+
+    # restore the original contents of the collection
+    allowances_collection.insert_many(original_allowances)


### PR DESCRIPTION
On this branch, I update the ensure_default_api_perms function so it ensures the admin user has aggregation permission

### Related issue

Fixes #1035.

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

- [ ] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by...

### Documentation

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
