### PR TITLE
Do not raise Failure exception when study_set does not contain single item

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -644,7 +644,9 @@ def add_public_image_urls(
     client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
 
     if database.study_set is None or len(database.study_set) == 0:
-        context.log.info("No studies in nmdc.Database; skipping public image URL addition.")
+        context.log.info(
+            "No studies in nmdc.Database; skipping public image URL addition."
+        )
         return database
 
     if len(database.study_set) > 1:


### PR DESCRIPTION
On this branch, I modified the logic of the `add_public_image_urls` to not raise a `Failure` exception when it is passed an `nmdc:Database` doesn't have exactly one item in `study_set`.

### Details

The following cases are now handled:

1. If `study_set` is not present or is empty, this is an expected scenario. This can happen if the submission data is being attached to an existing `nmdc:Study`. The general philosophy in this case is to only add samples to the existing study without modifying the study details. Therefore we just issue an `INFO` message to the logs and return the unmodified `nmdc:Database`.
2. If `study_set` contains exactly 1 item, this means we are translating the submission into a new study. In this case, we proceed with attaching the images to that one study.
3. If `study_set` contains more than 1 item, we've encountered an unusual situation. This should never happen given the way the Dagster jobs are currently set up. In this case, we issue a `WARNING` message to the logs and attach the images to the first study in the set.

### Related issue(s)

Fixes #1358 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [ ] I tested these changes (explain below)
- [x] I did not test these changes

I will test in dev.

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
