### PR TITLE
Handle submission images in translation process

### DIFF
--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -64,6 +64,7 @@ from nmdc_runtime.site.ops import (
     generate_data_generation_set_post_biosample_ingest,
     get_instrument_ids_by_model,
     log_database_ids,
+    add_public_image_urls,
 )
 from nmdc_runtime.site.export.study_metadata import get_biosamples_by_study_id
 
@@ -239,6 +240,7 @@ def ingest_metadata_submission():
         instrument_mapping=instrument_mapping,
         study_id=study_id,
     )
+    database = add_public_image_urls(database, submission_id)
 
     log_database_ids(database)
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -637,6 +637,31 @@ def translate_portal_submission_to_nmdc_schema_database(
     return database
 
 
+@op(required_resource_keys={"nmdc_portal_api_client"})
+def add_public_image_urls(
+    context: OpExecutionContext, database: nmdc.Database, submission_id: str
+) -> nmdc.Database:
+    client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
+
+    if len(database.study_set) != 1:
+        raise Failure(
+            description="Expected exactly one study in the database to add public image URLs."
+        )
+
+    study_id = database.study_set[0].id
+    public_images = client.make_submission_images_public(
+        submission_id, study_id=study_id
+    )
+    SubmissionPortalTranslator.set_study_images(
+        database.study_set[0],
+        public_images.get("pi_image_url"),
+        public_images.get("primary_study_image_url"),
+        public_images.get("study_image_urls"),
+    )
+
+    return database
+
+
 @op
 def nmdc_schema_database_export_filename(study: Dict[str, Any]) -> str:
     source_id = None

--- a/nmdc_runtime/site/resources.py
+++ b/nmdc_runtime/site/resources.py
@@ -466,6 +466,17 @@ class NmdcPortalApiClient:
         response.raise_for_status()
         return response.json()
 
+    def make_submission_images_public(
+        self, submission_id: str, *, study_id: str
+    ) -> Dict[str, Any]:
+        response = self._request(
+            "POST",
+            f"/api/metadata_submission/{submission_id}/image/make_public",
+            json={"study_id": study_id},
+        )
+        response.raise_for_status()
+        return response.json()
+
 
 @resource(
     config_schema={

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1080,3 +1080,42 @@ class SubmissionPortalTranslator(Translator):
                 database.data_generation_set.append(nucleotide_sequencing)
 
         return database
+
+    @staticmethod
+    def set_study_images(
+        nmdc_study: nmdc.Study,
+        pi_image_url: Optional[str],
+        primary_study_image_url: Optional[str],
+        study_images_url: Optional[list[str]],
+    ) -> None:
+        """Set images for a study based on provided URLs."""
+
+        if pi_image_url:
+            if not nmdc_study.principal_investigator:
+                nmdc_study.principal_investigator = nmdc.PersonValue(
+                    type="nmdc:PersonValue"
+                )
+            nmdc_study.principal_investigator.profile_image_url = pi_image_url
+
+        if primary_study_image_url:
+            if not nmdc_study.study_image:
+                nmdc_study.study_image = []
+            nmdc_study.study_image.append(
+                nmdc.ImageValue(
+                    type="nmdc:ImageValue",
+                    url=primary_study_image_url,
+                    display_order=0,
+                )
+            )
+
+        if study_images_url:
+            if not nmdc_study.study_image:
+                nmdc_study.study_image = []
+            for idx, image_url in enumerate(study_images_url, start=1):
+                nmdc_study.study_image.append(
+                    nmdc.ImageValue(
+                        type="nmdc:ImageValue",
+                        url=image_url,
+                        display_order=idx,
+                    )
+                )

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -15,6 +15,7 @@ from nmdc_schema.nmdc import (
     DoiProviderEnum,
     DoiCategoryEnum,
     UnitEnum,
+    Study,
 )
 
 from nmdc_runtime.site.translation.submission_portal_translator import (
@@ -531,3 +532,31 @@ def test_parse_sample_link():
 
     parsed = translator._parse_sample_link("Pooling:sample1, sample2")
     assert parsed == ("Pooling", ["sample1", "sample2"])
+
+
+def test_set_study_images():
+    study = Study(
+        id="nmdc:study-00-00000000",
+        type="nmdc:Study",
+        study_category="research_study"
+    )
+
+    SubmissionPortalTranslator.set_study_images(
+        study,
+        pi_image_url="http://www.example.org/pi_image.jpg",
+        primary_study_image_url="http://www.example.org/primary_study_image.jpg",
+        study_images_url=[
+            "http://www.example.org/study_image1.jpg",
+            "http://www.example.org/study_image2.jpg",
+        ]
+    )
+
+    assert study.principal_investigator.profile_image_url == "http://www.example.org/pi_image.jpg"
+    assert study.study_image is not None
+    assert len(study.study_image) == 3
+    assert study.study_image[0].url == "http://www.example.org/primary_study_image.jpg"
+    assert study.study_image[0].display_order == 0
+    assert study.study_image[1].url == "http://www.example.org/study_image1.jpg"
+    assert study.study_image[1].display_order == 1
+    assert study.study_image[2].url == "http://www.example.org/study_image2.jpg"
+    assert study.study_image[2].display_order == 2


### PR DESCRIPTION
On this branch, I updated the process which translates submission data into MongoDB documents in order to handle submission images.

### Details

Images attached to submissions are private. Their access is controlled by using signed URLs so that only people with access to the submission itself can access the images. However, the images referenced in MongoDB documents must be publicly accessible. These changes update the submission translation process by:

1. Adding a static method (`set_study_images`) to `StudyPortalTranslator` which takes different kinds of public image URLs and populates the correct slots of a `Study` instance.
2. Adding a new `op` (`add_public_image_urls`) which:
    - Calls the `nmdc-server` endpoint which copies a submission's images from the private image bucket to the public image bucket
    - Uses the public image URLs in the response to populate various `Study` slots via `set_study_images`
3. Calling the new `op` in the `ingest_metadata_submission` graph. Note that this `op` is *intentionally* not called in the closely-related "dry-run" graph (`translate_metadata_submission_to_nmdc_schema_database`) because we only want to make the public image copies when we really mean it!

### Related issue(s)

Fixes #1262 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by

* Adding a new automated test for the translator static method
* Manually running the Dagster graph in my local development environment and ensuring I got the expected results

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
