### PR TITLE
Prevent uv from installing dependencies when running application

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -43,4 +43,4 @@ jobs:
       #       file, or due to one of the dependencies becoming unavailable), which can prompt remedial action.
       #
       - name: Build MkDocs site
-        run: uv run mkdocs build -f docs/mkdocs.yml
+        run: uv run --no-sync mkdocs build -f docs/mkdocs.yml

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ reset-db-test:
 run-test:
 	docker compose --file docker-compose.test.yml exec -it test \
 		./.docker/wait-for-it.sh fastapi:8000 --strict --timeout=300 -- \
-			uv run --active \
+			uv run --active --no-sync \
 				pytest --cov=nmdc_runtime \
 				       --doctest-modules \
 				       --ignore=util/load_testing \
@@ -60,16 +60,16 @@ test: down-test up-test run-test
 # Format Python code using `black`.
 # TODO: Migrate from `black` to `ruff`.
 black:
-	uv run --active black nmdc_runtime
+	uv run --active --no-sync black nmdc_runtime
 
 # Lint Python code using `flake8`.
 # TODO: Migrate from `flake8` to `ruff`.
 lint:
 	# Python syntax errors or undefined names
-	uv run --active flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --extend-ignore=F722 \
+	uv run --active --no-sync flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --extend-ignore=F722 \
 		./nmdc_runtime ./tests
 	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-	uv run --active flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 \
+	uv run --active --no-sync flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 \
 		--statistics --extend-exclude="./build/" --extend-ignore=F722 \
 		./nmdc_runtime ./tests
 
@@ -122,7 +122,7 @@ mongorestore-nmdc-db:
 		--drop --nsInclude='nmdc.*' --gzip --dir /tmp/remote-mongodump
 
 quick-blade:
-	uv run --active python -c "from nmdc_runtime.api.core.idgen import generate_id; print(f'nmdc:nt-11-{generate_id(length=8, split_every=0)}')"
+	uv run --active --no-sync python -c "from nmdc_runtime.api.core.idgen import generate_id; print(f'nmdc:nt-11-{generate_id(length=8, split_every=0)}')"
 
 # List of Make targets that do not represent files being created.
 # Note: I think _most_ of the targets in this Makefile meet that criterion,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     #       oftentimes modify those files while doing load testing, and those files are
     #       not part of the FastAPI app.
     #       Docs: https://www.uvicorn.org/settings/?h=watch#reloading-with-watchfiles
-    command: ["uv", "run", "--active", "uvicorn", "nmdc_runtime.api.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000", "--reload-exclude", "util/load_testing/*"]
+    command: ["uv", "run", "--active", "--no-sync", "uvicorn", "nmdc_runtime.api.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000", "--reload-exclude", "util/load_testing/*"]
     env_file: .env
     # Note: Setting `tty: true` makes it so the console output is in color.
     #       Reference: https://docs.docker.com/reference/cli/docker/container/run/#tty

