### PR TITLE
Fix bugs where response validation would fail when projection was used

### DIFF
--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -7,7 +7,6 @@ from pymongo.database import Database
 from fastapi import APIRouter, Depends, Query, HTTPException, Path
 from pymongo.errors import ConnectionFailure, OperationFailure
 from starlette import status
-from nmdc_runtime.api.models.metadata import Doc
 from nmdc_runtime.api.core.util import (
     raise404_if_none,
 )
@@ -15,6 +14,7 @@ from nmdc_runtime.api.db.mongo import get_mongo_db
 from nmdc_runtime.api.core.idgen import generate_one_id
 from nmdc_runtime.api.endpoints.util import list_resources, _claim_job, strip_oid
 from nmdc_runtime.api.models.job import Job, JobClaim, JobIn
+from nmdc_runtime.api.models.metadata import Doc
 from nmdc_runtime.api.models.operation import Operation, MetadataT
 from nmdc_runtime.api.models.site import (
     Site,
@@ -26,6 +26,9 @@ from nmdc_runtime.api.models.util import ListRequest, ListResponse, ResultT
 router = APIRouter()
 
 
+# Note: We use the generic `Doc` class—instead of the `Job` class—to describe the response
+#       because this endpoint (via `ListRequest`) supports projection, which can be used to omit
+#       fields from the response, even fields the `Job` class says are required.
 @router.get(
     "/jobs", response_model=ListResponse[Doc], response_model_exclude_unset=True
 )

--- a/nmdc_runtime/api/endpoints/objects.py
+++ b/nmdc_runtime/api/endpoints/objects.py
@@ -8,7 +8,6 @@ from pymongo.database import Database as MongoDatabase
 import requests
 from starlette.responses import RedirectResponse
 from toolz import merge
-from nmdc_runtime.api.models.metadata import Doc
 
 from nmdc_runtime.api.core.idgen import decode_id, generate_one_id, local_part
 from nmdc_runtime.api.core.util import raise404_if_none, API_SITE_ID
@@ -21,6 +20,7 @@ from nmdc_runtime.api.endpoints.util import (
     BASE_URL_EXTERNAL,
     strip_oid,
 )
+from nmdc_runtime.api.models.metadata import Doc
 from nmdc_runtime.api.models.object import (
     DrsId,
     DrsObject,
@@ -91,6 +91,9 @@ def create_object(
     )
 
 
+# Note: We use the generic `Doc` class—instead of the `DrsObject` class—to describe the response
+#       because this endpoint (via `ListRequest`) supports projection, which can be used to omit
+#       fields from the response, even fields the `DrsObject` class says are required.
 @router.get("/objects", response_model=ListResponse[Doc])
 def list_objects(
     req: Annotated[ListRequest, Query()],

--- a/nmdc_runtime/api/endpoints/wf_file_staging.py
+++ b/nmdc_runtime/api/endpoints/wf_file_staging.py
@@ -5,12 +5,15 @@ from toolz import merge
 import logging
 
 from nmdc_runtime.api.core.util import raise404_if_none, HTTPException, status
-from nmdc_runtime.api.models.user import User, get_current_active_user
 from nmdc_runtime.api.db.mongo import get_mongo_db
-from nmdc_runtime.api.models.util import ListRequest, ListResponse
-from nmdc_runtime.api.endpoints.util import list_resources, strip_oid
+from nmdc_runtime.api.endpoints.util import (
+    check_action_permitted,
+    list_resources,
+    strip_oid,
+)
 from nmdc_runtime.api.models.metadata import Doc
-
+from nmdc_runtime.api.models.user import User, get_current_active_user
+from nmdc_runtime.api.models.util import ListRequest, ListResponse
 from nmdc_runtime.api.models.wfe_file_stages import (
     GlobusTask,
     GlobusTaskStatus,
@@ -19,7 +22,6 @@ from nmdc_runtime.api.models.wfe_file_stages import (
     JGISequencingProject,
     WorkflowFileStagingCollectionName as CollectionName,
 )
-from nmdc_runtime.api.endpoints.util import check_action_permitted
 
 router = APIRouter()
 
@@ -112,6 +114,9 @@ def update_globus_tasks(
     return doc_globus_patched
 
 
+# Note: We use the generic `Doc` class—instead of the `GlobusTask` class—to describe the response
+#       because this endpoint (via `ListRequest`) supports projection, which can be used to omit
+#       fields from the response, even fields the `GlobusTask` class says are required.
 @router.get(
     "/wf_file_staging/globus_tasks",
     response_model=ListResponse[Doc],
@@ -178,6 +183,9 @@ def create_jgi_sample(
         )
 
 
+# Note: We use the generic `Doc` class—instead of the `JGISample` class—to describe the response
+#       because this endpoint (via `ListRequest`) supports projection, which can be used to omit
+#       fields from the response, even fields the `JGISample` class says are required.
 @router.get(
     "/wf_file_staging/jgi_samples",
     response_model=ListResponse[Doc],
@@ -230,6 +238,9 @@ def update_jgi_samples(
     return doc_jgi_sample_patched
 
 
+# Note: We use the generic `Doc` class—instead of the `JGISequencingProject` class—to describe the response
+#       because this endpoint (via `ListRequest`) supports projection, which can be used to omit
+#       fields from the response, even fields the `JGISequencingProject` class says are required.
 @router.get(
     "/wf_file_staging/jgi_sequencing_projects",
     response_model=ListResponse[Doc],


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I investigated the bug in the get /jobs endpoint when trying to input a projection. 

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->
I fixed the response object and am now stripping the _id mongo given field. 
### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

fixes #1317 
### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by run the dev stack locally and calling the endpoint with projections

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [ ] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
