### PR TITLE
Add optional study ID input to tie submissions to one study

### DIFF
--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -173,6 +173,7 @@ def translate_metadata_submission_to_nmdc_schema_database():
         data_object_mapping_file_url,
         biosample_extras_file_url,
         biosample_extras_slot_mapping_file_url,
+        study_id,
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
@@ -193,6 +194,7 @@ def translate_metadata_submission_to_nmdc_schema_database():
         biosample_extras=biosample_extras,
         biosample_extras_slot_mapping=biosample_extras_slot_mapping,
         instrument_mapping=instrument_mapping,
+        study_id=study_id,
     )
 
     validate_metadata(database)
@@ -213,6 +215,7 @@ def ingest_metadata_submission():
         data_object_mapping_file_url,
         biosample_extras_file_url,
         biosample_extras_slot_mapping_file_url,
+        study_id,
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
@@ -233,6 +236,7 @@ def ingest_metadata_submission():
         biosample_extras=biosample_extras,
         biosample_extras_slot_mapping=biosample_extras_slot_mapping,
         instrument_mapping=instrument_mapping,
+        study_id=study_id,
     )
 
     log_database_ids(database)

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -588,6 +588,7 @@ def translate_portal_submission_to_nmdc_schema_database(
     instrument_mapping: Dict[str, str],
     study_category: Optional[str],
     study_pi_image_url: Optional[str],
+    study_id: Optional[str],
     biosample_extras: Optional[list[dict]],
     biosample_extras_slot_mapping: Optional[list[dict]],
 ) -> nmdc.Database:
@@ -604,6 +605,7 @@ def translate_portal_submission_to_nmdc_schema_database(
         id_minter=id_minter,
         study_category=study_category,
         study_pi_image_url=study_pi_image_url,
+        study_id = study_id,
         biosample_extras=biosample_extras,
         biosample_extras_slot_mapping=biosample_extras_slot_mapping,
         illumina_instrument_mapping=instrument_mapping,

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -545,27 +545,41 @@ def nmdc_schema_database_from_gold_study(
 
 
 @op(
+    required_resource_keys={"mongo"},
     out={
         "submission_id": Out(),
         "nucleotide_sequencing_mapping_file_url": Out(Optional[str]),
         "data_object_mapping_file_url": Out(Optional[str]),
         "biosample_extras_file_url": Out(Optional[str]),
         "biosample_extras_slot_mapping_file_url": Out(Optional[str]),
+        "study_id": Out(Optional[str]),
     },
 )
 def get_submission_portal_pipeline_inputs(
+    context: OpExecutionContext,
     submission_id: str,
     nucleotide_sequencing_mapping_file_url: Optional[str],
     data_object_mapping_file_url: Optional[str],
     biosample_extras_file_url: Optional[str],
     biosample_extras_slot_mapping_file_url: Optional[str],
-) -> Tuple[str, str | None, str | None, str | None, str | None]:
+    study_id: Optional[str],
+) -> Tuple[str, str | None, str | None, str | None, str | None, str | None]:
+    #query for studies matching the ID to see if it eists
+    if study_id:
+        mdb = context.resources.mongo.db
+        result = mdb.study_set.find_one({"id": study_id})
+        if not result:
+            raise Exception(
+                f"Study id: {study_id} does not exist in Mongo."
+            )
+
     return (
         submission_id,
         nucleotide_sequencing_mapping_file_url,
         data_object_mapping_file_url,
         biosample_extras_file_url,
         biosample_extras_slot_mapping_file_url,
+        study_id,
     )
 
 
@@ -588,9 +602,9 @@ def translate_portal_submission_to_nmdc_schema_database(
     instrument_mapping: Dict[str, str],
     study_category: Optional[str],
     study_pi_image_url: Optional[str],
-    study_id: Optional[str],
     biosample_extras: Optional[list[dict]],
     biosample_extras_slot_mapping: Optional[list[dict]],
+    study_id: Optional[str],
 ) -> nmdc.Database:
     client: RuntimeApiSiteClient = context.resources.runtime_api_site_client
 
@@ -605,10 +619,10 @@ def translate_portal_submission_to_nmdc_schema_database(
         id_minter=id_minter,
         study_category=study_category,
         study_pi_image_url=study_pi_image_url,
-        study_id=study_id,
         biosample_extras=biosample_extras,
         biosample_extras_slot_mapping=biosample_extras_slot_mapping,
         illumina_instrument_mapping=instrument_mapping,
+        study_id=study_id,
     )
     database = translator.get_database()
     return database

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -605,7 +605,7 @@ def translate_portal_submission_to_nmdc_schema_database(
         id_minter=id_minter,
         study_category=study_category,
         study_pi_image_url=study_pi_image_url,
-        study_id = study_id,
+        study_id=study_id,
         biosample_extras=biosample_extras,
         biosample_extras_slot_mapping=biosample_extras_slot_mapping,
         illumina_instrument_mapping=instrument_mapping,

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -564,14 +564,12 @@ def get_submission_portal_pipeline_inputs(
     biosample_extras_slot_mapping_file_url: Optional[str],
     study_id: Optional[str],
 ) -> Tuple[str, str | None, str | None, str | None, str | None, str | None]:
-    #query for studies matching the ID to see if it eists
+    # query for studies matching the ID to see if it eists
     if study_id:
         mdb = context.resources.mongo.db
         result = mdb.study_set.find_one({"id": study_id})
         if not result:
-            raise Exception(
-                f"Study id: {study_id} does not exist in Mongo."
-            )
+            raise Exception(f"Study id: {study_id} does not exist in Mongo.")
 
     return (
         submission_id,

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -502,13 +502,13 @@ def biosample_submission_ingest():
                             "data_object_mapping_file_url": None,
                             "biosample_extras_file_url": None,
                             "biosample_extras_slot_mapping_file_url": None,
+                            "study_id": None,
                         }
                     },
                     "translate_portal_submission_to_nmdc_schema_database": {
                         "inputs": {
                             "study_category": "research_study",
                             "study_pi_image_url": None,
-                            "study_id": None,
                         }
                     },
                 },