--- a/docs/content/contributing-docs.md
+++ b/docs/content/contributing-docs.md
@@ -13,7 +13,7 @@ Reference for contributing to this documentation.
 2. Start the [MkDocs development server](https://www.mkdocs.org/user-guide/cli/#mkdocs-serve).
 
    ```shell
-   uv run mkdocs serve -f docs/mkdocs.yml
+   uv run --no-sync mkdocs serve -f docs/mkdocs.yml
    ```
 
    > The MkDocs development server will be accessible at: [`http://localhost:8000`](http://localhost:8000). It will have live reloading enabled. You can press `Ctrl+C` to terminate the server.
@@ -21,7 +21,7 @@ Reference for contributing to this documentation.
 3. (Optional) Build the MkDocs website.
 
    ```shell
-   uv run mkdocs build -f docs/mkdocs.yml
+   uv run --no-sync mkdocs build -f docs/mkdocs.yml
    ```
 
 ## File tree

--- a/nmdc_runtime/Dockerfile
+++ b/nmdc_runtime/Dockerfile
@@ -103,7 +103,7 @@ COPY . /code
 # Install the project in editable mode.
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /code && \
-    uv sync --active --no-dev
+    uv sync --active --no-dev --compile-bytecode
 
 # Use Uvicorn to serve the FastAPI app on port 8000.
 EXPOSE 8000
@@ -124,7 +124,7 @@ COPY . /opt/dagster/lib
 # Install the project in editable mode.
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /opt/dagster/lib && \
-    uv sync --active --no-dev
+    uv sync --active --no-dev --compile-bytecode
 
 # Move Dagster configuration files to the place Dagster expects.
 ENV DAGSTER_HOME="/opt/dagster/dagster_home/"
@@ -154,7 +154,7 @@ COPY . /code
 # Install the project in editable mode, and install development dependencies.
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /code && \
-    uv sync --active
+    uv sync --active --compile-bytecode
 
 # Make `wait-for-it.sh` executable.
 RUN chmod +x /code/.docker/wait-for-it.sh

--- a/nmdc_runtime/Dockerfile
+++ b/nmdc_runtime/Dockerfile
@@ -85,13 +85,17 @@ ENV PATH="/root/.local/bin/:$PATH"
 #       instead of when the container is running. By default, `uv` defers this compilation
 #       to "import time," whereas `pip` (by default) performs it at "install time" (like this).
 #
+# Note: We use `--locked` so that `uv sync` exits with an error if the `uv.lock` file isn't _already_
+#       up to date. By default, `uv sync` would automatically update the lock file if necessary.
+#       Reference: https://docs.astral.sh/uv/reference/cli/#uv-sync--locked
+#
 ENV VIRTUAL_ENV="/venv"
 RUN mkdir -p "${VIRTUAL_ENV}"
 COPY ./pyproject.toml /code/pyproject.toml
 COPY ./uv.lock        /code/uv.lock
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /code && \
-    UV_LINK_MODE=copy uv sync --active --no-dev --no-install-project --compile-bytecode
+    UV_LINK_MODE=copy uv sync --active --no-dev --no-install-project --compile-bytecode --locked
 
 # ────────────────────────────────────────────────────────────────────────────┐
 FROM base AS fastapi
@@ -103,12 +107,18 @@ COPY . /code
 # Install the project in editable mode.
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /code && \
-    uv sync --active --no-dev --compile-bytecode
+    uv sync --active --no-dev --compile-bytecode --locked
 
 # Use Uvicorn to serve the FastAPI app on port 8000.
+#
+# Note: We include the `--no-sync` option to prevent `uv run` from automatically syncing dependencies.
+#       If it were to sync dependencies at this point, it would install development dependencies, since
+#       we exclude them above, but they are listed in uv's `default-groups` configuration by default.
+#       This is explained at: https://github.com/astral-sh/uv/issues/12558#issuecomment-2764611918
+#
 EXPOSE 8000
 WORKDIR /code
-CMD ["uv", "run", "--active", "uvicorn", "nmdc_runtime.api.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "--active", "--no-sync", "uvicorn", "nmdc_runtime.api.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8000"]
 
 # ────────────────────────────────────────────────────────────────────────────┐
 FROM base AS dagster
@@ -124,7 +134,7 @@ COPY . /opt/dagster/lib
 # Install the project in editable mode.
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /opt/dagster/lib && \
-    uv sync --active --no-dev --compile-bytecode
+    uv sync --active --no-dev --compile-bytecode --locked
 
 # Move Dagster configuration files to the place Dagster expects.
 ENV DAGSTER_HOME="/opt/dagster/dagster_home/"
@@ -154,7 +164,7 @@ COPY . /code
 # Install the project in editable mode, and install development dependencies.
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /code && \
-    uv sync --active --compile-bytecode
+    uv sync --active --compile-bytecode --locked
 
 # Make `wait-for-it.sh` executable.
 RUN chmod +x /code/.docker/wait-for-it.sh

--- a/nmdc_runtime/site/entrypoint-daemon.sh
+++ b/nmdc_runtime/site/entrypoint-daemon.sh
@@ -23,4 +23,4 @@ file_env() {
 file_env "MONGO_PASSWORD"
 file_env "DAGSTER_POSTGRES_PASSWORD"
 
-exec uv run --active dagster-daemon run
+exec uv run --active --no-sync dagster-daemon run

--- a/nmdc_runtime/site/entrypoint-dagit-readonly.sh
+++ b/nmdc_runtime/site/entrypoint-dagit-readonly.sh
@@ -23,4 +23,4 @@ file_env() {
 file_env "MONGO_PASSWORD"
 file_env "DAGSTER_POSTGRES_PASSWORD"
 
-exec uv run --active dagit -h 0.0.0.0 -p 3000 -w workspace.yaml --read-only
+exec uv run --active --no-sync dagit -h 0.0.0.0 -p 3000 -w workspace.yaml --read-only

--- a/nmdc_runtime/site/entrypoint-dagit.sh
+++ b/nmdc_runtime/site/entrypoint-dagit.sh
@@ -23,4 +23,4 @@ file_env() {
 file_env "MONGO_PASSWORD"
 file_env "DAGSTER_POSTGRES_PASSWORD"
 
-exec uv run --active dagit -h 0.0.0.0 -p 3000 -w workspace.yaml
+exec uv run --active --no-sync dagit -h 0.0.0.0 -p 3000 -w workspace.yaml


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I made changes to the way uv syncs dependencies and runs applications (e.g. uvicorn, black).

On this branch, here's what the `fastapi` container logs show when the container first starts up:

```console
2025-10-02 19:23:42.465 | INFO:     Will watch for changes in these directories: ['/code']
2025-10-02 19:23:42.465 | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
2025-10-02 19:23:42.465 | INFO:     Started reloader process [10] using WatchFiles
2025-10-02 19:23:51.163 | INFO:     Started server process [12]
2025-10-02 19:23:51.163 | INFO:     Waiting for application startup.
2025-10-02 19:23:51.765 | Identifying schema-allowed references.
2025-10-02 19:23:52.312 | INFO:     Application startup complete.
```

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Here are the changes I made on this branch:
1. I added the `--compile-bytecode` option to _all_ `uv sync` commands in the `Dockerfile`. 
   1. Now, when uv installs the project, it will compile `.pyc` files at that time (i.e. at container image **build** time), instead of compiling them when they are first imported (i.e. at application **run** time).
   2. We were already doing this for dependencies, but not for the project, itself.
3. I added the `--locked` option to _all_ `uv sync` commands in the `Dockerfile`.
   1. Now, if `uv sync` determines that it would need to update the `uv.lock` file, it will exit with an error (instead of updating the `uv.lock` file).
   3. This will make it so `uv sync` isn't silently updating some ephemeral copy of the `uv.lock` file (e.g. during the container image build process). I don't know why it would do this, but I would want to know about it if it did.
4. I added the `--no-sync` option to _all_ `uv run` commands in the entire repository.
   1. Now, uv will run things using **whatever versions of the dependencies are already installed**.
   2. Previously, it would spontaneously install our `dev` dependencies before running things, since we omit those when we do `uv sync` and, by default, (a) uv has its `default-groups` list set to `["dev"]` ([source](https://docs.astral.sh/uv/reference/settings/#default-groups)) and (b) uv automatically performs a `uv sync` when performing `uv run`. 
   3. By adding this CLI option, we are preventing that automatic `uv sync` from happening—we'll be responsible for running `uv sync` ourselves (we already do this).

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1251

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

The container image build process, and the launching of applications (e.g. uvicorn, black).

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running `$ make up-dev` locally and watching the `fastapi` container log. Snippets from the container log are in a comment in the linked issue.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
