### PR TITLE
Switch build backend to `hatch` and enable dynamic versioning

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -21,13 +21,15 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Set up Python virtual environment
         run: uv sync
-
-      - name: Build source and wheel archives
+      - name: Preview derived version number
+        run: uvx uv-dynamic-versioning
+      # Here, we build the package using the build settings specified in `pyproject.toml`,
+      # one of which is to derive the package's version number from the Git repository.
+      - name: Build package  # Docs: https://docs.astral.sh/uv/reference/cli/#uv-build
         run: uv build
-
-      - name: Publish distribution 📦 to PyPI
+      - name: Publish package
         if: github.repository == 'microbiomedata/nmdc-runtime'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nmdc-runtime"
-version = "0.0.0"
+dynamic = ["version"]
 description = "A runtime system for NMDC data management and orchestration"
 authors = []
 # Note: This version requirement of ">= 3.10" was copied from the `setup.py` file used by the application's original build system.
@@ -134,13 +134,27 @@ nmdcdb-mongodump = "nmdc_runtime.site.backup.nmdcdb_mongodump:main"
 nmdcdb-mongoimport = "nmdc_runtime.site.backup.nmdcdb_mongoimport:main"
 
 [build-system]
-# Reference: https://docs.astral.sh/uv/concepts/build-backend/#using-the-uv-build-backend
-requires = ["uv_build >= 0.8.14, < 0.9.0"]
-build-backend = "uv_build"
+# Reference: https://hatch.pypa.io/latest/config/build/#build-system
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
 
-[tool.uv.build-backend]
-# Note: We specify `module-name` here to tell the `uv_build` backend that our main module is in `nmdc_runtime/`
-#       (as opposed to being in a `src/` directory, which is where the backend would look for it by default).
+# Note: We specify `packages` here to tell the build backend that our main module is in `nmdc_runtime/`.
 #       Reference: https://docs.astral.sh/uv/concepts/build-backend/#modules
-module-name = "nmdc_runtime"
-module-root = ""
+[tool.hatch.build.targets.wheel]
+packages = ["nmdc_runtime"]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+# Configure hatch to allow dependencies to be specified with the "<NAME> @ <URL>" syntax,
+# which we currently use (above) for specifying `scalar-fastapi` as a dependency.
+# Reference: https://hatch.pypa.io/latest/config/metadata/#allowing-direct-references
+[tool.hatch.metadata]
+allow-direct-references = true
+
+# Note: We use dynamic versioning.
+#       You can preview the version number by running: `$ uvx uv-dynamic-versioning`
+# Docs: https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/version_source.md
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"  # can use "pep440" (default) or "semver"

--- a/uv.lock
+++ b/uv.lock
@@ -2846,7 +2846,6 @@ wheels = [
 
 [[package]]
 name = "nmdc-runtime"
-version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "base32-lib" },


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I switched the build backend from `uv` to `hatch` and enabled dynamic versioning.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

As a result, the Swagger UI page once again shows the app version string instead of "0.0.0" (in the PR where I switched the build system to uv, I introduced a bug that caused the Swagger UI page to always show the latter; i.e. "0.0.0"—this PR fixes that).

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1206 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

Affects the `/version` endpoint and the top of the Swagger UI page.

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by sending a GET request to `/version` and confirming it returned the version string I expected.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
