### PR TITLE
Implement `POST /jobs` API endpoint that creates a job

### DIFF
--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -45,7 +45,10 @@ def list_jobs(
     return list_resources(req, mdb, "jobs")
 
 
-@router.post("/jobs")
+@router.post(
+    "/jobs",
+    status_code=status.HTTP_201_CREATED,
+)
 def create_job(
     job_in: JobIn,
     mdb: Database = Depends(get_mongo_db),

--- a/nmdc_runtime/api/models/job.py
+++ b/nmdc_runtime/api/models/job.py
@@ -42,7 +42,9 @@ class JobIn(JobBase):
     config: Dict[str, Any] = Field(
         ..., description="Configuration of the associated workflow", examples=[{}]
     )
-    claims: List[JobClaim] = Field([], description="Claims of the job", examples=[[]])
+    claims: List[JobClaim] = Field(
+        default_factory=list, description="Claims of the job", examples=[[]]
+    )
 
 
 class JobExecution(BaseModel):

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -521,11 +521,11 @@ class Faker:
                 "workflow": {"id": "arbitrary_string"},
                 **overrides,
             }
-            # Validate the parameters by attempting to instantiate a `DataObject`.
+            # Validate the parameters by attempting to instantiate a `Job`.
             instance = Job(**params)
             
-            # Dump the instance to a `dict` (technically, to a `JsonObj`).
-            document = json_dumper.to_dict(instance)
+            # Dump the instance to a `dict` using the Pydantic's model's `model_dump()` method.
+            document = instance.model_dump()
             documents.append(document)
 
         return documents

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -3244,7 +3244,7 @@ def test_create_job(api_site_client):
     response = api_site_client.request("POST", "/jobs", job)
 
     # Verify the response indicates success and its payload has the field and values we expect.
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_201_CREATED
     created_job = response.json()
     assert isinstance(created_job["id"], str) and len(created_job["id"]) > 0
     assert isinstance(created_job["created_at"], str) and len(created_job["created_at"]) > 0


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I create a new POST endpoint `/jobs` that accepts a json body of job information and submits it to the MongoDB. This requires site client credentials. Additionally I created a test and a new function to fake jobs.

### Details

Here's a screenshot showing the endpoint on Swagger UI, as of commit https://github.com/microbiomedata/nmdc-runtime/pull/1268/commits/8872776dd096bf84b1f0fe921000011c9b20125c.

<img width="753" height="693" alt="image" src="https://github.com/user-attachments/assets/34f86a09-b05f-4ca9-a08b-43343ec71c5e" />

### Related issue(s)
Fixes #1253 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by creating a new test in test_endpoints.py

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
