### PR TITLE
Add docstrings and type hints to `site` and `user` functions

### DIFF
--- a/nmdc_runtime/api/models/site.py
+++ b/nmdc_runtime/api/models/site.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pymongo.database
 from fastapi import Depends
@@ -33,7 +33,11 @@ class SiteInDB(Site):
     clients: List[SiteClientInDB] = []
 
 
-def get_site(mdb, client_id: str):
+def get_site(mdb, client_id: str) -> Optional[SiteInDB]:
+    r"""
+    Returns the site, if any, for which the specified `client_id` was generated.
+    """
+
     site = mdb.sites.find_one({"clients.id": client_id})
     if site is not None:
         return SiteInDB(**site)

--- a/nmdc_runtime/api/models/user.py
+++ b/nmdc_runtime/api/models/user.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional, Union
 
 import pymongo.database
 from fastapi import Depends, HTTPException
@@ -36,13 +36,21 @@ class UserInDB(User):
     hashed_password: str
 
 
-def get_user(mdb, username: str) -> UserInDB:
+def get_user(mdb, username: str) -> Optional[UserInDB]:
+    r"""
+    Returns the user having the specified username.
+    """
+
     user = mdb.users.find_one({"username": username})
     if user is not None:
         return UserInDB(**user)
 
 
-def authenticate_user(mdb, username: str, password: str):
+def authenticate_user(mdb, username: str, password: str) -> Union[UserInDB, bool]:
+    r"""
+    Returns the user, if any, having the specified username/password combination.
+    """
+    
     user = get_user(mdb, username)
     if not user:
         return False
@@ -56,6 +64,15 @@ async def get_current_user(
     bearer_credentials: str = Depends(bearer_scheme),
     mdb: pymongo.database.Database = Depends(get_mongo_db),
 ) -> UserInDB:
+    r"""
+    Returns a user based upon the provided token.
+    
+    If the token belongs to a site client, the returned user is an ephemeral "user"
+    whose username is the site client's `client_id`.
+
+    Raises an exception if the token is invalid.
+    """
+
     if mdb.invalidated_tokens.find_one({"_id": token}):
         raise credentials_exception
     try:
@@ -88,13 +105,25 @@ async def get_current_user(
 
 
 def get_client_user(mdb, client_id: str) -> UserInDB:
+    r"""
+    Returns an ephemeral "user" whose username is the specified `client_id`
+    and whose password is the hashed secret of the client; provided that the
+    specified `client_id` is associated with a site in the database.
+
+    TODO: Clarify the above summary of the function.
+    """
+
+    # Get the site associated with the identified client.
     site = get_site(mdb, client_id)
     if site is None:
         raise credentials_exception
+    
+    # Get the client, itself, via the site.
     client = next(client for client in site.clients if client.id == client_id)
     if client is None:
         raise credentials_exception
-    # Coerce the client into a user
+
+    # Make a ephemeral "user" whose username matches the client's `id`.
     user = UserInDB(username=client.id, hashed_password=client.hashed_secret)
     return user
 
@@ -102,6 +131,10 @@ def get_client_user(mdb, client_id: str) -> UserInDB:
 async def get_current_active_user(
     current_user: UserInDB = Depends(get_current_user),
 ) -> UserInDB:
+    r"""
+    Returns the current user, provided their user account is not disabled.
+    """
+
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
     return current_user


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I added some docstrings and type hints to functions that lacked them, in an attempt to facilitate debugging and maintenance.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

None.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Related to (but does not fix) #1115.

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I tested these changes (explain below)
- [x] I did not test these changes

These changes have no "run-time" impact.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
