### PR TITLE
Make site client auth error messages be more specific and actionable

### DIFF
--- a/nmdc_runtime/api/models/site.py
+++ b/nmdc_runtime/api/models/site.py
@@ -1,9 +1,11 @@
+import logging
 from typing import List, Optional
 
 import pymongo.database
-from fastapi import Depends
-from jose import JWTError, jwt
+from fastapi import Depends, HTTPException, status
+from jose import jwt
 from pydantic import BaseModel, ConfigDict, Field
+from jose.exceptions import ExpiredSignatureError, JWTClaimsError, JWTError
 
 from nmdc_runtime.api.core.auth import (
     verify_password,
@@ -13,7 +15,6 @@ from nmdc_runtime.api.core.auth import (
 from nmdc_runtime.api.db.mongo import get_mongo_db
 from nmdc_runtime.api.models.user import (
     oauth2_scheme,
-    credentials_exception,
     SECRET_KEY,
     ALGORITHM,
 )
@@ -74,23 +75,92 @@ def authenticate_site_client(mdb, client_id: str, client_secret: str):
 async def get_current_client_site(
     token: str = Depends(oauth2_scheme),
     mdb: pymongo.database.Database = Depends(get_mongo_db),
-):
-    if mdb.invalidated_tokens.find_one({"_id": token}):
-        raise credentials_exception
+) -> SiteInDB:
+    """
+    Returns the site associated with the site client identified by the specified token.
+
+    Raises an exception if the token is invalid.
+
+    Note: This function is similar to the `get_current_user` function
+          defined in `nmdc_runtime/api/models/user.py`. Consider consolidating
+          the exception definitions (accounting for differences in `detail` strings).
+    """
+
+    # Define some exceptions, which contain actionable—but not sensitive—information.
+    invalid_subject_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Access token is invalid. Please log in as a site client.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    invalid_claims_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Access token is invalid. Please log in again.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    invalid_token_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Access token is invalid. Please log in again.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    invalidated_token_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Access token has been invalidated. Please log in again.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    expired_token_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Access token has expired. Please log in again.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    invalid_or_missing_token_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Access token is invalid or missing. Please log in again.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    # Check whether there is a token, and whether it has been invalidated.
+    if token is None:
+        raise invalid_or_missing_token_exception
+    elif mdb.invalidated_tokens.find_one({"_id": token}):
+        raise invalidated_token_exception
+
+    # Validate the signature of the JWT and extract its payload.
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        subject: str = payload.get("sub")
-        if subject is None:
-            raise credentials_exception
-        if not subject.startswith("client:"):
-            raise credentials_exception
-        client_id = subject.split("client:", 1)[1]
-        token_data = TokenData(subject=client_id)
-    except JWTError:
-        raise credentials_exception
-    site = get_site(mdb, client_id=token_data.subject)
+    except ExpiredSignatureError as e:
+        logging.exception(e)
+        raise expired_token_exception
+    except JWTClaimsError as e:
+        logging.exception(e)
+        raise invalid_claims_exception
+    except (JWTError, AttributeError) as e:
+        logging.exception(e)
+        raise invalid_token_exception
+
+    # Extract the prefix and the username from the subject.
+    subject: Optional[str] = payload.get("sub", None)
+    if isinstance(subject, str):
+        if subject.startswith("client:"):
+            subject_prefix = "client:"
+        else:
+            logging.warning("The subject contains an invalid prefix.")
+            raise invalid_subject_exception
+        client_id = subject.removeprefix(subject_prefix)
+        if client_id == "":
+            logging.warning("The subject contains nothing after the prefix.")
+            raise invalid_subject_exception
+    else:
+        logging.warning("The subject is not a string.")
+        raise invalid_subject_exception
+    token_data = TokenData(subject=client_id)
+
+    # Get the associated site.
+    site = get_site(mdb, client_id=client_id)
     if site is None:
-        raise credentials_exception
+        logging.warning(
+            f"Failed to resolve token subject '{token_data.subject}' to a site."
+        )
+        raise invalid_subject_exception
     return site
 
 


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I made it so the error messages the Runtime API sends to HTTP clients that are trying to use an inadequate site client token are more specific and actionable.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

My original goal was to make it so the minter endpoint (auth error message) tells users that they must be logged in as a site client, not a regular user. These changes accomplish that and more.

<img width="650" height="273" alt="image" src="https://github.com/user-attachments/assets/631221f3-93ad-4706-a5d6-fc6a21f6c8a4" />

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1347

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [x] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by trying to mint an ID while logged in as a regular user, and confirming that I saw an error message that says to log in as a site client. Then, I logged in as a site client and confirmed I could mint an ID.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
