### PR TITLE
Implement Python notebook that migrates Mongo database from schema `11.10.0` to `11.11.1`

### DIFF
--- a/db/migrations/notebooks/migrate_11_10_0_to_11_11_1.ipynb
+++ b/db/migrations/notebooks/migrate_11_10_0_to_11_11_1.ipynb
@@ -1,0 +1,943 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "86266489462d10d5",
+   "metadata": {},
+   "source": [
+    "# Migrate MongoDB database from `nmdc-schema` `v11.10.0` to `v11.11.1`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81809c54b43ee383",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook will be used to migrate the database from `nmdc-schema` `v11.10.0` ([released](https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.10.0) August 13, 2025) to `v11.11.1` ([released](https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.11.1) September 18, 2025).\n",
+    "\n",
+    "Note about version(s) `11.11.x`: The schema is exactly the same between `nmdc-schema` package versions `v11.11.0` and `11.11.1`. The latter package was only released in order to fix a bug in a migrator.\n",
+    "\n",
+    "### Notice\n",
+    "\n",
+    "In each migration notebook between schema `v10.9.1` and `v11.3.0`, we dumped **all collections** from the Mongo database. We started doing that once migrations involved _collection_-level operations (i.e., creating, renaming, and deleting them), as opposed to only _document_-level operations.\n",
+    "\n",
+    "In _this_ migration notebook, we dump only **specific collection** from the Mongo database. We opted to do this after understanding the scope of the `Migrator` class imported by this notebook. This eliminates some overhead from the migration process (i.e. dumping and restoring unrelated collections)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7488090d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:08:57.837847Z",
+     "start_time": "2025-08-08T21:08:57.832741Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Also, as usual, confirm that the `COLLECTION_NAMES` list below contains the names of any additional collections\n",
+    "# accessed by any other migrators that are \"partials of\" the top-level migrator we'll be running. You can determine\n",
+    "# which collections they access, by inspecting their code.\n",
+    "\n",
+    "COLLECTION_NAMES = list({\n",
+    "    # Collection(s) accessed by \"...part_1\" migrator:\n",
+    "    'biosample_set',\n",
+    "    \n",
+    "    # Additional collection(s) accessed by \"...part_2\" migrator:\n",
+    "    'data_object_set',\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dffc8fac414e6b8a",
+   "metadata": {},
+   "source": [
+    "## Prerequisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f033049a3dd6d9d",
+   "metadata": {},
+   "source": [
+    "### 1. Coordinate with stakeholders.\n",
+    "\n",
+    "We will be enacting full Runtime and Database downtime for this migration. Ensure stakeholders are aware of that."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fedebacf9793fc9",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8be6e542187f9a62",
+   "metadata": {},
+   "source": [
+    "### 2. Set up notebook environment.\n",
+    "\n",
+    "Here, you'll prepare an environment for running this notebook.\n",
+    "\n",
+    "1. Start a **MongoDB server** on your local machine (and ensure it does **not** already contain a database having the name specified in the notebook configuration file).\n",
+    "    1. You can start a [Docker](https://hub.docker.com/_/mongo)-based MongoDB server at `localhost:27055` by running the following command. A MongoDB server started this way will be accessible without a username or password.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14b2b2c65f62c309",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:16:05.540437Z",
+     "start_time": "2025-08-08T21:16:05.230808Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The 11.10.0 migrator uses transactions, so start the MongoDB server with a replica set.\n",
+    "!/usr/local/bin/docker run \\\n",
+    "    --rm \\\n",
+    "    --detach \\\n",
+    "    --name mongo-migration-transformer \\\n",
+    "    -p 27055:27017 \\\n",
+    "    -v ./.docker/01-init.js:/docker-entrypoint-initdb.d/01-init.js \\\n",
+    "    mongo:8.0.4 \\\n",
+    "    --replSet rs0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d516ac8a1c15c660",
+   "metadata": {},
+   "source": [
+    "2. Create and populate a **notebook configuration file** named `.notebook.env`.\n",
+    "   > You can use `.notebook.env.example` as a template."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48d25f7b40726502",
+   "metadata": {},
+   "source": [
+    "## Procedure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e025d76e8fcdc5bf",
+   "metadata": {},
+   "source": [
+    "### Install Python packages\n",
+    "\n",
+    "In this step, you'll [install](https://saturncloud.io/blog/what-is-the-difference-between-and-in-jupyter-notebooks/) the Python packages upon which this notebook depends.\n",
+    "\n",
+    "> Note: If the output of this cell says \"Note: you may need to restart the kernel to use updated packages\", restart the kernel (not the notebook cells), then proceed to the next cell.\n",
+    "\n",
+    "##### References\n",
+    "\n",
+    "| Description                                                                     | Link                                                   |\n",
+    "|---------------------------------------------------------------------------------|--------------------------------------------------------|\n",
+    "| NMDC Schema PyPI package | https://pypi.org/project/nmdc-schema                   |\n",
+    "| How to `pip install` from a Git branch<br>instead of PyPI                       | https://stackoverflow.com/a/20101940                   |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efcd532dd6184f23",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:08:41.906052Z",
+     "start_time": "2025-08-08T21:08:36.935427Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade pip\n",
+    "%pip install -r requirements.txt\n",
+    "%pip install nmdc-schema==11.11.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b52d1ff0e0d98472",
+   "metadata": {},
+   "source": [
+    "### Import Python dependencies\n",
+    "\n",
+    "Import the Python objects upon which this notebook depends.\n",
+    "\n",
+    "#### References\n",
+    "\n",
+    "| Description                            | Link                                                                                                  |\n",
+    "|----------------------------------------|-------------------------------------------------------------------------------------------------------|\n",
+    "| Dynamically importing a Python module  | [`importlib.import_module`](https://docs.python.org/3/library/importlib.html#importlib.import_module) |\n",
+    "| Confirming something is a Python class | [`inspect.isclass`](https://docs.python.org/3/library/inspect.html#inspect.isclass)                   |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11c5d669a24f0ae6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:15.697521Z",
+     "start_time": "2025-08-08T21:09:15.694703Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "MIGRATOR_MODULE_NAME = \"migrator_from_11_10_0_to_11_11_0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d443a1bbc8e3701",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:17.346271Z",
+     "start_time": "2025-08-08T21:09:16.578477Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Standard library packages:\n",
+    "import subprocess\n",
+    "from typing import List\n",
+    "import importlib\n",
+    "from inspect import isclass\n",
+    "\n",
+    "# Third-party packages:\n",
+    "import pymongo\n",
+    "from linkml.validator import Validator, ValidationReport\n",
+    "from linkml.validator.plugins import JsonschemaValidationPlugin\n",
+    "from nmdc_schema.nmdc_data import get_nmdc_schema_definition\n",
+    "from nmdc_schema.migrators.adapters.mongo_adapter import MongoAdapter\n",
+    "from linkml_runtime import SchemaView\n",
+    "\n",
+    "# First-party packages:\n",
+    "from helpers import Config, setup_logger, get_collection_names_from_schema, derive_schema_class_name_from_document\n",
+    "from bookkeeper import Bookkeeper, MigrationEvent\n",
+    "\n",
+    "# Dynamic imports:\n",
+    "migrator_module = importlib.import_module(f\".{MIGRATOR_MODULE_NAME}\", package=\"nmdc_schema.migrators\")\n",
+    "Migrator = getattr(migrator_module, \"Migrator\")  # gets the class\n",
+    "assert isclass(Migrator), \"Failed to import Migrator class.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b496f19c849e733d",
+   "metadata": {},
+   "source": [
+    "### Parse configuration files\n",
+    "\n",
+    "Parse the notebook and Mongo configuration files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ba2424242fb74e4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:23.221041Z",
+     "start_time": "2025-08-08T21:09:22.022437Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cfg = Config()\n",
+    "\n",
+    "# Define some aliases we can use to make the shell commands in this notebook easier to read.\n",
+    "mongodump = cfg.mongodump_path\n",
+    "mongorestore = cfg.mongorestore_path\n",
+    "mongosh = cfg.mongosh_path\n",
+    "\n",
+    "# Make the base CLI options for Mongo shell commands.\n",
+    "origin_mongo_cli_base_options = Config.make_mongo_cli_base_options(\n",
+    "    mongo_host=cfg.origin_mongo_host,\n",
+    "    mongo_port=cfg.origin_mongo_port,\n",
+    "    mongo_username=cfg.origin_mongo_username,\n",
+    "    mongo_password=cfg.origin_mongo_password,\n",
+    ")\n",
+    "transformer_mongo_cli_base_options = Config.make_mongo_cli_base_options(\n",
+    "    mongo_host=cfg.transformer_mongo_host,\n",
+    "    mongo_port=cfg.transformer_mongo_port,\n",
+    "    mongo_username=cfg.transformer_mongo_username,\n",
+    "    mongo_password=cfg.transformer_mongo_password,\n",
+    ")\n",
+    "\n",
+    "# Perform a sanity test of the application paths.\n",
+    "!{mongodump} --version\n",
+    "!{mongorestore} --version\n",
+    "!{mongosh} --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ab8f0802ebed34",
+   "metadata": {},
+   "source": [
+    "### Create MongoDB clients\n",
+    "\n",
+    "Create MongoDB clients you can use to access the \"origin\" and \"transformer\" MongoDB servers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a883186068ed590d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:34.503992Z",
+     "start_time": "2025-08-08T21:09:34.473441Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Mongo client for \"origin\" MongoDB server.\n",
+    "origin_mongo_client = pymongo.MongoClient(host=cfg.origin_mongo_host,\n",
+    "                                          port=int(cfg.origin_mongo_port),\n",
+    "                                          username=cfg.origin_mongo_username,\n",
+    "                                          password=cfg.origin_mongo_password,\n",
+    "                                          directConnection=True)\n",
+    "\n",
+    "# Mongo client for \"transformer\" MongoDB server.\n",
+    "transformer_mongo_client = pymongo.MongoClient(host=cfg.transformer_mongo_host,\n",
+    "                                               port=int(cfg.transformer_mongo_port),\n",
+    "                                               username=cfg.transformer_mongo_username,\n",
+    "                                               password=cfg.transformer_mongo_password,\n",
+    "                                               directConnection=True)\n",
+    "\n",
+    "# Perform sanity tests of those MongoDB clients' abilities to access their respective MongoDB servers.\n",
+    "with pymongo.timeout(3):\n",
+    "    # Display the MongoDB server version (running on the \"origin\" Mongo server).\n",
+    "    print(\"Origin Mongo server version:      \" + origin_mongo_client.server_info()[\"version\"])\n",
+    "\n",
+    "    # Sanity test: Ensure the origin database exists.\n",
+    "    assert cfg.origin_mongo_database_name in origin_mongo_client.list_database_names(), \"Origin database does not exist.\"\n",
+    "\n",
+    "    # Display the MongoDB server version (running on the \"transformer\" Mongo server).\n",
+    "    print(\"Transformer Mongo server version: \" + transformer_mongo_client.server_info()[\"version\"])\n",
+    "\n",
+    "    # Sanity test: Ensure the transformation database does not exist.\n",
+    "    assert cfg.transformer_mongo_database_name not in transformer_mongo_client.list_database_names(), \"Transformation database already exists.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "846e97bb0b6544ae",
+   "metadata": {},
+   "source": [
+    "Delete the transformer database from the transformer MongoDB server if that database already exists there (e.g. if it was left over from an experiment).\n",
+    "\n",
+    "#### References\n",
+    "\n",
+    "| Description                  | Link                                                          |\n",
+    "|------------------------------|---------------------------------------------------------------|\n",
+    "| Python's `subprocess` module | https://docs.python.org/3/library/subprocess.html             |\n",
+    "| `mongosh` CLI options        | https://www.mongodb.com/docs/mongodb-shell/reference/options/ |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "331093f3ce6c50a8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:40.002363Z",
+     "start_time": "2025-08-08T21:09:39.137045Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Note: I run this command via Python's `subprocess` module instead of via an IPython magic `!` command\n",
+    "#       because I expect to eventually use regular Python scripts—not Python notebooks—for migrations.\n",
+    "shell_command = f\"\"\"\n",
+    "  {cfg.mongosh_path} {transformer_mongo_cli_base_options} \\\n",
+    "      --eval 'use {cfg.transformer_mongo_database_name}' \\\n",
+    "      --eval 'db.dropDatabase()' \\\n",
+    "      --quiet\n",
+    "\"\"\"\n",
+    "completed_process = subprocess.run(shell_command, shell=True)\n",
+    "print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8839f276a4402775",
+   "metadata": {},
+   "source": [
+    "### Create validator\n",
+    "\n",
+    "In this step, you'll create a validator that can be used to check whether data conforms to the NMDC Schema. You'll use it later, to do that.\n",
+    "\n",
+    "#### References\n",
+    "\n",
+    "| Description                  | Link                                                                         |\n",
+    "|------------------------------|------------------------------------------------------------------------------|\n",
+    "| LinkML's `Validator` class   | https://linkml.io/linkml/code/validator.html#linkml.validator.Validator      |\n",
+    "| Validating data using LinkML | https://linkml.io/linkml/data/validating-data.html#validation-in-python-code |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd01c9f52db7f6e1",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:43.458078Z",
+     "start_time": "2025-08-08T21:09:42.856818Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "schema_definition = get_nmdc_schema_definition()\n",
+    "validator = Validator(\n",
+    "    schema=schema_definition,\n",
+    "    validation_plugins=[JsonschemaValidationPlugin(closed=True)],\n",
+    ")\n",
+    "\n",
+    "# Perform a sanity test of the validator.\n",
+    "assert callable(validator.validate), \"Failed to instantiate a validator\"\n",
+    "\n",
+    "schema_definition.version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d45f8a5d3aa9f3",
+   "metadata": {},
+   "source": [
+    "### Create SchemaView\n",
+    "\n",
+    "In this step, you'll instantiate a `SchemaView` that is bound to the destination schema.\n",
+    "\n",
+    "#### References\n",
+    "\n",
+    "| Description                 | Link                                                |\n",
+    "|-----------------------------|-----------------------------------------------------|\n",
+    "| LinkML's `SchemaView` class | https://linkml.io/linkml/developers/schemaview.html |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1778be5cd7b68ad2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:45.543250Z",
+     "start_time": "2025-08-08T21:09:44.916742Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "schema_view = SchemaView(get_nmdc_schema_definition())\n",
+    "\n",
+    "# As a sanity test, confirm we can use the `SchemaView` instance to access a schema class.\n",
+    "schema_view.get_class(class_name=\"Database\")[\"name\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2413c292652103a2",
+   "metadata": {},
+   "source": [
+    "### Revoke access from the \"origin\" MongoDB server\n",
+    "\n",
+    "We revoke both \"write\" and \"read\" access to the server.\n",
+    "\n",
+    "#### Rationale\n",
+    "\n",
+    "We revoke \"write\" access so people don't make changes to the original data while the migration is happening, given that the migration ends with an overwriting of the original data (which would wipe out any changes made in the meantime).\n",
+    "\n",
+    "We also revoke \"read\" access. The revocation of \"read\" access is technically optional, but (a) the JavaScript mongosh script will be easier for me to maintain if it revokes everything and (b) this prevents people from reading data during the restore step, during which the database may not be self-consistent.\n",
+    "\n",
+    "#### References\n",
+    "\n",
+    "| Description                    | Link                                                      |\n",
+    "|--------------------------------|-----------------------------------------------------------|\n",
+    "| Running a script via `mongosh` | https://www.mongodb.com/docs/mongodb-shell/write-scripts/ |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7eef0f264af138f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:48.119153Z",
+     "start_time": "2025-08-08T21:09:47.470894Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "shell_command = f\"\"\"\n",
+    "  {cfg.mongosh_path} {origin_mongo_cli_base_options} \\\n",
+    "      --file='mongosh-scripts/revoke-privileges.mongo.js' \\\n",
+    "      --quiet\n",
+    "\"\"\"\n",
+    "completed_process = subprocess.run(shell_command, shell=True)\n",
+    "print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1295c7a43cfbd083",
+   "metadata": {},
+   "source": [
+    "### Delete obsolete dumps from previous migrations\n",
+    "\n",
+    "Delete any existing dumps before we create new ones in this notebook. This is so the dumps you generate with this notebook do not get merged with any unrelated ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5d721e946414514",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:50.911657Z",
+     "start_time": "2025-08-08T21:09:50.635812Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!rm -rf {cfg.origin_dump_folder_path}\n",
+    "!rm -rf {cfg.transformer_dump_folder_path}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd224e2f5d6ccd5",
+   "metadata": {},
+   "source": [
+    "### Dump collection(s) from the \"origin\" MongoDB server\n",
+    "\n",
+    "Use `mongodump` to dump specific collection(s) **from** the \"origin\" MongoDB server **into** a local directory.\n",
+    "\n",
+    "> Note: The reason we do this in a loop is that the `mongodump` program does not allow the user to specify multiple collections to dump. A distinct collection will be dumped on each iteration of the loop.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "725dcb33c1728521",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:09:54.943465Z",
+     "start_time": "2025-08-08T21:09:54.051946Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Dump the specified collections from the \"origin\" database.\n",
+    "for collection_name in COLLECTION_NAMES:\n",
+    "  shell_command = f\"\"\"\n",
+    "    {mongodump} {origin_mongo_cli_base_options} \\\n",
+    "        --db='{cfg.origin_mongo_database_name}' \\\n",
+    "        --out='{cfg.origin_dump_folder_path}' \\\n",
+    "        --gzip \\\n",
+    "        --collection='{collection_name}'\n",
+    "  \"\"\"\n",
+    "  completed_process = subprocess.run(shell_command, shell=True)\n",
+    "  print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a7865d1a9d31945",
+   "metadata": {},
+   "source": [
+    "### Load the dumped collection(s) into the \"transformer\" MongoDB server\n",
+    "\n",
+    "Use `mongorestore` to load the dumped collection(s) **from** the local directory **into** the \"transformer\" MongoDB server.\n",
+    "\n",
+    "References:\n",
+    "- https://www.mongodb.com/docs/database-tools/mongorestore/#std-option-mongorestore\n",
+    "- https://www.mongodb.com/docs/database-tools/mongorestore/mongorestore-examples/#copy-clone-a-database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c047360d46e09cb",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:10:03.908119Z",
+     "start_time": "2025-08-08T21:10:03.188524Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Restore the dumped collections to the \"transformer\" MongoDB server.\n",
+    "shell_command = f\"\"\"\n",
+    "  {mongorestore} {transformer_mongo_cli_base_options} \\\n",
+    "      --nsFrom='{cfg.origin_mongo_database_name}.*' \\\n",
+    "      --nsTo='{cfg.transformer_mongo_database_name}.*' \\\n",
+    "      --dir='{cfg.origin_dump_folder_path}' \\\n",
+    "      --stopOnError \\\n",
+    "      --drop \\\n",
+    "      --gzip\n",
+    "\"\"\"\n",
+    "completed_process = subprocess.run(shell_command, shell=True)\n",
+    "print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d3e516513c3b7a8",
+   "metadata": {},
+   "source": [
+    "### Transform the collections within the \"transformer\" MongoDB server\n",
+    "\n",
+    "Use the migrator to transform the collections in the \"transformer\" database.\n",
+    "\n",
+    "> Reminder: The database transformation functions are defined in the `nmdc-schema` Python package installed earlier.\n",
+    "\n",
+    "> Reminder: The \"origin\" database is **not** affected by this step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "282941a1a07a94cd",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:11:41.920558Z",
+     "start_time": "2025-08-08T21:10:58.700653Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Instantiate a MongoAdapter bound to the \"transformer\" database.\n",
+    "adapter = MongoAdapter(\n",
+    "    database=transformer_mongo_client[cfg.transformer_mongo_database_name],\n",
+    "    on_collection_created=lambda name: print(f'Created collection \"{name}\"'),\n",
+    "    on_collection_renamed=lambda old_name, name: print(f'Renamed collection \"{old_name}\" to \"{name}\"'),\n",
+    "    on_collection_deleted=lambda name: print(f'Deleted collection \"{name}\"'),\n",
+    ")\n",
+    "\n",
+    "# Instantiate a Migrator bound to that adapter.\n",
+    "logger = setup_logger()\n",
+    "migrator = Migrator(adapter=adapter, logger=logger)\n",
+    "\n",
+    "# Execute the Migrator's `upgrade` method to perform the migration.\n",
+    "migrator.upgrade()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "673e10ac5be8f3d8",
+   "metadata": {},
+   "source": [
+    "### Validate the transformed documents\n",
+    "\n",
+    "Now that we have transformed the database, validate each document in each collection in the \"transformer\" MongoDB server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b70d83efc93ba0e8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:05.678811Z",
+     "start_time": "2025-08-08T21:11:48.589262Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Get the names of all collections.\n",
+    "collection_names: List[str] = get_collection_names_from_schema(schema_view)\n",
+    "\n",
+    "# Ensure that, if the (large) \"functional_annotation_agg\" collection is present in `collection_names`,\n",
+    "# it goes at the end of the list we process. That way, we can find out about validation errors in\n",
+    "# other collections without having to wait for that (large) collection to be validated.\n",
+    "ordered_collection_names = sorted(collection_names.copy())\n",
+    "large_collection_name = \"functional_annotation_agg\"\n",
+    "if large_collection_name in ordered_collection_names:\n",
+    "    ordered_collection_names = list(filter(lambda n: n != large_collection_name, ordered_collection_names))\n",
+    "    ordered_collection_names.append(large_collection_name)  # puts it last\n",
+    "\n",
+    "# Process each collection.\n",
+    "for collection_name in ordered_collection_names:\n",
+    "    collection = transformer_mongo_client[cfg.transformer_mongo_database_name][collection_name]\n",
+    "    num_documents_in_collection = collection.count_documents({})\n",
+    "    print(f\"Validating collection {collection_name} ({num_documents_in_collection} documents) [\", end=\"\")  # no newline\n",
+    "\n",
+    "    # Calculate how often we'll display a tick mark (i.e. a sign of life).\n",
+    "    num_documents_per_tick = num_documents_in_collection * 0.10  # one tenth of the total\n",
+    "    num_documents_since_last_tick = 0\n",
+    "\n",
+    "    for document in collection.find():\n",
+    "        # Validate the transformed document.\n",
+    "        #\n",
+    "        # Reference: https://github.com/microbiomedata/nmdc-schema/blob/main/src/docs/schema-validation.md\n",
+    "        #\n",
+    "        # Note: Dictionaries originating as Mongo documents include a Mongo-generated key named `_id`. However,\n",
+    "        #       the NMDC Schema does not describe that key and, indeed, data validators consider dictionaries\n",
+    "        #       containing that key to be invalid with respect to the NMDC Schema. So, here, we validate a\n",
+    "        #       copy (i.e. a shallow copy) of the document that lacks that specific key.\n",
+    "        #\n",
+    "        # Note: The reason we don't use a progress bar library such as `rich[jupyter]`, `tqdm`, or `ipywidgets`\n",
+    "        #       is that _PyCharm's_ Jupyter Notebook integration doesn't fully work with any of them. :(\n",
+    "        #\n",
+    "        schema_class_name = derive_schema_class_name_from_document(schema_view=schema_view, document=document)\n",
+    "        document_without_underscore_id_key = {key: value for key, value in document.items() if key != \"_id\"}\n",
+    "        validation_report: ValidationReport = validator.validate(document_without_underscore_id_key, schema_class_name)\n",
+    "        if len(validation_report.results) > 0:\n",
+    "            result_messages = [result.message for result in validation_report.results]\n",
+    "            raise TypeError(f\"Document is invalid.\\n{result_messages=}\\n{document_without_underscore_id_key=}\")\n",
+    "\n",
+    "        # Display a tick mark if we have validated enough documents since we last displayed one.\n",
+    "        num_documents_since_last_tick += 1\n",
+    "        if num_documents_since_last_tick >= num_documents_per_tick:\n",
+    "            num_documents_since_last_tick = 0\n",
+    "            print(\".\", end=\"\")  # no newline\n",
+    "\n",
+    "    print(\"]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "992778323e5abf6a",
+   "metadata": {},
+   "source": [
+    "### Dump the collections from the \"transformer\" MongoDB server\n",
+    "\n",
+    "Now that the collections have been transformed and validated, dump them **from** the \"transformer\" MongoDB server **into** a local directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e05899950263caa8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:12.311711Z",
+     "start_time": "2025-08-08T21:12:12.001407Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Dump the database from the \"transformer\" MongoDB server.\n",
+    "shell_command = f\"\"\"\n",
+    "  {mongodump} {transformer_mongo_cli_base_options} \\\n",
+    "      --db='{cfg.transformer_mongo_database_name}' \\\n",
+    "      --out='{cfg.transformer_dump_folder_path}' \\\n",
+    "      --gzip\n",
+    "\"\"\"\n",
+    "completed_process = subprocess.run(shell_command, shell=True)\n",
+    "print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "333a58b11c25631",
+   "metadata": {},
+   "source": [
+    "### Create a bookkeeper\n",
+    "\n",
+    "Create a `Bookkeeper` that can be used to document migration events in the \"origin\" server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b35d302475b22ea9",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:15.793943Z",
+     "start_time": "2025-08-08T21:12:15.764175Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bookkeeper = Bookkeeper(mongo_client=origin_mongo_client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e0866a47939597d",
+   "metadata": {},
+   "source": [
+    "### Indicate — on the \"origin\" server — that the migration is underway\n",
+    "\n",
+    "Add an entry to the migration log collection to indicate that this migration has started."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b08824e7b1f59c46",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:20.437074Z",
+     "start_time": "2025-08-08T21:12:20.419841Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_STARTED)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2982d126803c6558",
+   "metadata": {},
+   "source": [
+    "### Skipped: Drop the original collections from the \"origin\" MongoDB server\n",
+    "\n",
+    "Note: This step is necessary for migrations where collections are being renamed or deleted. (The `--drop` option of `mongorestore` would only drop collections that exist in the dump being restored, which would not include renamed or deleted collections.)\n",
+    "\n",
+    "In the case of _this_ migration, no collections are being renamed or deleted. So, we can skip this step. The collections that the migrator _did_ transform, will still be dropped when we run `mongorestore` with the `--drop` option later in this notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b5a6f4e30f3d6f1",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:23.123110Z",
+     "start_time": "2025-08-08T21:12:23.120170Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"skipped\")\n",
+    "\n",
+    "# shell_command = f\"\"\"\n",
+    "#   {cfg.mongosh_path} {origin_mongo_cli_base_options} \\\n",
+    "#       --eval 'use {cfg.origin_mongo_database_name}' \\\n",
+    "#       --eval 'db.dropDatabase()'\n",
+    "# \"\"\"\n",
+    "# completed_process = subprocess.run(shell_command, shell=True)\n",
+    "# print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d2845a0322bfc8c",
+   "metadata": {},
+   "source": [
+    "### Load the collections into the \"origin\" MongoDB server\n",
+    "\n",
+    "Load the transformed collections into the \"origin\" MongoDB server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "248c443030832cdf",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:26.349257Z",
+     "start_time": "2025-08-08T21:12:25.063201Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Load the transformed collections into the origin server, replacing any same-named ones that are there.\n",
+    "shell_command = f\"\"\"\n",
+    "  {mongorestore} {origin_mongo_cli_base_options} \\\n",
+    "      --nsFrom='{cfg.transformer_mongo_database_name}.*' \\\n",
+    "      --nsTo='{cfg.origin_mongo_database_name}.*' \\\n",
+    "      --dir='{cfg.transformer_dump_folder_path}' \\\n",
+    "      --stopOnError \\\n",
+    "      --verbose \\\n",
+    "      --drop \\\n",
+    "      --gzip\n",
+    "\"\"\"\n",
+    "completed_process = subprocess.run(shell_command, shell=True)\n",
+    "print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "777204c62e37c908",
+   "metadata": {},
+   "source": [
+    "### Indicate that the migration is complete\n",
+    "\n",
+    "Add an entry to the migration log collection to indicate that this migration is complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596aba5ac125cb65",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:35.906231Z",
+     "start_time": "2025-08-08T21:12:35.890996Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bookkeeper.record_migration_event(migrator=migrator, event=MigrationEvent.MIGRATION_COMPLETED)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7cac4478a921c3d",
+   "metadata": {},
+   "source": [
+    "### Restore access to the \"origin\" MongoDB server\n",
+    "\n",
+    "This effectively un-does the access revocation that we did earlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db70dca5eb1e31e7",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-08T21:12:38.798899Z",
+     "start_time": "2025-08-08T21:12:37.807615Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "shell_command = f\"\"\"\n",
+    "  {cfg.mongosh_path} {origin_mongo_cli_base_options} \\\n",
+    "      --file='mongosh-scripts/restore-privileges.mongo.js' \\\n",
+    "      --quiet\n",
+    "\"\"\"\n",
+    "completed_process = subprocess.run(shell_command, shell=True)\n",
+    "print(f\"\\nReturn code: {completed_process.returncode}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "ontology-loader == 0.2.2",
     # We use `nmdc-schema` to interpret the data residing in the MongoDB database.
     # Docs: https://microbiomedata.github.io/nmdc-schema/
-    "nmdc-schema == 11.11.0",
+    "nmdc-schema == 11.11.1",
     "pandas",
     "passlib[bcrypt]",
     "pymongo",

--- a/uv.lock
+++ b/uv.lock
@@ -2928,7 +2928,7 @@ requires-dist = [
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
-    { name = "nmdc-schema", specifier = "==11.11.0" },
+    { name = "nmdc-schema", specifier = "==11.11.1" },
     { name = "ontology-loader", specifier = "==0.2.2" },
     { name = "pandas" },
     { name = "passlib", extras = ["bcrypt"] },
@@ -2966,7 +2966,7 @@ dev = [
 
 [[package]]
 name = "nmdc-schema"
-version = "11.11.0"
+version = "11.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2983,9 +2983,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/fc/24a7728d96c5fb14d3a48fa1e5d8cefaf6755afde331ee02ab4ff9df5246/nmdc_schema-11.11.0.tar.gz", hash = "sha256:af445c7be1bc6d0cfd20c24732912364e3fb94a6dc17b9b0cf83ff199e39b18c", size = 679168, upload-time = "2025-09-17T19:56:56.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/3a/9d6ef0f7618eefbe59ae497cc2d35f745562a7b1d6061a9c37b7835ad0d7/nmdc_schema-11.11.1.tar.gz", hash = "sha256:fbf290e3991ba192ad45a90d2aeaa4db364e4be2041392d80f234617a26e5460", size = 679182, upload-time = "2025-09-19T01:08:59.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/d2/6412a43b6168632eb11e03032761218941bbad56a335efc7014547da26ca/nmdc_schema-11.11.0-py3-none-any.whl", hash = "sha256:b4658d5346fe7f8b9a9be1025d0a8b7ff05c78642f4c2540e9706ec2d6e8a31e", size = 743964, upload-time = "2025-09-17T19:56:53.318Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d9/08134cdec2260ade3048cdae87b47e693b3c2e7003d9810b744d82381ea1/nmdc_schema-11.11.1-py3-none-any.whl", hash = "sha256:5df7e14f997f48a221620472b27938c12310d76308bbfb184a53a59c05de74db", size = 743976, upload-time = "2025-09-19T01:08:57.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I implemented a Python notebook that can be used to migrate the Mongo database from conforming to schema 11.10.0 to conforming to schema 11.11.1.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

The schema, itself, did not change between schema versions 11.11.0 and 11.11.1. The schema did, however, change between schema versions 11.10.0 and 11.11.0.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1230

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [x] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by migrating the dev Mongo database.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
