### PR TITLE
Do not create `<Attribute>` when `soil_horizon` slot has a value of "M horizon"

### DIFF
--- a/nmdc_runtime/site/export/ncbi_xml.py
+++ b/nmdc_runtime/site/export/ncbi_xml.py
@@ -519,6 +519,10 @@ class NCBISubmissionXML:
 
                         formatted_value = handler(item)
 
+                        # Special handling for "geo_loc_name" - convert unicode to closest ASCII characters
+                        if json_key == "geo_loc_name":
+                            formatted_value = unidecode(formatted_value)
+
                         # For pooled samples, we typically want the first value or aggregate appropriately
                         if xml_key not in aggregated_attributes:
                             aggregated_attributes[xml_key] = formatted_value
@@ -542,6 +546,13 @@ class NCBISubmissionXML:
                     if "term" in value and "id" in value["term"]:
                         value = re.findall(r"\d+", value["term"]["id"].split(":")[1])[0]
                     aggregated_attributes[xml_key] = value
+                    continue
+
+                # Special handling for "geo_loc_name" - convert unicode to closest ASCII characters
+                if json_key == "geo_loc_name":
+                    formatted_value = handler(value)
+                    formatted_value = unidecode(formatted_value)
+                    aggregated_attributes[xml_key] = formatted_value
                     continue
 
                 formatted_value = handler(value)


### PR DESCRIPTION
We are constraining the NCBI XML exporter logic such that an `<Attribute>` does not get created for individual biosamples when the `soil_horizon` value is 'M horizon'.

<hr />
 
There is also a commit [011773a](https://github.com/microbiomedata/nmdc-runtime/pull/1331/commits/011773ab07391656a38ffbdc0e79643c55cb65db) to properly enforce the unicode decoding of characters even when we are creating the XML for processed samples instead of just individual biosamples.