### PR TITLE
Update boot code to ensure `jobs` collection has index on `config.activity_id` field

### DIFF
--- a/nmdc_runtime/api/models/util.py
+++ b/nmdc_runtime/api/models/util.py
@@ -252,4 +252,8 @@ entity_attributes_to_index = {
         "has_input",
         "has_output",
     },
+    # Note: The `jobs` collection is not described by the NMDC schema.
+    "jobs": {
+        "config.activity_id",
+    },
 }

--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -491,6 +491,11 @@ def populated_schema_collection_names_with_id_field(mdb: MongoDatabase) -> List[
 
 def ensure_unique_id_indexes(mdb: MongoDatabase):
     """Ensure that any collections with an "id" field have an index on "id"."""
+
+    # Note: The pipe (i.e. `|`) operator performs a union of the two sets. In this case,
+    #       it creates a set (i.e. `candidate_names`) consisting of the names of both
+    #       (a) all collections in the real database, and (b) all collections that
+    #       the NMDC schema says can contain instances of classes that have an "id" slot.
     candidate_names = (
         set(mdb.list_collection_names()) | schema_collection_names_with_id_field()
     )


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the standard index-creation code that runs as part of the Runtime's boot-up sequence, so that it creates (if one doesn't already exist) and index on the `config.activity_id` field of the `jobs` collection.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

This is all in an attempt to speed up some queries that are run within the `DELETE /workflows/workflow_executions/{workflow_execution_id}` endpoint.

I also added a comment to a separate function, in an attempt to make it easier for people to understand that that function affects both schema-described collections and non-schema-described collections.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

At least mitigates, if not fixes, issue #1101

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by manually creating the index in my local development environment and using...

```js
db.jobs.find({"config.activity_id": "nmdc:mgrqc0xxxx.1"}).explain("executionStats")["executionStats"]["executionTimeMillis"];
```

...to check how long the execution time was when (a) the index was active and (b) when the index was hidden. The numbers bounced a round a bit, but I came away with the impression that creating the index will result in around a 10x speed boost to that query.

I will also confirm that all the GHA tests still pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
