### PR TITLE
Implement Dagster graph that displays Dagster repository version

### DIFF
--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -18,6 +18,7 @@ from nmdc_runtime.site.ops import (
     list_operations,
     filter_ops_done_object_puts,
     hello,
+    show_version_info_op,
     mongo_stats,
     run_script_to_update_insdc_biosample_identifiers,
     submit_metadata_to_db,
@@ -80,6 +81,11 @@ def create_objects_from_site_object_puts():
 @graph
 def hello_graph():
     return hello()
+
+
+@graph
+def show_version_info_graph():
+    return show_version_info_op()
 
 
 @graph

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 from collections import defaultdict
 from datetime import datetime, timezone
+from importlib.metadata import version
 from io import BytesIO
 from pprint import pformat
 from toolz.dicttoolz import keyfilter
@@ -127,6 +128,14 @@ def hello(context):
     out = f"Hello, {name}!"
     context.log.info(out)
     return out
+
+
+@op
+def show_version_info_op(context):
+    """Logs and returns the Dagster repository version (i.e. the "nmdc_runtime" package version)."""
+    dagster_repository_version = version("nmdc_runtime")
+    context.log.info(f"Dagster repository version: {dagster_repository_version}")
+    return dagster_repository_version
 
 
 @op

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -34,6 +34,7 @@ from nmdc_runtime.site.graphs import (
     apply_changesheet,
     apply_metadata_in,
     hello_graph,
+    show_version_info_graph,
     translate_neon_api_soil_metadata_to_nmdc_schema_database,
     translate_neon_api_benthic_metadata_to_nmdc_schema_database,
     translate_neon_api_surface_water_metadata_to_nmdc_schema_database,
@@ -421,6 +422,10 @@ def on_run_fail(context: RunStatusSensorContext):
 def repo():
     graph_jobs = [
         hello_graph.to_job(name="hello_job"),
+        show_version_info_graph.to_job(
+            name="show_version_info",
+            description="Shows version information",
+        ),
         ensure_jobs.to_job(**preset_normal),
         apply_metadata_in.to_job(**preset_normal),
         export_study_biosamples_metadata.to_job(**preset_normal),

--- a/tests/test_graphs/test_show_version_info.py
+++ b/tests/test_graphs/test_show_version_info.py
@@ -1,0 +1,16 @@
+from importlib.metadata import version
+
+from nmdc_runtime.site.graphs import show_version_info_graph
+from nmdc_runtime.site.repository import repo
+
+
+def test_show_version_info():
+    job = show_version_info_graph.to_job(name="show_version_info")
+    result = job.execute_in_process()
+
+    assert result.success
+    assert result.output_value("result") == version("nmdc_runtime")
+
+
+def test_show_version_info_is_in_repo():
+    assert repo.get_job("show_version_info").name == "show_version_info"


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I implemented a tiny Dagster graph that Dagster web UI users can run spontaneously, in order to check which version of the `nmdc-runtime` codebase the current Dagster "repository" (i.e. definitions of graphs, ops, etc.) is based upon.

Here's what it shows when run locally:

<img width="1005" height="1028" alt="image" src="https://github.com/user-attachments/assets/3ff13b15-ce64-4d44-b87e-49d3c4d30727" />

When run in dev, we'll see something more specific, like this:

<img width="520" height="163" alt="image" src="https://github.com/user-attachments/assets/fca92e2a-9c0f-4c3c-b617-9d4ca819f40d" />

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

The graph prints the current version number of the `nmdc_runtime` Python package that contains the Dagster "repository" (i.e. the definitions of the various Dagster graphs, ops, etc.). Dagster web UI users will be able to use this to determine whether code that they recently merged into `nmdc-runtime/main` has "made its way into" Dagster yet (without having to check Argo CD).

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1420 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by implementing a couple new automated tests that exercise the changes and ensuring those tests pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
