### PR TITLE
Update Swagger UI authorization modal to focus on "Username" field when opened

### DIFF
--- a/nmdc_runtime/api/swagger_ui/assets/script.js
+++ b/nmdc_runtime/api/swagger_ui/assets/script.js
@@ -63,13 +63,11 @@ window.addEventListener("nmdcInit", (event) => {{
             const formHeaderEls = modalContentEl.querySelectorAll('.auth-container h4');
             formHeaderEls.forEach(el => {
                 // Update the header text based on its current value.
-                switch (el.textContent) {
-                    // Note: This default string has a trailing space.
-                    case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, password) ":
+                switch (el.textContent.trim()) {
+                    case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, password)":
                         el.textContent = "User login";
                         break;
-                    // Note: This default string has a trailing space.
-                    case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, clientCredentials) ":
+                    case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, clientCredentials)":
                         el.textContent = "Site client login";
                         break;
                     // Note: This default string has a `U+00a0` character before the space.

--- a/nmdc_runtime/api/swagger_ui/assets/script.js
+++ b/nmdc_runtime/api/swagger_ui/assets/script.js
@@ -43,40 +43,60 @@ window.addEventListener("nmdcInit", (event) => {{
         }});
     }
 
-    // Customize the headers in the modal login form so they are more user-friendly.
+    /**
+     * Customizes the login form.
+     * 
+     * Prerequisite: The login form must be present in the DOM.
+     */
+    const customizeLoginForm = () => {
+        const modalContentEl = document.querySelector('.auth-wrapper .modal-ux-content');
+
+        console.debug("Customizing login form headers");
+        const formHeaderEls = modalContentEl.querySelectorAll('.auth-container h4');
+        formHeaderEls.forEach(el => {
+            // Update the header text based on its current value.
+            switch (el.textContent.trim()) {
+                case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, password)":
+                    el.textContent = "User login";
+                    break;
+                case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, clientCredentials)":
+                    el.textContent = "Site client login";
+                    break;
+                // Note: This default string has a `U+00a0` character before the space.
+                case "bearerAuth  (http, Bearer)":
+                    break; // do nothing
+                default:
+                    console.debug(`Unrecognized header: ${el.textContent}`);
+            }
+        });
+
+        console.debug("Focusing on username field if present");
+        const usernameInputEl = modalContentEl.querySelector("input#oauth_username");
+        if (usernameInputEl !== null) {
+            usernameInputEl.focus();
+        }
+    };
+    console.debug("Setting up event listener for customizing login form");
+    //
+    // Listen for a "click" event on the `body` element, check whether the element that was clicked
+    // was the "Authorize" button (or one of its descendants), and if so, customize the modal login
+    // form that will have been mounted to the DOM by the time the "click" event propagated to the
+    // `body` element and our event handler was called.
     //
     // Note: We attach this event listener to the `body` element because that's the lowest-level
-    //       element where we found that mounting it doesn't cause it to run too early (i.e. doesn't
-    //       cause it to run _before_ the event handlers that mount the modal login form to the DOM
-    //       have run). Our event handler needs that form to be mounted so it can access its elements.
+    //       element where we found that mounting it doesn't cause our event handler to run too early
+    //       (i.e. doesn't cause it to run _before_ the event handlers that mount the modal login form
+    //       to the DOM have run). Our event handler needs that form to be mounted so it can access
+    //       its elements.
     //       
     //       If we were to attach it to a lower-level element (e.g. directly to the "Authorize" button),
     //       we would have to, for example, make its body a `setTimeout(fn, 0)` callback in order to
     //       defer its execution until all the event handlers for the "click" even have run.
     //
-    console.debug("Setting up event listener for customizing login form headers");
     bodyEl.addEventListener("click", (event) => {
         // Check whether the clicked element was the "Authorize" button or any of its descendants.
         if (event.target.closest(".auth-wrapper > .btn.authorize:not(.modal-btn)") !== null) {
-            console.debug("Customizing login form headers");
-            const modalContentEl = document.querySelector('.auth-wrapper .modal-ux-content');
-            const formHeaderEls = modalContentEl.querySelectorAll('.auth-container h4');
-            formHeaderEls.forEach(el => {
-                // Update the header text based on its current value.
-                switch (el.textContent.trim()) {
-                    case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, password)":
-                        el.textContent = "User login";
-                        break;
-                    case "OAuth2PasswordOrClientCredentialsBearer (OAuth2, clientCredentials)":
-                        el.textContent = "Site client login";
-                        break;
-                    // Note: This default string has a `U+00a0` character before the space.
-                    case "bearerAuth  (http, Bearer)":
-                        break; // do nothing
-                    default:
-                        console.debug(`Unrecognized header: ${el.textContent}`);
-                }
-            });
+            customizeLoginForm();
         }
     });
 }});


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I made it so, on Swagger UI, when the user clicks on the "Authorize" button, the web browser's focus is on the "Username" field at the top of the modal.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Previously, the web browser's focus was on the "bearer" field at the bottom of the modal—resulting in some users not realizing there _was_ a user login field higher up in the modal.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1181

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

Swagger UI.

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by manually clicking the "Authorize" button and observing that the focus was on the "Username" field.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
