### PR TITLE
Update `filter` in ad hoc Mongo migration script to exclude irrelevant documents

### DIFF
--- a/db/migrations/ad_hoc_scripts/migrate_jobs_collection_from_schema_11.8.0_to_11.9.1.mongosh.js
+++ b/db/migrations/ad_hoc_scripts/migrate_jobs_collection_from_schema_11.8.0_to_11.9.1.mongosh.js
@@ -9,7 +9,15 @@ use("nmdc");
  */
 
 // 🔍 Define the filter for the documents we will be updating.
-const filter = { "config.was_informed_by": { $type: "string" } };
+//
+//    Note: The condition — `{ $type: "string" }` — will match documents where either
+//          (a) the value of `config.was_informed_by` is a string, or
+//          (b) the value is an array that contains a string.
+//          Since we don't want to match documents in (b), we include
+//          the additional condition — `$not: { $type: "array" } }`.
+//          Reference: https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-data-type
+//
+const filter = { "config.was_informed_by": { $type: "string", $not: { $type: "array" } } };
 
 // 🧮 Before: Print the total number of documents.
 let numDocsTotal = db.getCollection("jobs").countDocuments({});

--- a/db/migrations/ad_hoc_scripts/migrate_jobs_collection_from_schema_11.8.0_to_11.9.1.mongosh.js
+++ b/db/migrations/ad_hoc_scripts/migrate_jobs_collection_from_schema_11.8.0_to_11.9.1.mongosh.js
@@ -10,11 +10,11 @@ use("nmdc");
 
 // 🔍 Define the filter for the documents we will be updating.
 //
-//    Note: The condition — `{ $type: "string" }` — will match documents where either
+//    Note: The condition — `$type: "string"` — will match documents where either
 //          (a) the value of `config.was_informed_by` is a string, or
 //          (b) the value is an array that contains a string.
 //          Since we don't want to match documents in (b), we include
-//          the additional condition — `$not: { $type: "array" } }`.
+//          the additional condition — `$not: { $type: "array" }`.
 //          Reference: https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-data-type
 //
 const filter = { "config.was_informed_by": { $type: "string", $not: { $type: "array" } } };


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated a `filter` in an ad hoc migration script (which was run in production on Monday, July 28, 2025, as part of [Release 2025.7](https://github.com/microbiomedata/issues/issues/1263)). I updated the `filter` so that it no longer matches documents whose `config.was_informed_by` field consists of a list. This way, the final debug statement will produce a count of `0`, which will match the stated expectation.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

None.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

None.

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [x] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running the updated script in my local development environment.

```js
db.jobs.countDocuments({});
// -> 27060
db.jobs.countDocuments({ 
  "config.was_informed_by": { 
    $type: "string",
    $not: { $type: "array" }
  }
});
// -> 23380
db.jobs.countDocuments({ 
  "config.was_informed_by": { 
    $type: "string",
  }
});
// -> 23380
const filter = { "config.was_informed_by": { $type: "string" } };
db.jobs.updateMany(filter, [
  {
    $set: {
      "config.was_informed_by": ["$config.was_informed_by"],
    },
  }
]);
// -> {
//      acknowledged: true,
//      insertedId: null,
//      matchedCount: 23380,
//      modifiedCount: 23380,
//      upsertedCount: 0
//    }
db.jobs.countDocuments({ 
  "config.was_informed_by": { 
    $type: "string",
  }
});
// -> 23380
db.jobs.countDocuments({ 
  "config.was_informed_by": { 
    $type: "string",
    $not: { $type: "array" }
  }
});
// -> 0
```

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
