### PR TITLE
Create `ProcessedSample` and `MaterialProcessing` instances based on parsing `sample_link`

### DIFF
--- a/tests/test_data/data/soil_sample_link_input.yaml
+++ b/tests/test_data/data/soil_sample_link_input.yaml
@@ -1,0 +1,103 @@
+metadata_submission:
+  metadata_submission:
+    packageName: [ 'soil' ]
+    addressForm:
+      shipper:
+        name: ''
+        email: ''
+        phone: ''
+        line1: ''
+        line2: ''
+        city: ''
+        state: ''
+        postalCode: ''
+      expectedShippingDate:
+      shippingConditions: ''
+      sample: ''
+      description: ''
+      experimentalGoals: ''
+      randomization: ''
+      usdaRegulated:
+      permitNumber: ''
+      biosafetyLevel: ''
+      irbOrHipaa:
+      comments: ''
+    templates: [ 'soil' ]
+    studyForm:
+      studyName: A test submission where sample_link is used to generate processed sample records
+      piName: Test Testerson
+      piEmail: test.testerson@example.com
+      piOrcid: 0000-0000-0000-000X
+      linkOutWebpage:
+      studyDate:
+      description:
+      notes:
+      fundingSources:
+      contributors:
+      alternativeNames:
+      GOLDStudyId:
+      NCBIBioProjectId:
+    multiOmicsForm:
+      JGIStudyId:
+      award:
+      dataGenerated: true
+      facilities: [ ]
+      facilityGenerated: true
+      omicsProcessingTypes:
+      otherAward:
+      studyNumber:
+    sampleData:
+      soil_data:
+        - elev: 123
+          analysis_type:
+            - metagenomics
+          collection_date: '2022-01-15'
+          depth: "0 - 1"
+          env_broad_scale: 'urban biome [ENVO:01000249]'
+          env_local_scale: 'tunnel [ENVO:00000068]'
+          env_medium: 'bare soil [ENVO:01001616]'
+          geo_loc_name: 'USA: Nowhere, Oklahoma'
+          growth_facil: greenhouse
+          lat_lon: 35.211445 -98.464612
+          samp_name: "00001"
+          samp_store_temp: "-80 Cel"
+          store_cond: frozen
+        - elev: 123
+          analysis_type:
+            - metagenomics
+          collection_date: '2022-01-15'
+          depth: "0 - 1"
+          env_broad_scale: 'urban biome [ENVO:01000249]'
+          env_local_scale: 'tunnel [ENVO:00000068]'
+          env_medium: 'bare soil [ENVO:01001616]'
+          geo_loc_name: 'USA: Nowhere, Oklahoma'
+          growth_facil: greenhouse
+          lat_lon: 35.211445 -98.464612
+          samp_name: "00002"
+          samp_store_temp: "-80 Cel"
+          store_cond: frozen
+        - elev: 123
+          analysis_type:
+            - metagenomics
+          collection_date: '2022-01-15'
+          depth: "0 - 1"
+          env_broad_scale: 'urban biome [ENVO:01000249]'
+          env_local_scale: 'tunnel [ENVO:00000068]'
+          env_medium: 'bare soil [ENVO:01001616]'
+          geo_loc_name: 'USA: Nowhere, Oklahoma'
+          growth_facil: greenhouse
+          lat_lon: 35.211445 -98.464612
+          sample_link: "Pooling:00001,00002"
+          samp_name: "00003-POOLED"
+          samp_store_temp: "-80 Cel"
+          store_cond: frozen
+  status: in-progress
+  id: 406e6ce5-ec5f-4617-badd-dc061358da24
+  author_orcid: 0000-0000-0000-000X
+  created: '2023-04-03T18:31:16.856377'
+  author:
+    id: a295b145-dc87-416d-9a57-9373d791fb68
+    orcid: 0000-0000-0000-000X
+    name: Test Testerson
+    is_admin: false
+    type: nmdc:PersonValue

