### PR TITLE
Clarify user-facing documentation for `/jobs/{job_id}:release` endpoint

### DIFF
--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -76,7 +76,7 @@ def release_job(
 ) -> Optional[Job]:
     r"""
     Release the specified job.
-    
+
     Releasing a job cancels all the unfinished operations (of that job)
     claimed by the `site` associated with the logged-in site client.
 
@@ -129,7 +129,7 @@ def release_job(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Transaction failed: {e}",
         )
-    
+
     # Return the updated `jobs` document.
     #
     # TODO: Consider retrieving the document within the transaction

--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional, Annotated
 
-import pymongo
+from pymongo.database import Database
 from fastapi import APIRouter, Depends, Query, HTTPException, Path
 from pymongo.errors import ConnectionFailure, OperationFailure
 from starlette import status
@@ -28,7 +28,7 @@ router = APIRouter()
 )
 def list_jobs(
     req: Annotated[ListRequest, Query()],
-    mdb: pymongo.database.Database = Depends(get_mongo_db),
+    mdb: Database = Depends(get_mongo_db),
     maybe_site: Optional[Site] = Depends(maybe_get_current_client_site),
 ):
     """List pre-configured workflow jobs.
@@ -45,7 +45,7 @@ def list_jobs(
 @router.get("/jobs/{job_id}", response_model=Job, response_model_exclude_unset=True)
 def get_job_info(
     job_id: str,
-    mdb: pymongo.database.Database = Depends(get_mongo_db),
+    mdb: Database = Depends(get_mongo_db),
 ):
     return raise404_if_none(mdb.jobs.find_one({"id": job_id}))
 
@@ -53,7 +53,7 @@ def get_job_info(
 @router.post("/jobs/{job_id}:claim", response_model=Operation[ResultT, MetadataT])
 def claim_job(
     job_id: str,
-    mdb: pymongo.database.Database = Depends(get_mongo_db),
+    mdb: Database = Depends(get_mongo_db),
     site: Site = Depends(get_current_client_site),
 ):
     return _claim_job(job_id, mdb, site)
@@ -71,7 +71,7 @@ def release_job(
             examples=["nmdc:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"],
         ),
     ],
-    mdb: pymongo.database.Database = Depends(get_mongo_db),
+    mdb: Database = Depends(get_mongo_db),
     site: Site = Depends(get_current_client_site),
 ):
     """Cancel all operations registered as claims by `site` for job `job_id`.

--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -59,9 +59,7 @@ def claim_job(
     return _claim_job(job_id, mdb, site)
 
 
-@router.post(
-    "/jobs/{job_id}:release", response_model=Job, response_model_exclude_unset=True
-)
+@router.post("/jobs/{job_id}:release")
 def release_job(
     job_id: Annotated[
         str,


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the user-facing documentation (visible on Swagger UI) of the `/jobs/{job_id}:release` endpoint, in an attempt to make it more clear to users what is happening (especially, what the word `site` is referring to).

| Before | After |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/7cd8b5e3-5d61-4ee0-b5e1-cd6778cfbd71" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/7e1a08df-a33a-4b92-80db-77d82ee96b82" /> |

I think someone more familiar with jobs and claims would be able to make the endpoint's documentation even more clear. I consider this to be an improvement, though.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I also moved the return type "hint" from the FastAPI router decorator to the standard Python function return type hint location, which enables IDE assistance (to warn when the function doesn't return that type—which was the case, here, since the function returns `None` in some situations). I also updated the `return` logic to be more explicit about what is being returned in a given scenario. The endpoint still returns either a JSON object representing a `jobs` document, or `null`, as shown here:

<img width="743" height="342" alt="image" src="https://github.com/user-attachments/assets/eb6a90cb-72a3-4b3f-9431-10e1b1b2f226" />

Finally, I fixed a type import error reported by Pylance.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1050

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming that `make test` completes without any errors.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
