### PR TITLE
Fix miscellaneous issues about which pytest displays warnings

### DIFF
--- a/nmdc_runtime/api/core/util.py
+++ b/nmdc_runtime/api/core/util.py
@@ -103,4 +103,7 @@ def json_clean(data, model, exclude_unset=False) -> dict:
     if not isinstance(data, (dict, BaseModel)):
         raise TypeError("`data` must be a pydantic model or its .model_dump()")
     m = model(**data) if isinstance(data, dict) else data
-    return json.loads(m.json(exclude_unset=exclude_unset))
+
+    # Note: Between Pydantic v1 and v2, the `json` method was renamed to `model_dump_json`.
+    #       Reference: https://docs.pydantic.dev/2.11/migration/#changes-to-pydanticbasemodel
+    return json.loads(m.model_dump_json(exclude_unset=exclude_unset))

--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -371,7 +371,7 @@ def find_planned_process_by_id(
             title="PlannedProcess ID",
             description="The `id` of the document that represents an instance of "
             "the `PlannedProcess` class or any of its subclasses",
-            example=r"nmdc:wfmag-11-00jn7876.1",
+            examples=[r"nmdc:wfmag-11-00jn7876.1"],
         ),
     ],
     mdb: MongoDatabase = Depends(get_mongo_db),

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -90,7 +90,7 @@ def run_query(
         ),
     ] = False,
 ):
-    """
+    r"""
     Performs `find`, `aggregate`, `update`, `delete`, and `getMore` commands for users that have adequate permissions.
 
     For `find` and `aggregate` commands, the requested items will be in `cursor.batch`.

--- a/nmdc_runtime/api/models/object.py
+++ b/nmdc_runtime/api/models/object.py
@@ -90,7 +90,9 @@ class ContentsObject(BaseModel):
         return drs_uri
 
 
-ContentsObject.update_forward_refs()
+# Note: Between Pydantic v1 and v2, the `update_forward_refs` method was renamed to `model_rebuild`.
+#       Reference: https://docs.pydantic.dev/2.11/migration/#changes-to-pydanticbasemodel
+ContentsObject.model_rebuild()
 
 Mimetype = Annotated[str, StringConstraints(pattern=r"^\w+/[-+.\w]+$")]
 SizeInBytes = Annotated[int, Field(strict=True, ge=0)]

--- a/nmdc_runtime/lib/nmdc_dataframes.py
+++ b/nmdc_runtime/lib/nmdc_dataframes.py
@@ -305,10 +305,10 @@ def make_study_dataframe(study_table, contact_table, proposals_table, result_col
 
     ## make sure the contact ids are strings with the ".0" removed from the end (i.e., the strings aren't floats)
     study_table["contact_id"] = (
-        study_table["contact_id"].astype(str).replace("\.0", "", regex=True)
+        study_table["contact_id"].astype(str).replace(r"\.0", "", regex=True)
     )
     contact_table_splice["contact_id"] = (
-        contact_table_splice["contact_id"].astype(str).replace("\.0", "", regex=True)
+        contact_table_splice["contact_id"].astype(str).replace(r"\.0", "", regex=True)
     )
     # print(study_table[['contact_id', 'principal_investigator_name']].head())
 

--- a/tests/test_data/test_translator.py
+++ b/tests/test_data/test_translator.py
@@ -4,6 +4,15 @@ from nmdc_runtime.site.translation.translator import Translator
 
 
 class TestTranslator(Translator):
+    # Note: We define a `__test__` attribute whose value is `False`, as a way of telling
+    #       pytest that this class is not a test class. If pytest thinks this class is a
+    #       test class, pytest will complain that this class has an `__init__` method
+    #       (which it does have, since it inherits one from the `Translator` class).
+    #       Reference: https://docs.pytest.org/en/stable/example/pythoncollection.html#customizing-test-collection
+    #
+    __test__ = False
+
+    # TODO: The type hint (`nmdc.Database`) is inconsistent with the return value (`None`).
     def get_database(self) -> nmdc.Database:
         pass
 


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I fixed various issues about which pytest displays warnings. I fixed all such issues over which we have direct control.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Pytest continues to warn about some issues in upstream packages (e.g. `pydantic`, `sssom_schema`, `eutils`).

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1110 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by checking the list of warnings pytest displays when the tests runs, and confirming that the only remaining ones are from `site-packages`.

<details>
<summary>Show/hide remaining warnings</summary>

```py
================================================================================================================== warnings summary ==================================================================================================================
../usr/local/lib/python3.10/site-packages/linkml/generators/pydanticgen/template.py:553: 12 warnings
  /usr/local/lib/python3.10/site-packages/linkml/generators/pydanticgen/template.py:553: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    imports=imports, **{k: getattr(self, k, None) for k in self.model_fields if k != "imports"}

../usr/local/lib/python3.10/site-packages/pydantic/_internal/_config.py:323
  /usr/local/lib/python3.10/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

../usr/local/lib/python3.10/site-packages/sssom_schema/datamodel/sssom_schema.py:20
  /usr/local/lib/python3.10/site-packages/sssom_schema/datamodel/sssom_schema.py:20: DeprecationWarning: The LinkML dataclass extension patch is deprecated and will be removed in a future release.
  If you're currently using Python < 3.13, where this patch still applies, you should:
    • Upgrade your LinkML tooling to version >= 1.9.0 (which no longer needs this patch), OR
    • Migrate to Pydantic models if you're using LinkML's generated classes at runtime.
  
    from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs

../usr/local/lib/python3.10/site-packages/eutils/__init__.py:4
  /usr/local/lib/python3.10/site-packages/eutils/__init__.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================== 196 passed, 6 skipped, 1 xfailed, 6 xpassed, 15 warnings in 126.49s (0:02:06) ====================================================================================

```

</details>

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
