### PR TITLE
Drop stale `_runtime.tmp.linked_instances.*` collections

### DIFF
--- a/nmdc_runtime/api/endpoints/lib/linked_instances.py
+++ b/nmdc_runtime/api/endpoints/lib/linked_instances.py
@@ -6,6 +6,7 @@ This module houses logic for the `GET /nmdcschema/linked_instances` endpoint, de
 
 """
 
+from datetime import timedelta
 from typing import Literal, Any
 
 from bson import ObjectId
@@ -13,7 +14,8 @@ from pymongo.collection import Collection as MongoCollection
 from pymongo.database import Database as MongoDatabase
 from toolz import merge
 
-from nmdc_runtime.api.core.util import hash_from_str
+from nmdc_runtime.api.core.util import hash_from_str, now
+from nmdc_runtime.api.db.mongo import get_mongo_db
 from nmdc_runtime.util import get_class_name_to_collection_names_map, nmdc_schema_view
 
 
@@ -33,6 +35,17 @@ def hash_from_ids_and_types(ids: list[str], types: list[str]) -> str:
 def temp_linked_instances_collection_name(ids: list[str], types: list[str]) -> str:
     """A name for a temporary mongo collection to store linked instances in service of an API request."""
     return f"_runtime.tmp.linked_instances.{hash_from_ids_and_types(ids=ids,types=types)}.{ObjectId()}"
+
+
+def drop_stale_temp_linked_instances_collections():
+    """Drop any temporary linked-instances collections that were generated earlier than one day ago."""
+    mdb = get_mongo_db()
+    one_day_ago = now() - timedelta(days=1)
+    for collection_name in mdb.list_collection_names(
+        filter={"name": {"$regex": r"^_runtime.tmp.linked_instances\..*"}}
+    ):
+        if ObjectId(collection_name.split(".")[-1]).generation_time < one_day_ago:
+            mdb.drop_collection(collection_name)
 
 
 def gather_linked_instances(


### PR DESCRIPTION
On this branch, I add a `fastapi.BackgroundTasks` parameter to the path operation function for the `GET /nmdcschema/linked_instances` endpoint, and schedule a task  -- to be performed after the endpoint returns -- that drop any temporary linked-instances collections that were generated earlier than one day ago.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1240 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)

I tested these changes by inspection. Calling the endpoint locally dropped local stale temporary collections.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Other (explain below)

N/A

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
