### PR TITLE
Short-circuit ID pattern removal function

### DIFF
--- a/nmdc_runtime/util.py
+++ b/nmdc_runtime/util.py
@@ -112,12 +112,10 @@ def get_type_collections() -> dict:
 
 
 def without_id_patterns(nmdc_jsonschema):
-    rv = deepcopy(nmdc_jsonschema)
-    for cls_, spec in rv["$defs"].items():
-        if "properties" in spec:
-            if "id" in spec["properties"]:
-                spec["properties"]["id"].pop("pattern", None)
-    return rv
+    # !!! Return the unmodified schema !!!
+    # This is an experimental change to determine if removing the ID pattern exception would cause
+    # any issues in practice. If not, we can remove this function and the associated logic.
+    return nmdc_jsonschema
 
 
 @lru_cache


### PR DESCRIPTION
On this branch, I changed the `without_id_patterns` function to return the original schema unmodified. 

### Details

It wasn't clear if this ID pattern exception is still needed in practice. Having it there will complicate the transition to LinkML validation tools (https://github.com/microbiomedata/nmdc-runtime/issues/1152). Therefore, the suggestion from @aclum was to remove the exception and test it on dev before proceeding with the rest of that work.

### Related issue(s)

Related to (but should not close) https://github.com/microbiomedata/nmdc-runtime/issues/1152

### Related subsystem(s)

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running the test suite locally.

### Documentation

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [x] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
