### PR TITLE
Translate publication DOIs into `Study.associated_dois`

### DIFF
--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -468,48 +468,42 @@ class SubmissionPortalTranslator(Translator):
         return value
 
     def _get_study_dois(self, metadata_submission) -> Union[List[nmdc.Doi], None]:
-        """Collect and format DOIs from submission portal schema in nmdc format DOIs
+        """Collect and translate DOI info from submission into nmdc-schema DOI instances
 
         If there were no DOIs, None is returned.
 
         :param metadata_submission: submission portal entry
         :return: list of nmdc.DOI objects
         """
-        data_dois = self._get_from(metadata_submission, ["studyForm", "dataDois"])
-        award_dois = self._get_from(
-            metadata_submission, ["multiOmicsForm", "awardDois"]
-        )
-        if data_dois and len(data_dois) > 0:
-            updated_data_dois = [
-                nmdc.Doi(
-                    doi_category="dataset_doi",
-                    doi_provider=doi["provider"],
-                    doi_value=self._ensure_curie(doi["value"], default_prefix="doi"),
-                    type="nmdc:Doi",
+
+        # Tuples of (doi_category, field) where doi_category is the value to use for the
+        # `doi_category` slot in the nmdc:Doi object and field is the list of nested fields to
+        # extract the DOI information from in the submission portal entry.
+        doi_configs = [
+            ("dataset_doi", ["studyForm", "dataDois"]),
+            ("award_doi", ["multiOmicsForm", "awardDois"]),
+            ("publication_doi", ["studyForm", "publicationDois"]),
+        ]
+
+        study_dois = []
+        for category, field in doi_configs:
+            raw_dois = self._get_from(metadata_submission, field)
+            if raw_dois:
+                study_dois.extend(
+                    [
+                        nmdc.Doi(
+                            doi_category=category,
+                            doi_provider=doi["provider"],
+                            doi_value=self._ensure_curie(
+                                doi["value"], default_prefix="doi"
+                            ),
+                            type="nmdc:Doi",
+                        )
+                        for doi in raw_dois
+                    ]
                 )
-                for doi in data_dois
-            ]
-        else:
-            updated_data_dois = []
 
-        if award_dois and len(award_dois) > 0:
-            updated_award_dois = [
-                nmdc.Doi(
-                    doi_category="award_doi",
-                    doi_provider=doi["provider"],
-                    doi_value=self._ensure_curie(doi["value"], default_prefix="doi"),
-                    type="nmdc:Doi",
-                )
-                for doi in award_dois
-            ]
-        else:
-            updated_award_dois = []
-
-        return_val = updated_data_dois + updated_award_dois
-        if len(return_val) == 0:
-            return_val = None
-
-        return return_val
+        return study_dois if study_dois else None
 
     def _get_data_objects_from_fields(
         self,

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -86,39 +86,58 @@ def test_get_study_dois():
     dois = translator._get_study_dois(
         {
             "studyForm": {
-                "dataDois": 
-                    [
-                        {
+                "dataDois": [
+                    {
                         "provider": "emsl",
-                        "value" : "10.12345/6789",
-                        },
-                    ],
+                        "value": "10.12345/6789",
+                    },
+                ],
+                "publicationDois": [
+                    {
+                        "provider": None,
+                        "value": "10.54321/9876",
+                    },
+                    {
+                        "provider": "zenodo",
+                        "value": "10.99999/abcd",
+                    }
+                ],
             },
             "multiOmicsForm": {
-                "awardDois":
-                    [
-                        {
+                "awardDois": [
+                    {
                         "provider": "jgi",
-                        "value" : "doi:10.11121314/15161718",
-                        },
-                    ]
-            }
+                        "value": "doi:10.11121314/15161718",
+                    },
+                ]
+            },
         }
     )
     assert dois is not None
-    assert len(dois) == 2
+    assert len(dois) == 4
+
     assert dois[0].doi_value == "doi:10.12345/6789"
     assert dois[0].doi_provider == DoiProviderEnum("emsl")
     assert dois[0].type == "nmdc:Doi"
     assert dois[0].doi_category == DoiCategoryEnum("dataset_doi")
 
     assert dois[1].doi_value == "doi:10.11121314/15161718"
-    assert dois[1].doi_provider == DoiProviderEnum('jgi')
+    assert dois[1].doi_provider == DoiProviderEnum("jgi")
     assert dois[1].type == "nmdc:Doi"
     assert dois[1].doi_category == DoiCategoryEnum("award_doi")
 
+    assert dois[2].doi_value == "doi:10.54321/9876"
+    assert dois[2].doi_provider is None
+    assert dois[2].type == "nmdc:Doi"
+    assert dois[2].doi_category == DoiCategoryEnum("publication_doi")
+
+    assert dois[3].doi_value == "doi:10.99999/abcd"
+    assert dois[3].doi_provider == DoiProviderEnum("zenodo")
+    assert dois[3].type == "nmdc:Doi"
+    assert dois[3].doi_category == DoiCategoryEnum("publication_doi")
+
     empty_doi = translator._get_study_dois({})
-    assert empty_doi == None
+    assert empty_doi is None
 
 
 def test_get_has_credit_associations():
@@ -213,7 +232,7 @@ def test_get_quantity_value_with_storage_units():
                 "tag": "storage_units",
                 "value": "Cel",
             }
-        ]
+        ],
     )
     qv = translator._get_quantity_value(-80, single_unit_slot)
     assert qv is not None
@@ -229,7 +248,7 @@ def test_get_quantity_value_with_storage_units():
                 "tag": "storage_units",
                 "value": "g|mg|kg",
             }
-        ]
+        ],
     )
     qv = translator._get_quantity_value("0.5 kg", multi_unit_slot)
     assert qv is not None
@@ -470,7 +489,12 @@ def test_instruments(test_minter):
 
 @pytest.mark.parametrize(
     "data_file_base",
-    ["plant_air_jgi", "nucleotide_sequencing_mapping", "sequencing_data", "soil_sample_link"],
+    [
+        "plant_air_jgi",
+        "nucleotide_sequencing_mapping",
+        "sequencing_data",
+        "soil_sample_link",
+    ],
 )
 def test_get_database(test_minter, monkeypatch, data_file_base):
     # OmicsProcess objects have an add_date and a mod_date slot that are populated with the
@@ -536,9 +560,7 @@ def test_parse_sample_link():
 
 def test_set_study_images():
     study = Study(
-        id="nmdc:study-00-00000000",
-        type="nmdc:Study",
-        study_category="research_study"
+        id="nmdc:study-00-00000000", type="nmdc:Study", study_category="research_study"
     )
 
     SubmissionPortalTranslator.set_study_images(
@@ -548,10 +570,13 @@ def test_set_study_images():
         study_images_url=[
             "http://www.example.org/study_image1.jpg",
             "http://www.example.org/study_image2.jpg",
-        ]
+        ],
     )
 
-    assert study.principal_investigator.profile_image_url == "http://www.example.org/pi_image.jpg"
+    assert (
+        study.principal_investigator.profile_image_url
+        == "http://www.example.org/pi_image.jpg"
+    )
     assert study.study_image is not None
     assert len(study.study_image) == 3
     assert study.study_image[0].url == "http://www.example.org/primary_study_image.jpg"


### PR DESCRIPTION
On this branch, I added the new `publicationDois` field to the set of fields processed when populating `Study.associated_dois`.

### Details

The new `publicationDois` field was added to submissions in https://github.com/microbiomedata/nmdc-server/pull/2011. Previously the `SubmissionPortalTranslator` handled data and award DOIs. These changes add publication DOIs to that list. Since each set from the submission data is processed in essentially the same way (only the `doi_category` changes), I refactored the code to DRY it up a bit.

### Related issue(s)

https://github.com/microbiomedata/nmdc-server/issues/2007

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by expanding an existing test for the `_get_study_dois` method.

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

This is not publicly documented functionality. I did update the docstring of `_get_study_dois` to be a little more accurate.

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