--- a/tests/test_data/data/soil_sample_link_output.yaml
+++ b/tests/test_data/data/soil_sample_link_output.yaml
@@ -1,0 +1,139 @@
+biosample_set:
+  - id: 'nmdc:bsm-00-4wn6isig'
+    type: 'nmdc:Biosample'
+    name: '00001'
+    associated_studies: ['nmdc:sty-00-y0cq65zt']
+    env_broad_scale:
+      type: 'nmdc:ControlledIdentifiedTermValue'
+      has_raw_value: 'urban biome [ENVO:01000249]'
+      term:
+        id: 'ENVO:01000249'
+        type: 'nmdc:OntologyClass'
+        name: 'urban biome'
+    env_local_scale:
+      type: 'nmdc:ControlledIdentifiedTermValue'
+      has_raw_value: 'tunnel [ENVO:00000068]'
+      term:
+        id: 'ENVO:00000068'
+        type: 'nmdc:OntologyClass'
+        name: 'tunnel'
+    env_medium:
+      type: 'nmdc:ControlledIdentifiedTermValue'
+      has_raw_value: 'bare soil [ENVO:01001616]'
+      term:
+        id: 'ENVO:01001616'
+        type: 'nmdc:OntologyClass'
+        name: 'bare soil'
+    collection_date:
+       type: 'nmdc:TimestampValue'
+       has_raw_value: '2022-01-15'
+    depth:
+      type: 'nmdc:QuantityValue'
+      has_raw_value: '0 - 1'
+      has_unit: 'm'
+      has_maximum_numeric_value: 1
+      has_minimum_numeric_value: 0
+    elev: 123.0
+    env_package:
+      type: 'nmdc:TextValue'
+      has_raw_value: 'soil'
+    geo_loc_name:
+      type: 'nmdc:TextValue'
+      has_raw_value: 'USA: Nowhere, Oklahoma'
+    growth_facil:
+      type: 'nmdc:ControlledTermValue'
+      has_raw_value: 'greenhouse'
+    lat_lon:
+      type: 'nmdc:GeolocationValue'
+      has_raw_value: '35.211445 -98.464612'
+      latitude: 35.211445
+      longitude: -98.464612
+    samp_name: '00001'
+    samp_store_temp:
+      type: 'nmdc:QuantityValue'
+      has_raw_value: '-80 Cel'
+      has_unit: 'Cel'
+      has_numeric_value: -80
+    store_cond:
+      type: 'nmdc:TextValue'
+      has_raw_value: 'frozen'
+    analysis_type: ['metagenomics']
+  - id: 'nmdc:bsm-00-q8jtgev4'
+    type: 'nmdc:Biosample'
+    name: '00002'
+    associated_studies: [ 'nmdc:sty-00-y0cq65zt' ]
+    env_broad_scale:
+      type: 'nmdc:ControlledIdentifiedTermValue'
+      has_raw_value: 'urban biome [ENVO:01000249]'
+      term:
+        id: 'ENVO:01000249'
+        type: 'nmdc:OntologyClass'
+        name: 'urban biome'
+    env_local_scale:
+      type: 'nmdc:ControlledIdentifiedTermValue'
+      has_raw_value: 'tunnel [ENVO:00000068]'
+      term:
+        id: 'ENVO:00000068'
+        type: 'nmdc:OntologyClass'
+        name: 'tunnel'
+    env_medium:
+      type: 'nmdc:ControlledIdentifiedTermValue'
+      has_raw_value: 'bare soil [ENVO:01001616]'
+      term:
+        id: 'ENVO:01001616'
+        type: 'nmdc:OntologyClass'
+        name: 'bare soil'
+    collection_date:
+      type: 'nmdc:TimestampValue'
+      has_raw_value: '2022-01-15'
+    depth:
+      type: 'nmdc:QuantityValue'
+      has_raw_value: '0 - 1'
+      has_unit: 'm'
+      has_maximum_numeric_value: 1
+      has_minimum_numeric_value: 0
+    elev: 123.0
+    env_package:
+      type: 'nmdc:TextValue'
+      has_raw_value: 'soil'
+    geo_loc_name:
+      type: 'nmdc:TextValue'
+      has_raw_value: 'USA: Nowhere, Oklahoma'
+    growth_facil:
+      type: 'nmdc:ControlledTermValue'
+      has_raw_value: 'greenhouse'
+    lat_lon:
+      type: 'nmdc:GeolocationValue'
+      has_raw_value: '35.211445 -98.464612'
+      latitude: 35.211445
+      longitude: -98.464612
+    samp_name: '00002'
+    samp_store_temp:
+      type: 'nmdc:QuantityValue'
+      has_raw_value: '-80 Cel'
+      has_unit: 'Cel'
+      has_numeric_value: -80
+    store_cond:
+      type: 'nmdc:TextValue'
+      has_raw_value: 'frozen'
+    analysis_type: [ 'metagenomics' ]
+processed_sample_set:
+  - id: 'nmdc:procsm-00-27qd9afz'
+    type: 'nmdc:ProcessedSample'
+    name: '00003-POOLED'
+material_processing_set:
+  - id: 'nmdc:poolp-00-a5vpuemo'
+    type: 'nmdc:Pooling'
+    has_input: ['nmdc:bsm-00-4wn6isig', 'nmdc:bsm-00-q8jtgev4']
+    has_output: ['nmdc:procsm-00-27qd9afz']
+study_set:
+  - id: 'nmdc:sty-00-y0cq65zt'
+    type: 'nmdc:Study'
+    name: 'A test submission where sample_link is used to generate processed sample records'
+    study_category: research_study
+    principal_investigator:
+      type: 'nmdc:PersonValue'
+      email: 'test.testerson@example.com'
+      name: 'Test Testerson'
+      orcid: '0000-0000-0000-000X'
+    title: 'A test submission where sample_link is used to generate processed sample records'

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -424,7 +424,7 @@ def test_instruments(test_minter):
 
 @pytest.mark.parametrize(
     "data_file_base",
-    ["plant_air_jgi", "nucleotide_sequencing_mapping", "sequencing_data"],
+    ["plant_air_jgi", "nucleotide_sequencing_mapping", "sequencing_data", "soil_sample_link"],
 )
 def test_get_dataset(test_minter, monkeypatch, data_file_base):
     # OmicsProcess objects have an add_date and a mod_date slot that are populated with the