@@ -539,13 +539,13 @@ def biosample_submission_ingest():
                             "data_object_mapping_file_url": None,
                             "biosample_extras_file_url": None,
                             "biosample_extras_slot_mapping_file_url": None,
+                            "study_id": None,
                         }
                     },
                     "translate_portal_submission_to_nmdc_schema_database": {
                         "inputs": {
                             "study_category": None,
                             "study_pi_image_url": None,
-                            "study_id": None,
                         }
                     },
                 },

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -508,6 +508,7 @@ def biosample_submission_ingest():
                         "inputs": {
                             "study_category": "research_study",
                             "study_pi_image_url": None,
+                            "study_id": None,
                         }
                     },
                 },
@@ -544,6 +545,7 @@ def biosample_submission_ingest():
                         "inputs": {
                             "study_category": None,
                             "study_pi_image_url": None,
+                            "study_id": None,
                         }
                     },
                 },

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -756,20 +756,12 @@ class SubmissionPortalTranslator(Translator):
 
         # Generate one Study instance based on the metadata submission, if a study_id wasn't provided
         if self.study_id:
-            if re.match(
-                "^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$",
-                self.study_id,
-            ):
-                nmdc_study_id = self.study_id
-            else:
-                nmdc_study_id = self._id_minter("nmdc:Study")[
-                    0
-                ]  # what do we actually want to do if an ID is supplied but it's invalid? I don't think we want to just mint a new id, probably raise an error.
+            nmdc_study_id = self.study_id
         else:
             nmdc_study_id = self._id_minter("nmdc:Study")[0]
-        database.study_set = [
-            self._translate_study(metadata_submission_data, nmdc_study_id)
-        ]
+            database.study_set = [
+                self._translate_study(metadata_submission_data, nmdc_study_id)
+            ]
 
         # Automatically populate the `env_package` field in the sample data based on which
         # environmental data tab the sample data came from.

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -756,10 +756,15 @@ class SubmissionPortalTranslator(Translator):
 
         # Generate one Study instance based on the metadata submission, if a study_id wasn't provided
         if self.study_id:
-            if re.match("^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$", self.study_id):
+            if re.match(
+                "^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$",
+                self.study_id,
+            ):
                 nmdc_study_id = self.study_id
             else:
-                nmdc_study_id = self._id_minter("nmdc:Study")[0] #what do we actually want to do if an ID is supplied but it's invalid? I don't think we want to just mint a new id, probably raise an error.     
+                nmdc_study_id = self._id_minter("nmdc:Study")[
+                    0
+                ]  # what do we actually want to do if an ID is supplied but it's invalid? I don't think we want to just mint a new id, probably raise an error.
         else:
             nmdc_study_id = self._id_minter("nmdc:Study")[0]
         database.study_set = [

--- a/tests/test_graphs/test_submission_portal_graphs.py
+++ b/tests/test_graphs/test_submission_portal_graphs.py
@@ -99,6 +99,7 @@ def test_translate_metadata_submission_to_nmdc_schema_database():
                 "inputs": {
                     "study_category": "research_study",
                     "study_pi_image_url": "http://www.example.com/test.png",
+                    "study_id": "",
                 }
             },
         },

--- a/tests/test_graphs/test_submission_portal_graphs.py
+++ b/tests/test_graphs/test_submission_portal_graphs.py
@@ -93,13 +93,13 @@ def test_translate_metadata_submission_to_nmdc_schema_database():
                     "biosample_extras_slot_mapping_file_url": None,
                     "data_object_mapping_file_url": None,
                     "nucleotide_sequencing_mapping_file_url": None,
+                    "study_id": "",
                 }
             },
             "translate_portal_submission_to_nmdc_schema_database": {
                 "inputs": {
                     "study_category": "research_study",
                     "study_pi_image_url": "http://www.example.com/test.png",
-                    "study_id": "",
                 }
             },
         },


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

This branch adds an optional config setting for Study ID for ingesting portal submissions.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Previously a new study ID was always minted. If a valid study ID is supplied, that ID will be used for the ingestion of the portal submission.
On error/invalid ID given an error is thrown.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

This PR resolves https://github.com/microbiomedata/nmdc-runtime/issues/1141

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I manually tested this change by providing an ID in the config, which was accepted. I did the same with an invalid ID which (should throw an error after review and figuring out exactly what to do, but the current logic for catching bad IDs works) which minted a new ID. And I tried a case where no ID was supplied which resulted in expected behavior of minting a new ID.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
