### PR TITLE
Replace slow MongoDB query with faster alternative (in `generate_ids` function)

### DIFF
--- a/nmdc_runtime/api/core/idgen.py
+++ b/nmdc_runtime/api/core/idgen.py
@@ -94,7 +94,11 @@ def generate_ids(
     collection = mdb.get_collection(collection_name(naa, shoulder))
     estimated_document_count = collection.estimated_document_count()
     n_chars = next(
-        (n for n, t in SPING_SIZE_THRESHOLDS if (number + estimated_document_count) < t),
+        (
+            n
+            for n, t in SPING_SIZE_THRESHOLDS
+            if (number + estimated_document_count) < t
+        ),
         12,
     )
     collected = []

--- a/nmdc_runtime/api/core/idgen.py
+++ b/nmdc_runtime/api/core/idgen.py
@@ -73,9 +73,9 @@ def generate_ids(
     shoulder: str = "fk4",
 ) -> List[str]:
     collection = mdb.get_collection(collection_name(naa, shoulder))
-    existing_count = collection.count_documents({})
+    estimated_document_count = collection.estimated_document_count()
     n_chars = next(
-        (n for n, t in SPING_SIZE_THRESHOLDS if (number + existing_count) < t),
+        (n for n, t in SPING_SIZE_THRESHOLDS if (number + estimated_document_count) < t),
         12,
     )
     collected = []

--- a/nmdc_runtime/api/core/idgen.py
+++ b/nmdc_runtime/api/core/idgen.py
@@ -56,10 +56,26 @@ def encode_id(number: int, split_every=4, min_length=10, checksum=True) -> int:
 
 
 # sping: "semi-opaque string" (https://n2t.net/e/n2t_apidoc.html).
+#
+# Note: The result is always the following list of tuples:
+#       ```
+#       [
+#         ( 2,             512),
+#         ( 4,          524288),
+#         ( 6,       536870912),
+#         ( 8,    549755813888),
+#         (10, 562949953421312)
+#       ]
+#       ````
 SPING_SIZE_THRESHOLDS = [(n, (2 ** (5 * n)) // 2) for n in [2, 4, 6, 8, 10]]
 
 
 def collection_name(naa, shoulder):
+    r"""
+    Returns a string designed to be used as a MongoDB collection name.
+
+    TODO: Document the function parameters, including expanding the "naa" acronym.
+    """
     return f"ids_{naa}_{shoulder}"
 
 
@@ -72,6 +88,9 @@ def generate_ids(
     naa: str = "nmdc",
     shoulder: str = "fk4",
 ) -> List[str]:
+    r"""
+    TODO: Document this function.
+    """
     collection = mdb.get_collection(collection_name(naa, shoulder))
     estimated_document_count = collection.estimated_document_count()
     n_chars = next(

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -115,6 +115,11 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
             filter_ = merge(filter_, {id_field: {"$gt": last_id}})
 
     # If limit is 0, the response will include all results (bypassing pagination altogether).
+    #
+    # TODO: Since we don't need to know the exact count, but we do need to know whether
+    #       it would be greater than `limit`; consider using an aggregation pipeline to
+    #       count only up to "limit + 1" (see: https://stackoverflow.com/a/67503437).
+    #
     if (limit == 0) or (mdb[collection_name].count_documents(filter=filter_) <= limit):
         rv = {
             "resources": list(


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the `generate_ids` function so that, instead of invoking `collection.count_documents({})`, it invokes `collection.estimated_document_count({})`. This sped up ID generation by about 200x.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I also added some `TODO` comments about documentation and about another performance optimization opportunity. 

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1160

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [x] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

See [linked issue](https://github.com/microbiomedata/nmdc-runtime/issues/1160#issuecomment-3213071851) for load testing and performance profiling screenshots.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
