### PR TITLE
Update healthcheck function to not overload MongoDB `_id` field

### DIFF
--- a/nmdc_runtime/api/db/mongo.py
+++ b/nmdc_runtime/api/db/mongo.py
@@ -36,8 +36,12 @@ from pymongo.database import Database as MongoDatabase
     wait=wait_random_exponential(multiplier=0.5, max=60),
 )
 def check_mongo_ok_autoreconnect(mdb: MongoDatabase):
-    mdb["_runtime.healthcheck"].insert_one({"_id": "ok"})
-    mdb["_runtime.healthcheck"].delete_one({"_id": "ok"})
+    r"""
+    Check whether the application can write to the database.
+    """
+    collection = mdb.get_collection("_runtime.healthcheck")
+    collection.insert_one({"status": "ok"})
+    collection.delete_one({"status": "ok"})
     return True
 
 

--- a/tests/test_api/test_db_mongo.py
+++ b/tests/test_api/test_db_mongo.py
@@ -4,6 +4,7 @@ import pytest
 from toolz import dissoc
 
 from nmdc_runtime.api.db.mongo import (
+    check_mongo_ok_autoreconnect,
     get_mongo_db,
     get_mongo_client,
     OverlayDBError,
@@ -210,3 +211,7 @@ def test_mongo_client_supports_transactions(mongo_client):
 
     # Clean up.
     mongo_client.drop_database(db_name)
+
+
+def test_check_mongo_ok_autoreconnect(test_db):
+    assert check_mongo_ok_autoreconnect(mdb=test_db) is True


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the `check_mongo_ok_autoreconnect` function so that it would not overload the `_id` field (which always has a unique index on it) in a MongoDB collection.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Thanks to @shreddd and @dwinston for diagnosing the issue and proposing a solution, respectively.

I thought about using MongoDB's `ping` command, but opted to not do that right now because I wanted to finish this PR quickly and thought deviating from the previous implementation would open a (relative) can of worms.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1158 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I tested these changes (explain below)
- [ ] I did not test these changes

I'll wait for GHA tests to pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
