### PR TITLE
Update `related_resources` endpoint to account for multiple `DataGeneration`s informing a `WorkflowExecution`

### DIFF
--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -410,10 +410,9 @@ def find_planned_process_by_id(
         "This endpoint returns a JSON object that contains "
         "(a) the specified `WorkflowExecution`, "
         "(b) all the `DataObject`s that are inputs to — or outputs from — the specified `WorkflowExecution`, "
-        "(c) all the `DataGeneration`s that generated those `DataObject`s, "
-        "(d) all the `Biosample`s that were inputs to those `DataGeneration`s, "
-        "(e) all the `Study`s with which those `Biosample`s are associated, and "
-        "(f) all the other `WorkflowExecution`s that are part of the same processing pipeline "
+        "(c) all the `Biosample`s that were inputs to those `DataGeneration`s, "
+        "(d) all the `Study`s with which those `Biosample`s are associated, and "
+        "(e) all the other `WorkflowExecution`s that are part of the same processing pipeline "
         "as the specified `WorkflowExecution`."
         "<br /><br />"  # newlines
         "**Note:** The data returned by this API endpoint can be up to 24 hours out of date "

--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -655,9 +655,7 @@ def find_related_objects_for_workflow_execution(
         # get all `Biosample`s and `Study`s associated with each of those `DataGeneration`s.
         dg_docs = mdb.alldocs.find({"id": {"$in": was_informed_by}})
         for dg_doc in dg_docs:
-            if any(
-                t in dg_descendants for t in dg_doc.get("_type_and_ancestors", [])
-            ):
+            if any(t in dg_descendants for t in dg_doc.get("_type_and_ancestors", [])):
                 # Get Biosamples from the DataGeneration's `has_input` field by recursively walking up the chain.
                 # While we recursively walk up the chain, we'll add those Biosamples to our list of Biosamples.
                 for input_id in dg_doc.get("has_input", []):


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the API endpoint to return `Biosample`s related to a `WorkflowExecution` through _any_ `DataGeneration`s that inform that `WorkflowExecution`, as opposed to only one of the `DataGeneration`s that informs it.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

To do that, I took a TDD approach: I first implemented a test demonstrating that (on `main`), when a `WorkflowExecution` "was informed by" two `DataGeneration`s, the API response only included the `Biosample` associated with _one_ of those `DataGeneration`s. Then, I updated the endpoint so that its response includes both `Biosample`s.

I also updated the endpoint's description to reflect the fact that its response payload does _not_ include `DataGeneration`s.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1083 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by implementing a test demonstrating the bug. The test failed before I made changes to the endpoint, then passed after I made changes to the endpoint. All other tests still pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
