### PR TITLE
Configure Swagger UI to persist auth status and simplify login form

### DIFF
--- a/docs/content/howto-guides/minting-ids.md
+++ b/docs/content/howto-guides/minting-ids.md
@@ -19,7 +19,7 @@ Here's how you can obtain site client credentials:
 1. Visit the NMDC Runtime API's [Swagger UI](https://api.microbiomedata.org/docs). 
 2. Login as a regular Runtime user.
    1. Near the upper right corner of the page, click the "Authorize" button.
-   2. In the topmost section—entitled "OAuth2PasswordOrClientCredentialsBearer (OAuth2, password)"—enter your Runtime username and password, then click the "Authorize" button.
+   2. In the topmost section—entitled "User login"—enter your Runtime username and password, then click the "Authorize" button.
    3. Click the "Close" button to close the "Available authorizations" popup.
 3. Check whether your user account is already an admin of any sites.
    1. Expand the `GET /users/me` API endpoint section.
@@ -51,7 +51,7 @@ Here's how you can log into the NMDC Runtime API as a site client:
 1. Visit the NMDC Runtime API's [Swagger UI](https://api.microbiomedata.org/docs) (if you aren't already there).
 2. Log in as a site client.
    1. Near the upper right corner of the page, click the "Authorize" button.
-   2. Scroll down to the section entitled "OAuth2PasswordOrClientCredentialsBearer (OAuth2, clientCredentials)".
+   2. Scroll down to the section entitled "Site client login".
    3. In that section, enter your site client credentials—i.e., your `client_id` and `client_secret`—then click the "Authorize" button.
    4. Click the "Close" button to close the "Available authorizations" popup.
 

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -327,7 +327,10 @@ def custom_swagger_ui_html(
             rv.raise_for_status()
         access_token = rv.json()["access_token"]
 
-    swagger_ui_parameters: dict = {"withCredentials": True}
+    # Note: Setting `persistAuthorization` to `True` makes it so a logged-in user remains logged-in
+    #       even after reloading the web page (or leaving the website and coming back to it later).
+    # Reference: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#parameters
+    swagger_ui_parameters: dict = {"withCredentials": True, "persistAuthorization": True}
     onComplete = ""
     if access_token is not None:
         onComplete += f"""

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -330,7 +330,10 @@ def custom_swagger_ui_html(
     # Note: Setting `persistAuthorization` to `True` makes it so a logged-in user remains logged-in
     #       even after reloading the web page (or leaving the website and coming back to it later).
     # Reference: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#parameters
-    swagger_ui_parameters: dict = {"withCredentials": True, "persistAuthorization": True}
+    swagger_ui_parameters: dict = {
+        "withCredentials": True,
+        "persistAuthorization": True,
+    }
     onComplete = ""
     if access_token is not None:
         onComplete += f"""

--- a/nmdc_runtime/api/swagger_ui/assets/style.css
+++ b/nmdc_runtime/api/swagger_ui/assets/style.css
@@ -12,3 +12,20 @@
 .nmdc-error {
     color: red;
 }
+
+/** 
+ * Hides the following text from the Swagger UI modal login form:
+ *
+ * > Scopes are used to grant an application different levels of
+ * > access to data on behalf of the end user. Each API may declare
+ * > one or more scopes.
+ * > 
+ * > API requires the following scopes. Select which ones you want
+ * > to grant to Swagger UI.
+ *
+ * TODO: Check whether this text can be hidden via standard
+ *       Swagger UI configuration, rather than custom CSS.
+ */
+.auth-wrapper .modal-ux-content .auth-container .scope-def {
+    display: none;
+}


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I...
- Configured Swagger UI to keep the user logged in across page refreshes
- Hid the scope definitions that appeared atop the login forms (here's a before-and-after)
  <img width="800" alt="image" src="https://github.com/user-attachments/assets/fd90ef54-3454-4282-9630-c43a56fb5093" />
- Updated user-facing documentation to reflect the recently-customized login form header text (the customizations were made in https://github.com/microbiomedata/nmdc-runtime/pull/1064)

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

N/A

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1151 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

Swagger UI only.

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming that, when I'm logged into a native Runtime account and I reload the Swagger UI page, I am still logged in after the page has reloaded.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [x] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