@@ -473,3 +473,16 @@ def test_get_dataset(test_minter, monkeypatch, data_file_base):
 
     validation_result = validate_json(json_dumper.to_dict(actual), mongo_db)
     assert validation_result == {"result": "All Okay!"}
+
+
+def test_parse_sample_link():
+    translator = SubmissionPortalTranslator()
+
+    parsed = translator._parse_sample_link("")
+    assert parsed is None
+
+    parsed = translator._parse_sample_link("invalid syntax")
+    assert parsed is None
+
+    parsed = translator._parse_sample_link("Pooling:sample1, sample2")
+    assert parsed == ("Pooling", ["sample1", "sample2"])


### PR DESCRIPTION
On this branch, I updated the `SubmissionPortalTranslator` to conditionally create `ProcessedSample` and `MaterialProcessing` instances instead of a `Biosample` instance based on the value of the `sample_link` slot.

### Details

This is a somewhat ad-hoc solution to allow us to get NEON samples in through the submission portal. Currently each row in DataHarmonizer becomes a `Biosample`. In the submissions that NEON is creating they add some rows that represent "true" samples and some rows that represent the result of a processing operation on one or more "true" samples. 

In order to differentiate those two cases we are going to use the `sample_link` slot. If a row in DataHarmonizer has that slot filled in and it is of the format `[ProcessingType]:[SampleName,...]` then we _won't_ create a `Biosample` and instead create a `ProcessedSample` and a `MaterialProcessing` with the necessary `has_input` and `has_output` connections. See the issue linked below for more details.

### Related issue(s)

Fixes #1211 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

Writing new passing tests, ensuring existing tests pass.

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability


- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
