### PR TITLE
Upgrade nmdc-schema to 11.17.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # We use `nmdc-schema` to interpret data residing in—and validate data
     # destined for—the NMDC database (i.e. the MongoDB database named `nmdc`).
     # Docs: https://microbiomedata.github.io/nmdc-schema/
-    "nmdc-schema==11.17.0",
+    "nmdc-schema==11.17.1",
     "pandas",
     "passlib[bcrypt]",
     "pymongo",

--- a/uv.lock
+++ b/uv.lock
@@ -3011,7 +3011,7 @@ requires-dist = [
     { name = "linkml" },
     { name = "linkml-runtime" },
     { name = "lxml" },
-    { name = "nmdc-schema", specifier = "==11.17.0" },
+    { name = "nmdc-schema", specifier = "==11.17.1" },
     { name = "ontology-loader", specifier = "==0.2.2" },
     { name = "pandas" },
     { name = "passlib", extras = ["bcrypt"] },
@@ -3057,7 +3057,7 @@ docs = [
 
 [[package]]
 name = "nmdc-schema"
-version = "11.17.0"
+version = "11.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3074,9 +3074,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/ca/6c6ff982f6755c25ec2b56d49c5525939f4423f6407746e435734f1ec014/nmdc_schema-11.17.0.tar.gz", hash = "sha256:cf8d82feb9202c2669c1fd07c1cf8ba653615f445a856c2f35ec508cf248d774", size = 714495, upload-time = "2026-03-11T21:48:05.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/fe/4a091c146cdb6e4af08c60bc7ff8161c33d8d032fed7d45d0a15151b80fe/nmdc_schema-11.17.1.tar.gz", hash = "sha256:8ca454a759809d5dcd15b1463beb003d8284dc95a58b98535daf8dad917fb33f", size = 714562, upload-time = "2026-03-23T17:25:06.144Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/73/d6b9995900fa32a578dca071a18a7dced5fabb25b0d66beae72ec0684280/nmdc_schema-11.17.0-py3-none-any.whl", hash = "sha256:cff858c70c30116dd71c4a6d67b724bb498d64cc7be5da4219b941f4e22e31ab", size = 786960, upload-time = "2026-03-11T21:48:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/58/ad5bb97836ba663c2a127af6f91af1b40560c2b6029a8d99890f188c1c95/nmdc_schema-11.17.1-py3-none-any.whl", hash = "sha256:45980f6b414c31f3e55b9202852709f7030c03bb5ce85cd287eed2dba344c5b4", size = 786986, upload-time = "2026-03-23T17:25:04.204Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
On this branch, I upgraded `nmdc-schema` to version 11.17.1.

### Details

The reason for having a 11.17.1 release was primarily about dependency resolution that affected `nmdc-submission-schema`. But the 11.17.1 release also swept in one purely additive schema change (https://github.com/microbiomedata/nmdc-schema/pull/2879). So just to keep everything consistent I'm doing the upgrade here even though it shouldn't affect anything in `nmdc-runtime`.

### Related issue(s)

N/A

### Related subsystem(s)


- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other: dependencies

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running existing tests.

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other: No doc impact

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
