### PR TITLE
Speed up `list_resources` function for large collections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,11 @@ services:
     # before starting this FastAPI container.
     depends_on:
       mongo-init: { condition: service_completed_successfully }
-    command: ["uvicorn", "nmdc_runtime.api.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+    # Note: We use `--reload-exclude` to prevent Uvicorn from restarting the FastAPI
+    #       app whenever files in the `util/load_testing/` directory change. Developers
+    #       oftentimes modify those files while doing load testing.
+    #       Docs: https://www.uvicorn.org/settings/?h=watch#reloading-with-watchfiles
+    command: ["uvicorn", "nmdc_runtime.api.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000", "--reload-exclude", "util/load_testing/*"]
     env_file: .env
 
   # Short-lived MongoDB server used to initialize the one used by the FastAPI application.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,8 @@ services:
       mongo-init: { condition: service_completed_successfully }
     # Note: We use `--reload-exclude` to prevent Uvicorn from restarting the FastAPI
     #       app whenever files in the `util/load_testing/` directory change. Developers
-    #       oftentimes modify those files while doing load testing.
+    #       oftentimes modify those files while doing load testing, and those files are
+    #       not part of the FastAPI app.
     #       Docs: https://www.uvicorn.org/settings/?h=watch#reloading-with-watchfiles
     command: ["uvicorn", "nmdc_runtime.api.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000", "--reload-exclude", "util/load_testing/*"]
     env_file: .env

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -138,9 +138,9 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
     elif max_page_size < 1:
         will_paginate = False
     elif not does_num_matching_docs_exceed_threshold(
-            collection=mdb[collection_name], filter_=filter_, threshold=max_page_size
-        ):
-            will_paginate = False
+        collection=mdb[collection_name], filter_=filter_, threshold=max_page_size
+    ):
+        will_paginate = False
 
     if not will_paginate:
         rv = {

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -128,7 +128,7 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
         id_field = (
             "_id"  # currently expected for `functional_annotation_agg` collection
         )
-    limit = req.max_page_size
+    max_page_size = req.max_page_size
     filter_ = json_util.loads(check_filter(req.filter)) if req.filter else {}
     projection = (
         list(set(comma_separated_values(req.projection)) | {id_field})
@@ -154,15 +154,15 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
     # Determine whether we will paginate the results.
     #
     # We will paginate them unless either of the following is true:
-    # - the `limit` is not a positive integer
-    # - the number of documents matching the filter is no larger than `limit`
+    # - the `max_page_size` is not a positive integer
+    # - the number of documents matching the filter is no larger than `max_page_size`
     #
     will_paginate = True
-    if (not isinstance(limit, int)) or (limit < 1):
+    if (not isinstance(max_page_size, int)) or (max_page_size < 1):
         will_paginate = False
     else:
         would_exceed_page = does_collection_contain_more_than_n_matching_documents(
-            collection=mdb[collection_name], filter_=filter_, n=limit
+            collection=mdb[collection_name], filter_=filter_, n=max_page_size
         )
         if not would_exceed_page:
             will_paginate = False
@@ -179,7 +179,7 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
             mdb[collection_name].find(
                 filter=filter_,
                 projection=projection,
-                limit=limit,
+                limit=max_page_size,
                 sort=[(id_field, 1)],
                 allow_disk_use=True,
             )

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -72,20 +72,17 @@ def does_collection_contain_more_than_n_matching_documents(
     Inspired by: https://stackoverflow.com/a/67503437
     """
 
-    # Ensure the `n` value is non-negative, since the aggregation pipeline's
-    # `$limit` stage requires a non-negative integer.
-    if n < 0:
-        raise ValueError("The `n` value must be non-negative.")
+    # Ensure the `n` value is at least 0, since the aggregation pipeline's
+    # `$limit` stage requires a positive integer.
+    if not n >= 0:
+        raise ValueError("The `n` value must be at least 0.")
 
-    result: List[Dict[str, int]] = list(
-        collection.aggregate(
-            [
-                {"$match": filter_},
-                {"$limit": n + 1},
-                {"$count": "numCounted"},
-            ]
-        )
-    )
+    result_cursor = collection.aggregate([
+        {"$match": filter_},
+        {"$limit": n + 1},
+        {"$count": "numCounted"},
+    ])
+    result: List[Dict[str, int]] = list(result_cursor)
 
     # Note: If no documents match the filter, `result` will be an empty list;
     #       otherwise, it will be a 1-item list consisting of a dictionary.

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -92,8 +92,7 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
     Returns a dictionary containing the requested MongoDB documents, maybe alongside pagination information.
 
     Note: If the specified page size (`req.max_page_size`) is non-zero and more documents match the filter
-          criteria than can fit on a page of that size, this function will paginate the resources. Paginating the
-          resources currently involves MongoDB sorting _all_ matching documents, which can take a long time.
+          criteria than can fit on a page of that size, this function will paginate the resources.
     """
 
     id_field = "id"
@@ -129,18 +128,18 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
 
     # Determine whether we will paginate the results.
     #
-    # We will paginate them unless either of the following is true:
-    # - the `max_page_size` is not a positive integer
-    # - the number of documents matching the filter does not exceed `max_page_size`
+    # Note: We will paginate them unless either:
+    #       - the `max_page_size` is not a positive integer
+    #       - the number of documents matching the filter does not exceed `max_page_size`
     #
     will_paginate = True
-    if (not isinstance(max_page_size, int)) or (max_page_size < 1):
+    if not isinstance(max_page_size, int):
         will_paginate = False
-    else:
-        num_matching_docs_exceeds_page_size = does_num_matching_docs_exceed_threshold(
+    elif max_page_size < 1:
+        will_paginate = False
+    elif not does_num_matching_docs_exceed_threshold(
             collection=mdb[collection_name], filter_=filter_, threshold=max_page_size
-        )
-        if not num_matching_docs_exceeds_page_size:
+        ):
             will_paginate = False
 
     if not will_paginate:

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -56,9 +56,7 @@ HOSTNAME_EXTERNAL = BASE_URL_EXTERNAL.split("://", 1)[-1]
 
 
 def does_collection_contain_more_than_n_matching_documents(
-    collection: MongoCollection,
-    filter_: dict,
-    n: int
+    collection: MongoCollection, filter_: dict, n: int
 ) -> bool:
     """
     Check whether a MongoDB collection contains more than `n` documents that match the filter.
@@ -79,11 +77,15 @@ def does_collection_contain_more_than_n_matching_documents(
     if n < 0:
         raise ValueError("The `n` value must be non-negative.")
 
-    result: List[Dict[str, int]] = list(collection.aggregate([
-        { "$match": filter_ },
-        { "$limit": n + 1 },
-        { "$count": "numCounted" },
-    ]))
+    result: List[Dict[str, int]] = list(
+        collection.aggregate(
+            [
+                {"$match": filter_},
+                {"$limit": n + 1},
+                {"$count": "numCounted"},
+            ]
+        )
+    )
 
     # Note: If no documents match the filter, `result` will be an empty list;
     #       otherwise, it will be a 1-item list consisting of a dictionary.
@@ -153,11 +155,9 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
     # If limit is 0 or it is <= the number of matching documents in the collection,
     # the response will include all results (bypassing pagination altogether).
     if isinstance(limit, int) and (
-        limit == 0 or
-        not does_collection_contain_more_than_n_matching_documents(
-            collection=mdb[collection_name],
-            filter_=filter_,
-            n=limit
+        limit == 0
+        or not does_collection_contain_more_than_n_matching_documents(
+            collection=mdb[collection_name], filter_=filter_, n=limit
         )
     ):
         rv = {

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -114,10 +114,9 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
     r"""
     Returns a dictionary containing the requested MongoDB documents, maybe alongside pagination information.
 
-    Note: If the specified `ListRequest` has a non-zero `max_page_size` number and the number of documents matching the
-          filter criteria is _larger_ than that number, this function will paginate the resources. Paginating the
-          resources currently involves MongoDB sorting _all_ matching documents, which can take a long time, especially
-          when the collection involved contains many documents.
+    Note: If the specified page size (`req.max_page_size`) is non-zero and more documents match the filter
+          criteria than can fit on a page of that size, this function will paginate the resources. Paginating the
+          resources currently involves MongoDB sorting _all_ matching documents, which can take a long time.
     """
 
     id_field = "id"

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -77,11 +77,13 @@ def does_collection_contain_more_than_n_matching_documents(
     if not n >= 0:
         raise ValueError("The `n` value must be at least 0.")
 
-    result_cursor = collection.aggregate([
-        {"$match": filter_},
-        {"$limit": n + 1},
-        {"$count": "numCounted"},
-    ])
+    result_cursor = collection.aggregate(
+        [
+            {"$match": filter_},
+            {"$limit": n + 1},
+            {"$count": "numCounted"},
+        ]
+    )
     result: List[Dict[str, int]] = list(result_cursor)
 
     # Note: If no documents match the filter, `result` will be an empty list;

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -138,9 +138,7 @@ def list_resources(req: ListRequest, mdb: MongoDatabase, collection_name: str):
         will_paginate = False
     else:
         num_matching_docs_exceeds_page_size = does_num_matching_docs_exceed_threshold(
-            collection=mdb[collection_name],
-            filter_=filter_,
-            threshold=max_page_size
+            collection=mdb[collection_name], filter_=filter_, threshold=max_page_size
         )
         if not num_matching_docs_exceeds_page_size:
             will_paginate = False

--- a/tests/test_api/test_endpoints_util.py
+++ b/tests/test_api/test_endpoints_util.py
@@ -1,0 +1,61 @@
+from pymongo.database import Database
+import pytest
+
+from nmdc_runtime.api.db.mongo import get_mongo_db
+from nmdc_runtime.api.endpoints.util import does_collection_contain_more_than_n_matching_documents
+from tests.lib.faker import Faker
+
+
+@pytest.fixture
+def seeded_db_for_filtered_counting():
+    db = get_mongo_db()
+
+    # Seed the database.
+    faker = Faker()
+    studies = faker.generate_studies(10, title="Test Study")
+    studies[0]["title"] = "Test Study (outlier)"  # one different title
+    filter_ = {"title": {"$regex": "^Test Study"}}
+    assert db["study_set"].count_documents(filter_) == 0
+    db["study_set"].insert_many(studies)
+    assert db["study_set"].count_documents(filter_) == 10
+
+    yield db
+
+    # 🧹 Clean up.
+    db["study_set"].delete_many(filter_)
+
+
+def test_does_collection_contain_more_than_n_matching_documents(seeded_db_for_filtered_counting: Database):
+    # Seed the database.
+    db = seeded_db_for_filtered_counting
+    collection = db["study_set"]
+    filter_a = {"title": "Test Study"}
+    filter_b = {"title": "Test Study (outlier)"}
+    filter_c = {"title": {"$regex": "^Test Study"}}
+    filter_d = {"title": "Nonexistent Study"}
+    assert collection.count_documents(filter_a) == 9
+    assert collection.count_documents(filter_b) == 1
+    assert collection.count_documents(filter_c) == 10
+
+    # Test: Vary the count.
+    with pytest.raises(ValueError):
+        assert does_collection_contain_more_than_n_matching_documents(collection, filter_a, -1)
+    assert does_collection_contain_more_than_n_matching_documents(collection, filter_a, 0)
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_a, 9)  # there are exactly 9
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_a, 10)
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_a, 11)
+
+    # Test: Vary the filter.
+    assert does_collection_contain_more_than_n_matching_documents(collection, filter_b, 0)
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_b, 1)  # there is exactly 1
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_b, 2)
+    assert does_collection_contain_more_than_n_matching_documents(collection, filter_c, 9)
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_c, 10)  # there are exactly 10
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_c, 11)
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_d, 0)  # there are exactly 0
+    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_d, 1)
+
+    # Test: Vary collection.
+    collection = db["empty_collection"]
+    assert collection.count_documents({}) == 0
+    assert not does_collection_contain_more_than_n_matching_documents(collection, {}, 0)

--- a/tests/test_api/test_endpoints_util.py
+++ b/tests/test_api/test_endpoints_util.py
@@ -36,6 +36,7 @@ def test_does_collection_contain_more_than_n_matching_documents(seeded_db_for_fi
     assert collection.count_documents(filter_a) == 9
     assert collection.count_documents(filter_b) == 1
     assert collection.count_documents(filter_c) == 10
+    assert collection.count_documents(filter_d) == 0
 
     # Test: Vary the count.
     with pytest.raises(ValueError):

--- a/tests/test_api/test_endpoints_util.py
+++ b/tests/test_api/test_endpoints_util.py
@@ -2,7 +2,7 @@ from pymongo.database import Database
 import pytest
 
 from nmdc_runtime.api.db.mongo import get_mongo_db
-from nmdc_runtime.api.endpoints.util import does_collection_contain_more_than_n_matching_documents
+from nmdc_runtime.api.endpoints.util import does_num_matching_docs_exceed_threshold
 from tests.lib.faker import Faker
 
 
@@ -25,7 +25,7 @@ def seeded_db_for_filtered_counting():
     db["study_set"].delete_many(filter_)
 
 
-def test_does_collection_contain_more_than_n_matching_documents(seeded_db_for_filtered_counting: Database):
+def test_does_num_matching_docs_exceed_threshold(seeded_db_for_filtered_counting: Database):
     # Seed the database.
     db = seeded_db_for_filtered_counting
     collection = db["study_set"]
@@ -40,23 +40,23 @@ def test_does_collection_contain_more_than_n_matching_documents(seeded_db_for_fi
 
     # Test: Vary the count.
     with pytest.raises(ValueError):
-        assert does_collection_contain_more_than_n_matching_documents(collection, filter_a, -1)
-    assert does_collection_contain_more_than_n_matching_documents(collection, filter_a, 0)
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_a, 9)  # there are exactly 9
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_a, 10)
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_a, 11)
+        assert does_num_matching_docs_exceed_threshold(collection, filter_a, -1)
+    assert does_num_matching_docs_exceed_threshold(collection, filter_a, 0)
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_a, 9)  # there are exactly 9
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_a, 10)
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_a, 11)
 
     # Test: Vary the filter.
-    assert does_collection_contain_more_than_n_matching_documents(collection, filter_b, 0)
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_b, 1)  # there is exactly 1
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_b, 2)
-    assert does_collection_contain_more_than_n_matching_documents(collection, filter_c, 9)
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_c, 10)  # there are exactly 10
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_c, 11)
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_d, 0)  # there are exactly 0
-    assert not does_collection_contain_more_than_n_matching_documents(collection, filter_d, 1)
+    assert does_num_matching_docs_exceed_threshold(collection, filter_b, 0)
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_b, 1)  # there is exactly 1
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_b, 2)
+    assert does_num_matching_docs_exceed_threshold(collection, filter_c, 9)
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_c, 10)  # there are exactly 10
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_c, 11)
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_d, 0)  # there are exactly 0
+    assert not does_num_matching_docs_exceed_threshold(collection, filter_d, 1)
 
     # Test: Vary collection.
     collection = db["empty_collection"]
     assert collection.count_documents({}) == 0
-    assert not does_collection_contain_more_than_n_matching_documents(collection, {}, 0)
+    assert not does_num_matching_docs_exceed_threshold(collection, {}, 0)

--- a/util/load_testing/README.md
+++ b/util/load_testing/README.md
@@ -45,7 +45,7 @@ All commands shown below were designed to be issued from the root directory of t
    > - `--users 25` (so the test creates _25_ "actors" in total)
    > - `--spawn-rate 5` (so the test creates its "actors" at a rate of _5_ per second)
    > - `--stop-timeout 180s` (so the test waits for HTTP responses for an additional _180 seconds_ after the test would otherwise have ended)
-   > - Append a specific `HttpUser` subclass name to the end of the command (so only that kind of user is spawned during the test)
+   > - Append a specific `HttpUser` subclass name (e.g. `User`, `SiteClient`) to the command (so only that kind of user is spawned during the test)
    >
    > We may eventually specify some CLI options via a [configuration file](https://docs.locust.io/en/stable/configuration.html#configuration-file).
 4. Visit the Locust web UI, at: http://localhost:8089

--- a/util/load_testing/README.md
+++ b/util/load_testing/README.md
@@ -44,6 +44,7 @@ All commands shown below were designed to be issued from the root directory of t
    > - `--exclude-tags mints_ids` (so tasks tagged with "`mints_ids`" are skipped)
    > - `--users 25` (so the test creates _25_ "actors" in total)
    > - `--spawn-rate 5` (so the test creates its "actors" at a rate of _5_ per second)
+   > - `--run-time 30s` (so the test runs for _30_ seconds)
    > - `--stop-timeout 180s` (so the test waits for HTTP responses for an additional _180 seconds_ after the test would otherwise have ended)
    > - Append a specific `HttpUser` subclass name (e.g. `User`, `SiteClient`) to the command (so only that kind of user is spawned during the test)
    >

--- a/util/load_testing/README.md
+++ b/util/load_testing/README.md
@@ -35,13 +35,19 @@ All commands shown below were designed to be issued from the root directory of t
        --network nmdc-runtime-dev_default \
        locustio/locust \
          --locustfile /mnt/locust/locustfile.py \
-         --users 1 \
-         --spawn-rate 1 \
          --host http://fastapi:8000
    ```
    > **Note:** The `--network nmdc-runtime-dev_default` CLI option causes Docker to connect the Locust container to the same network as the standard development stack. That way, the Locust container will be able to access the Runtime API at `http://fastapi:8000`, regardless of how you access the Runtime API from your host OS.
    >
-   > **Note:** The CLI options Locust supports are documented [here](https://docs.locust.io/en/stable/configuration.html#command-line-options). For example, developers sometimes use the `--autostart ` CLI option (so the test starts without requiring us to press the "Start" button on the web UI). Also, developers sometimes use the `--exclude-tags {string}` CLI option (so tasks tagged with `{string}` are skipped). Finally, developers sometimes append a specific `HttpUser` subclass name to the end of the command (so only that kind of user is spawned during the test). We may eventually specify some CLI options via a [configuration file](https://docs.locust.io/en/stable/configuration.html#configuration-file).
+   > **Note:** The CLI options Locust supports are documented [here](https://docs.locust.io/en/stable/configuration.html#command-line-options). Here are some that I have used:
+   > - `--autostart` (so the test starts without requiring me to press the "Start" button on the web UI)
+   > - `--exclude-tags mints_ids` (so tasks tagged with "`mints_ids`" are skipped)
+   > - `--users 25` (so the test creates _25_ "actors" in total)
+   > - `--spawn-rate 5` (so the test creates its "actors" at a rate of _5_ per second)
+   > - `--stop-timeout 180s` (so the test waits for HTTP responses for an additional _180 seconds_ after the test would otherwise have ended)
+   > - Append a specific `HttpUser` subclass name to the end of the command (so only that kind of user is spawned during the test)
+   >
+   > We may eventually specify some CLI options via a [configuration file](https://docs.locust.io/en/stable/configuration.html#configuration-file).
 4. Visit the Locust web UI, at: http://localhost:8089
 5. Perform load testing.
    - Press the "Start" button to start the test.

--- a/util/load_testing/locustfile.py
+++ b/util/load_testing/locustfile.py
@@ -17,11 +17,11 @@ from locust import HttpUser, task, tag
 # Note: When invoking Locust in a container via `docker run`, you can define
 #       the environment variables for the container like this:
 #       ```
-#       docker run --env API_ADMIN_USER="bob" --env API_ADMIN_PASSWORD="shh" ...
+#       docker run --env API_USERNAME="bob" --env API_PASSWORD="shh" ...
 #       ```
 #
-username = os.getenv("API_ADMIN_USER", "admin")
-password = os.getenv("API_ADMIN_PASSWORD", "root")
+username = os.getenv("API_USERNAME", "admin")
+password = os.getenv("API_PASSWORD", "root")
 
 
 class User(HttpUser):

--- a/util/load_testing/locustfile.py
+++ b/util/load_testing/locustfile.py
@@ -53,6 +53,14 @@ class User(HttpUser):
         self.client.get("/version")
 
     @task
+    def get_functional_annotation_agg_documents(self):
+        """
+        A task that involves querying a very large MongoDB collection
+        via a general-purpose endpoint.
+        """
+        self.client.get("/nmdcschema/functional_annotation_agg")
+
+    @task
     def get_biosamples(self):
         """
         A task that involves querying a large MongoDB database
@@ -186,7 +194,7 @@ class User(HttpUser):
         """
         self.client.get("/nmdcschema/study_set")
 
-    @task
+    @task(1)
     def get_me(self):
         """
         A task that involves authentication.

--- a/util/load_testing/locustfile.py
+++ b/util/load_testing/locustfile.py
@@ -5,25 +5,23 @@ Note: This is a [Locustfile](https://docs.locust.io/en/stable/writing-a-locustfi
       a load on the system under test (SUT). In this case, the SUT is the Runtime API.
 """
 
-import base64
 import json
+import os
 
 from locust import HttpUser, task, tag
 
 
-# This is a quick-n-dirty way to specify user credentials for load testing,
-# allowing for visual obfuscation (which can be undone via base64 decoding)
-# for sharing screen with team members, mitigating accidental retention
-# via casual glancing. THIS IS NOT SECURE. DO NOT SCREENSHOT THESE VALUES.
-# 
-# You can use the following website to generate base64-encoded strings of
-# your username and password:
-# https://emn178.github.io/online-tools/base64_encode.html
+# Read the credentials of a Runtime API user from environment variables,
+# falling back to default values if the environment variables are not set.
 #
-# FIXME: Get the decoded values from environment variables instead.
+# Note: When invoking Locust in a container via `docker run`, you can define
+#       the environment variables for the container like this:
+#       ```
+#       docker run --env API_ADMIN_USER="bob" --env API_ADMIN_PASSWORD="shh" ...
+#       ```
 #
-username = base64.b64decode("__REPLACE_ME__")
-password = base64.b64decode("__REPLACE_ME__")
+username = os.getenv("API_ADMIN_USER", "admin")
+password = os.getenv("API_ADMIN_PASSWORD", "root")
 
 
 class User(HttpUser):
@@ -194,7 +192,7 @@ class User(HttpUser):
         """
         self.client.get("/nmdcschema/study_set")
 
-    @task(1)
+    @task
     def get_me(self):
         """
         A task that involves authentication.


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the `list_resources` function so that, instead of counting _all_ matching documents in a collection, it only counts _the minimum number necessary_ in order to do its job.

Here's an analogy:

<img width="462" height="243" alt="image" src="https://github.com/user-attachments/assets/dbce7f2b-d06f-48af-baca-6627b5c7b109" />

I have a yard with lots of different types of trees in it. I want to know whether my yard has **more than 3** oak trees. I can either:
1. (the old way) Ask someone to **count all** the oak trees in my yard, and tell me that number (I'll compare it with 3); or
2. (the new way) Ask someone to **count up to 4** oak trees in my yard, and tell me that number (I'll compare it with 3)

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

As a result, the `GET /nmdc_schema/{collection_name}` endpoint (and other endpoints and functions that use the `list_resources` function under the hood) is faster. See load testing results and performance profiling results below for information about "how much faster."

#### Load testing results

| Before<br/>(i.e. commit 722c3f6073312dc141abc9349efe03bbefadfd24, tip of `main` branch) | After<br/>(i.e. commit https://github.com/microbiomedata/nmdc-runtime/pull/1166/commits/7789b00e96742d4befe3a0b978efc0bf99da0c23, near tip of PR branch) |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/a5deebf9-2c16-42af-b8ac-ee809f34fb1b" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/2381bd09-727e-4b27-bbda-6a2a90ea0431" /> |
| Median response time for<br/>`GET /nmdcschema/functional_annotation_agg`<br/>under the test load: 76 seconds | Median response time for<br/>`GET /nmdcschema/functional_annotation_agg`<br/>under the test load: 300 milliseconds (~250x faster) | 


<details>
<summary>Show/hide load testing notes</summary>

Here's the command I used to launch the load test(er):

```sh
docker run --rm -it \
    --publish 8089:8089 \
    --volume ${PWD}/util/load_testing:/mnt/locust \
    --network nmdc-runtime-dev_default \
    locustio/locust \
      --locustfile /mnt/locust/locustfile.py \
      --host http://fastapi:8000 --autostart --users 25 --spawn-rate 5 -t 30s User --stop-timeout 180s
```

Notes:
- In the "Before" case, I used the `locustfile.py` file as it existed in the "After" case (i.e. same load configuration in both cases).
- I included `--stop-timeout 180s` in the command because—without it—in the "Before" case, the HTTP responses to the `GET /nmdcschema/functional_annotation_agg` requests were taking so long to come back (about 2 minutes, although that's dependent upon my local environment) that the load tester client would not acknowledge them at that point anymore. When using this 3-minute cleanup period, the load tester client does acknowledge them.

</details>

#### Performance profiling results

Here's how this change impacts the `GET /nmdcschema/functional_annotation_agg` endpoint's performance:

| Before<br/>(i.e. commit 722c3f6073312dc141abc9349efe03bbefadfd24, tip of `main` branch) | After<br/>(i.e. commit https://github.com/microbiomedata/nmdc-runtime/pull/1166/commits/7789b00e96742d4befe3a0b978efc0bf99da0c23, near tip of PR branch) |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/7c773027-d9af-4349-8a91-99f8434fb234" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/e3f517d9-2d4d-4721-999f-cf0c5056c237" /> |
| Response time: ~20 seconds | Response time: ~20 milliseconds (~1000x faster) |

<details>
<summary>Show/hide performance profiling notes</summary>

Notes:
- In both the "Before" and "After" cases, I prepended `async` to the definition of the endpoint function.
  ```diff
    @router.get(
        "/nmdcschema/{collection_name}",
        response_model=ListResponse[Doc],
        response_model_exclude_unset=True,
    )
  - def list_from_collection(
  + async def list_from_collection(
  ```
- The performance profiling was performed when the Runtime was not receiving any requests _other than_ the one being profiled.

</details>

Also on this branch:
- I added a check for `max_page_size` being something other than an integer, since its type hints say it can be `int | None`.
- I refactored some code in an attempt to make the conditions under which pagination will be performed more apparent to maintainers of this codebase.
- I refined the load testing instructions and related configuration file, based upon my experience measuring the performance of the `GET /nmdcschema/functional_annotation_agg` endpoint. I also configured Uvicorn's file watcher to ignore those files, since they aren't part of the FastAPI application.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1164 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

The test I added, which targets the newly-added helper function, passes locally and on GHA. I also performed load testing and performance profiling (shown above).

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
