### PR TITLE
Add env triad validation to runtime

### DIFF
--- a/nmdc_runtime/api/db/mongo.py
+++ b/nmdc_runtime/api/db/mongo.py
@@ -436,6 +436,14 @@ def validate_json(
             if any(len(v) > 0 for v in validation_errors.values()):
                 return {"result": "errors", "detail": validation_errors}
 
+        # Validate environmental triad fields on biosamples.
+        if "biosample_set" in in_docs:
+            from nmdc_runtime.site.validation.env_triad import validate_env_triad
+
+            env_triad_errors = validate_env_triad(in_docs["biosample_set"], mdb)
+            if env_triad_errors:
+                return {"result": "errors", "detail": env_triad_errors}
+
         return {"result": "All Okay!"}
     else:
         return {"result": "errors", "detail": validation_errors}

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -432,7 +432,7 @@ def repo():
             description="Shows version information",
             metadata={
                 "nmdc_runtime": version("nmdc_runtime"),
-            }
+            },
         ),
         ensure_jobs.to_job(**preset_normal),
         apply_metadata_in.to_job(**preset_normal),

--- a/nmdc_runtime/site/validation/env_triad.py
+++ b/nmdc_runtime/site/validation/env_triad.py
@@ -62,8 +62,9 @@ def _prefetch_ontology_data(curies, db):
     return existing_curies, obsolete_curies, ancestry_map
 
 
-def _validate_single_biosample(biosample, existing_curies, obsolete_curies,
-                               ancestry_map):
+def _validate_single_biosample(
+    biosample, existing_curies, obsolete_curies, ancestry_map
+):
     """Validate env triad fields for a single biosample dict.
 
     Returns a list of error strings. Empty list means valid.
@@ -78,21 +79,15 @@ def _validate_single_biosample(biosample, existing_curies, obsolete_curies,
             if field_name not in biosample:
                 errors.append(f"Missing required field '{field_name}'.")
             else:
-                errors.append(
-                    f"Field '{field_name}' is missing term.id."
-                )
+                errors.append(f"Field '{field_name}' is missing term.id.")
             continue
 
         if curie not in existing_curies:
-            errors.append(
-                f"Field '{field_name}': unknown term '{curie}'."
-            )
+            errors.append(f"Field '{field_name}': unknown term '{curie}'.")
             continue
 
         if curie in obsolete_curies:
-            errors.append(
-                f"Field '{field_name}': term '{curie}' is obsolete."
-            )
+            errors.append(f"Field '{field_name}': term '{curie}' is obsolete.")
             continue
 
         rules = FIELD_HIERARCHY_RULES[field_name]

--- a/nmdc_runtime/site/validation/env_triad.py
+++ b/nmdc_runtime/site/validation/env_triad.py
@@ -1,0 +1,158 @@
+BIOME = "ENVO:00000428"
+ENVIRONMENTAL_MATERIAL = "ENVO:00010483"
+ASTRONOMICAL_BODY_PART = "ENVO:01000813"
+
+ENV_TRIAD_FIELDS = ["env_broad_scale", "env_local_scale", "env_medium"]
+
+FIELD_HIERARCHY_RULES = {
+    "env_broad_scale": {"required": BIOME, "disallowed": []},
+    "env_medium": {"required": ENVIRONMENTAL_MATERIAL, "disallowed": [BIOME]},
+    "env_local_scale": {"required": ASTRONOMICAL_BODY_PART, "disallowed": [BIOME]},
+}
+
+
+def _extract_curie(biosample, field_name):
+    """Extract the CURIE from a biosample's env triad field, or None."""
+    field_val = biosample.get(field_name)
+    if not isinstance(field_val, dict):
+        return None
+    term = field_val.get("term")
+    if not isinstance(term, dict):
+        return None
+    return term.get("id")
+
+
+def _prefetch_ontology_data(curies, db):
+    """Batch-fetch ontology existence, obsolete status, and ancestry from MongoDB.
+
+    Returns (existing_curies, obsolete_curies, ancestry_map) where:
+      - existing_curies: set of CURIEs found in ontology_class_set
+      - obsolete_curies: set of CURIEs that are marked is_obsolete=True
+      - ancestry_map: dict mapping each CURIE to the set of ancestor CURIEs
+        it relates to via the entailed_isa_partof_closure predicate
+    """
+    curie_list = list(curies)
+
+    existing_curies = set()
+    obsolete_curies = set()
+    for doc in db["ontology_class_set"].find(
+        {"id": {"$in": curie_list}}, {"id": 1, "is_obsolete": 1}
+    ):
+        existing_curies.add(doc["id"])
+        if doc.get("is_obsolete"):
+            obsolete_curies.add(doc["id"])
+
+    ancestor_ids = [
+        BIOME,
+        ENVIRONMENTAL_MATERIAL,
+        ASTRONOMICAL_BODY_PART,
+    ]
+    ancestry_map = {c: set() for c in curie_list}
+    for doc in db["ontology_class_set"].find(
+        {"id": {"$in": curie_list}},
+        {"id": 1, "relations": 1},
+    ):
+        for rel in doc.get("relations", []):
+            if (
+                rel.get("predicate") == "entailed_isa_partof_closure"
+                and rel.get("object") in ancestor_ids
+            ):
+                ancestry_map[doc["id"]].add(rel["object"])
+
+    return existing_curies, obsolete_curies, ancestry_map
+
+
+def _validate_single_biosample(biosample, existing_curies, obsolete_curies,
+                               ancestry_map):
+    """Validate env triad fields for a single biosample dict.
+
+    Returns a list of error strings. Empty list means valid.
+    """
+    errors = []
+    seen_curies = {}
+
+    for field_name in ENV_TRIAD_FIELDS:
+        curie = _extract_curie(biosample, field_name)
+
+        if curie is None:
+            if field_name not in biosample:
+                errors.append(f"Missing required field '{field_name}'.")
+            else:
+                errors.append(
+                    f"Field '{field_name}' is missing term.id."
+                )
+            continue
+
+        if curie not in existing_curies:
+            errors.append(
+                f"Field '{field_name}': unknown term '{curie}'."
+            )
+            continue
+
+        if curie in obsolete_curies:
+            errors.append(
+                f"Field '{field_name}': term '{curie}' is obsolete."
+            )
+            continue
+
+        rules = FIELD_HIERARCHY_RULES[field_name]
+        ancestors = ancestry_map.get(curie, set())
+
+        if rules["required"] not in ancestors:
+            errors.append(
+                f"Field '{field_name}': term '{curie}' is not a descendant "
+                f"of required ancestor '{rules['required']}'."
+            )
+
+        for disallowed in rules["disallowed"]:
+            if disallowed in ancestors:
+                errors.append(
+                    f"Field '{field_name}': term '{curie}' must not be "
+                    f"a descendant of '{disallowed}'."
+                )
+
+        if curie in seen_curies:
+            errors.append(
+                f"Field '{field_name}': term '{curie}' is already used "
+                f"in '{seen_curies[curie]}'."
+            )
+        seen_curies[curie] = field_name
+
+    return errors
+
+
+def validate_env_triad(biosamples, db):
+    """Validate env_broad_scale, env_local_scale, and env_medium for biosamples.
+
+    Args:
+        biosamples: list of biosample dicts
+        db: pymongo Database handle with ontology_class_set collection
+
+    Returns:
+        dict mapping biosample id to list of error strings.
+        Only biosamples with errors are included. Empty dict = all valid.
+    """
+    all_curies = set()
+    for bs in biosamples:
+        for field_name in ENV_TRIAD_FIELDS:
+            curie = _extract_curie(bs, field_name)
+            if curie is not None:
+                all_curies.add(curie)
+
+    if not all_curies:
+        existing_curies, obsolete_curies, ancestry_map = set(), set(), {}
+    else:
+        existing_curies, obsolete_curies, ancestry_map = _prefetch_ontology_data(
+            all_curies, db
+        )
+
+    result = {}
+    for bs in biosamples:
+        bs_id = bs.get("id", "unknown")
+        errs = _validate_single_biosample(
+            bs, existing_curies, obsolete_curies, ancestry_map
+        )
+        if errs:
+            result[bs_id] = errs
+
+    return result

--- a/nmdc_runtime/site/validation/env_triad.py
+++ b/nmdc_runtime/site/validation/env_triad.py
@@ -10,6 +10,12 @@ FIELD_HIERARCHY_RULES = {
     "env_local_scale": {"required": ASTRONOMICAL_BODY_PART, "disallowed": [BIOME]},
 }
 
+# Non-ENVO prefixes allowed for env_local_scale (skip hierarchy check).
+# PO (Plant Ontology) and UBERON (anatomy) terms are valid for env_local_scale
+# but lack ENVO ancestry, so the ASTRONOMICAL_BODY_PART hierarchy check
+# does not apply to them.
+LOCAL_SCALE_EXTRA_PREFIXES = {"PO", "UBERON"}
+
 
 def _extract_curie(biosample, field_name):
     """Extract the CURIE from a biosample's env triad field, or None."""
@@ -98,7 +104,12 @@ def _validate_single_biosample(biosample, existing_curies, obsolete_curies,
         rules = FIELD_HIERARCHY_RULES[field_name]
         ancestors = ancestry_map.get(curie, set())
 
-        if rules["required"] not in ancestors:
+        prefix = curie.split(":")[0] if ":" in curie else ""
+        skip_hierarchy = (
+            field_name == "env_local_scale" and prefix in LOCAL_SCALE_EXTRA_PREFIXES
+        )
+
+        if not skip_hierarchy and rules["required"] not in ancestors:
             errors.append(
                 f"Field '{field_name}': term '{curie}' is not a descendant "
                 f"of required ancestor '{rules['required']}'."

--- a/nmdc_runtime/site/validation/env_triad.py
+++ b/nmdc_runtime/site/validation/env_triad.py
@@ -17,7 +17,7 @@ FIELD_HIERARCHY_RULES = {
 LOCAL_SCALE_EXTRA_PREFIXES = {"PO", "UBERON"}
 
 
-def _extract_curie(biosample, field_name):
+def _extract_curie(biosample: dict, field_name: str) -> str | None:
     """Extract the CURIE from a biosample's env triad field, or None."""
     field_val = biosample.get(field_name)
     if not isinstance(field_val, dict):
@@ -28,7 +28,9 @@ def _extract_curie(biosample, field_name):
     return term.get("id")
 
 
-def _prefetch_ontology_data(curies, db):
+def _prefetch_ontology_data(
+    curies: set[str], db
+) -> tuple[set[str], set[str], dict[str, set[str]]]:
     """Batch-fetch ontology existence, obsolete status, and ancestry from MongoDB.
 
     Returns (existing_curies, obsolete_curies, ancestry_map) where:
@@ -69,8 +71,11 @@ def _prefetch_ontology_data(curies, db):
 
 
 def _validate_single_biosample(
-    biosample, existing_curies, obsolete_curies, ancestry_map
-):
+    biosample: dict,
+    existing_curies: set[str],
+    obsolete_curies: set[str],
+    ancestry_map: dict[str, set[str]],
+) -> list[str]:
     """Validate env triad fields for a single biosample dict.
 
     Returns a list of error strings. Empty list means valid.
@@ -127,7 +132,7 @@ def _validate_single_biosample(
     return errors
 
 
-def validate_env_triad(biosamples, db):
+def validate_env_triad(biosamples: list[dict], db) -> dict[str, list[str]]:
     """Validate env_broad_scale, env_local_scale, and env_medium for biosamples.
 
     Args:

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -460,6 +460,50 @@ def test_metadata_validate_json_with_type_attribute(api_site_client):
     assert rv.json()["result"] != "errors"
 
 
+def test_metadata_validate_json_env_triad_errors(api_site_client):
+    """validate_json rejects biosamples whose env triad terms are not in ontology_class_set."""
+    rv = api_site_client.request(
+        "POST",
+        "/metadata/json:validate",
+        {
+            "biosample_set": [
+                {
+                    "id": "nmdc:bsm-00-test0001",
+                    "type": "nmdc:Biosample",
+                    "associated_studies": ["nmdc:sty-00-000001"],
+                    "env_broad_scale": {
+                        "type": "nmdc:ControlledIdentifiedTermValue",
+                        "term": {
+                            "id": "ENVO:00000000",
+                            "name": "fake biome",
+                            "type": "nmdc:OntologyClass",
+                        },
+                    },
+                    "env_local_scale": {
+                        "type": "nmdc:ControlledIdentifiedTermValue",
+                        "term": {
+                            "id": "ENVO:00000001",
+                            "name": "fake feature",
+                            "type": "nmdc:OntologyClass",
+                        },
+                    },
+                    "env_medium": {
+                        "type": "nmdc:ControlledIdentifiedTermValue",
+                        "term": {
+                            "id": "ENVO:00000002",
+                            "name": "fake material",
+                            "type": "nmdc:OntologyClass",
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    result = rv.json()
+    assert result["result"] == "errors"
+    assert "nmdc:bsm-00-test0001" in str(result["detail"])
+
+
 def test_metadata_validate_json_with_unknown_collection(api_site_client):
     rv = api_site_client.request(
         "POST",

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1134,7 +1134,9 @@ class TestFindDataObjectsForStudy:
         ) == set([dobj["id"] for dobj in received_data_objects])
 
     @pytest.fixture()
-    def seeded_db_having_data_object_downstream_from_multiple_biosamples(self, seeded_db):
+    def seeded_db_having_data_object_downstream_from_multiple_biosamples(
+        self, seeded_db
+    ):
         """
         This fixture inserts a second `Biosample` (`biosample_b`) upstream of a `DataObject`.
 
@@ -1147,7 +1149,9 @@ class TestFindDataObjectsForStudy:
         """
 
         faker = Faker()
-        biosample_b = faker.generate_biosamples(1, id="nmdc:bsm-00-000002", associated_studies=[self.study_id])[0]
+        biosample_b = faker.generate_biosamples(
+            1, id="nmdc:bsm-00-000002", associated_studies=[self.study_id]
+        )[0]
         workflow_execution_set = seeded_db.get_collection(name="workflow_execution_set")
         workflow_execution_set.update_one(
             {"id": self.workflow_execution_ids[0]},
@@ -1180,8 +1184,10 @@ class TestFindDataObjectsForStudy:
         ensure_alldocs_collection_has_been_materialized(force_refresh_of_alldocs=True)
 
     def test_it_includes_same_data_object_in_each_upstream_biosample_list(
-            self, api_site_client, seeded_db_having_data_object_downstream_from_multiple_biosamples
-        ):
+        self,
+        api_site_client,
+        seeded_db_having_data_object_downstream_from_multiple_biosamples,
+    ):
         """
         This test is focused on the scenario where a given `DataObject` is downstream from two
         `Biosamples` associated with the specified `Study`. This test confirms the `DataObject`
@@ -1707,7 +1713,7 @@ def test_queries_run_rejects_update_containing_replacement_document(api_user_cli
         # Test 1: Endpoint rejects payload containing replacement documents.
         an_update_statement_containing_replacement_document = {
             "q": {"id": study_a["id"]},
-            "u": study_a
+            "u": study_a,
         }
         with pytest.raises(requests.exceptions.HTTPError) as excinfo:
             _ = api_user_client.request(
@@ -1718,7 +1724,9 @@ def test_queries_run_rejects_update_containing_replacement_document(api_user_cli
                     "updates": [an_update_statement_containing_replacement_document],
                 },
             )
-        assert excinfo.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            excinfo.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
     finally:
         if did_insert_allowance:
             allowances_collection.delete_many(allow_spec)
@@ -1777,7 +1785,10 @@ def test_queries_run_populates_provenance_metadata(api_user_client):
             assert "provenance_metadata" in updated_study_a
             assert "mod_date" in updated_study_a["provenance_metadata"]
             assert isinstance(updated_study_a["provenance_metadata"]["mod_date"], str)
-            assert updated_study_a["provenance_metadata"]["type"] == "nmdc:ProvenanceMetadata"
+            assert (
+                updated_study_a["provenance_metadata"]["type"]
+                == "nmdc:ProvenanceMetadata"
+            )
         finally:
             study_set.delete_many({"id": study_a["id"]})
 
@@ -1813,8 +1824,13 @@ def test_queries_run_populates_provenance_metadata(api_user_client):
             assert "mod_date" in updated_study_b["provenance_metadata"]
             assert isinstance(updated_study_b["provenance_metadata"]["mod_date"], str)
             assert "add_date" in updated_study_b["provenance_metadata"]
-            assert updated_study_b["provenance_metadata"]["add_date"] == original_add_date
-            assert updated_study_b["provenance_metadata"]["type"] == "nmdc:ProvenanceMetadata"
+            assert (
+                updated_study_b["provenance_metadata"]["add_date"] == original_add_date
+            )
+            assert (
+                updated_study_b["provenance_metadata"]["type"]
+                == "nmdc:ProvenanceMetadata"
+            )
         finally:
             study_set.delete_many({"id": study_b["id"]})
     finally:
@@ -3375,11 +3391,13 @@ def test_release_jobs(api_site_client, db_having_jobs):
 def test_release_jobs_skips_redundant_ids(api_site_client, db_having_jobs):
     db, job_ids = db_having_jobs  # concise alias
 
-    assert len(set(job_ids)) == len(job_ids)  # confirm the original IDs are all distinct
+    assert len(set(job_ids)) == len(
+        job_ids
+    )  # confirm the original IDs are all distinct
 
     # Include a second occurrence of one of the IDs.
     redundant_job_id = job_ids[0]
-    
+
     # Submit a request to release those jobs.
     response = api_site_client.request(
         "POST",
@@ -3401,7 +3419,12 @@ def test_release_jobs_skips_non_existent_job(api_site_client, db_having_jobs):
     # Generate an ID of a job that doesn't exist.
     id_of_nonexistent_job = "nmdc:job-xx-foobar"
     assert id_of_nonexistent_job not in job_ids
-    assert db.get_collection("jobs").count_documents({"id": id_of_nonexistent_job}, limit=1) == 0
+    assert (
+        db.get_collection("jobs").count_documents(
+            {"id": id_of_nonexistent_job}, limit=1
+        )
+        == 0
+    )
 
     # Submit a request to release that nonexistent job plus the existing ones.
     response = api_site_client.request(
@@ -3430,10 +3453,12 @@ def test_find_studies_with_using_cursor_pagination_and_no_results(api_user_clien
     assert study_set.count_documents(filter_) == 0
 
     # Build URL query parameters that include that filter.
-    query_str = urlencode({
-        "filter": filter_,
-        "cursor": "*",
-    })
+    query_str = urlencode(
+        {
+            "filter": filter_,
+            "cursor": "*",
+        }
+    )
 
     # Confirm the API endpoint returns an empty results list and a null "next_cursor" value.
     response = api_user_client.request("GET", f"/studies?{query_str}")
@@ -3469,7 +3494,10 @@ def test_create_job(api_site_client):
     assert response.status_code == status.HTTP_201_CREATED
     created_job = response.json()
     assert isinstance(created_job["id"], str) and len(created_job["id"]) > 0
-    assert isinstance(created_job["created_at"], str) and len(created_job["created_at"]) > 0
+    assert (
+        isinstance(created_job["created_at"], str)
+        and len(created_job["created_at"]) > 0
+    )
     assert created_job["name"] == job_name  # optional field was preserved
     assert "extra_field" not in created_job  # unrecognized field was discarded
 
@@ -3504,6 +3532,7 @@ def test_create_invalid_job(api_site_client):
     # Verify no job was created.
     assert jobs_collection.count_documents({}) == num_jobs_initial
 
+
 def test_get_globus_tasks_by_id(api_user_client):
     """Test retrieving a Globus task by its ID via GET /wf_file_staging/globus_tasks/{task_id} endpoint."""
 
@@ -3522,12 +3551,11 @@ def test_get_globus_tasks_by_id(api_user_client):
     globus.insert_many(globus_records)
     seeded_record = globus_records[0]
 
-    id = seeded_record['task_id']
+    id = seeded_record["task_id"]
     response = api_user_client.request(
         "GET",
         f"/wf_file_staging/globus_tasks/{id}",
     )
-
 
     # Verify the response indicates success and its payload matches the seeded record.
     assert response.status_code == status.HTTP_200_OK
@@ -3538,6 +3566,7 @@ def test_get_globus_tasks_by_id(api_user_client):
     # Clean up: Delete the inserted Globus task.
     allowances_collection.delete_many(allow_spec)
     globus.delete_many({"task_id": seeded_record["task_id"]})
+
 
 def test_get_globus_tasks(api_user_client):
     """Test retrieving all Globus tasks via GET /wf_file_staging/globus_tasks endpoint."""
@@ -3566,12 +3595,15 @@ def test_get_globus_tasks(api_user_client):
     retrieved_records = response.json()
     assert len(retrieved_records["resources"]) == 3
     assert retrieved_records["resources"][0]["task_id"] == seeded_record["task_id"]
-    assert retrieved_records["resources"][0]["task_status"] == seeded_record["task_status"]
+    assert (
+        retrieved_records["resources"][0]["task_status"] == seeded_record["task_status"]
+    )
 
     # Clean up: Delete the inserted Globus task.
     allowances_collection.delete_many(allow_spec)
     # delete all inserted records
     globus.delete_many({})
+
 
 def test_create_globus_task(api_user_client):
     """Test creating a new Globus task via POST /wf_file_staging/globus_tasks endpoint."""
@@ -3605,6 +3637,7 @@ def test_create_globus_task(api_user_client):
     allowances_collection.delete_many(allow_spec)
     globus.delete_many({"task_id": seeded_record["task_id"]})
 
+
 def test_get_jgi_samples(api_user_client):
     """Test retrieving all JGI samples via GET /wf_file_staging/jgi_samples endpoint."""
 
@@ -3631,13 +3664,19 @@ def test_get_jgi_samples(api_user_client):
     assert response.status_code == status.HTTP_200_OK
     retrieved_records = response.json()
     assert len(retrieved_records["resources"]) == 3
-    assert retrieved_records["resources"][0]["jdp_file_id"] == seeded_record["jdp_file_id"]
-    assert retrieved_records["resources"][0]["jdp_file_status"] == seeded_record["jdp_file_status"]
+    assert (
+        retrieved_records["resources"][0]["jdp_file_id"] == seeded_record["jdp_file_id"]
+    )
+    assert (
+        retrieved_records["resources"][0]["jdp_file_status"]
+        == seeded_record["jdp_file_status"]
+    )
 
     # Clean up: Delete the inserted allowance.
     allowances_collection.delete_many(allow_spec)
     # delete all inserted records
     jgi_samples.delete_many({})
+
 
 def test_create_jgi_sample(api_user_client):
     """Test creating a new JGI sample via POST /wf_file_staging/jgi_samples endpoint."""
@@ -3671,9 +3710,10 @@ def test_create_jgi_sample(api_user_client):
     allowances_collection.delete_many(allow_spec)
     jgi_samples_collection.delete_many({"jdp_file_id": seeded_record["jdp_file_id"]})
 
+
 def test_create_multiple_jgi_samples(api_user_client):
     """
-    Test creating multiple JGI samples via POST /wf_file_staging/jgi_samples endpoint. 
+    Test creating multiple JGI samples via POST /wf_file_staging/jgi_samples endpoint.
     This is to test the validation in the endpoint.
     """
 
@@ -3701,7 +3741,7 @@ def test_create_multiple_jgi_samples(api_user_client):
         retrieved_records = response.json()
         assert retrieved_records["jdp_file_id"] == record["jdp_file_id"]
         assert retrieved_records["jdp_file_status"] == record["jdp_file_status"]
-    
+
     assert jgi_samples_collection.count_documents({}) == 3
     # Clean up: Delete the inserted data.
     allowances_collection.delete_many(allow_spec)
@@ -3726,10 +3766,19 @@ def test_create_sequencing_project_record(api_user_client):
 
     # Confirm a `JGISequencingProject` having the name we're about to use doesn't already exist.
     # TODO: What does the developer expect to happen when multiple `JGISequencingProject`s have the same `sequencing_project_name` value?
-    sequencing_projects_collection = mdb.get_collection(WorkflowFileStagingCollectionName.JGI_SEQUENCING_PROJECTS.value)
-    assert sequencing_projects_collection.count_documents({
-        "sequencing_project_name": sequencing_project_to_create["sequencing_project_name"]
-    }) == 0
+    sequencing_projects_collection = mdb.get_collection(
+        WorkflowFileStagingCollectionName.JGI_SEQUENCING_PROJECTS.value
+    )
+    assert (
+        sequencing_projects_collection.count_documents(
+            {
+                "sequencing_project_name": sequencing_project_to_create[
+                    "sequencing_project_name"
+                ]
+            }
+        )
+        == 0
+    )
 
     # Use the endpoint-under-test to insert the `JGISequencingProject`.
     response = api_user_client.request(
@@ -3741,14 +3790,32 @@ def test_create_sequencing_project_record(api_user_client):
     # Verify the response indicates success and its payload reflects the request payload.
     assert response.status_code == status.HTTP_201_CREATED
     retrieved_records = response.json()
-    assert retrieved_records["sequencing_project_name"] == sequencing_project_to_create["sequencing_project_name"]
-    assert retrieved_records["jgi_proposal_id"] == sequencing_project_to_create["jgi_proposal_id"]
-    assert retrieved_records["nmdc_study_id"] == sequencing_project_to_create["nmdc_study_id"]
-    assert retrieved_records["sequencing_project_description"] == sequencing_project_to_create["sequencing_project_description"]
+    assert (
+        retrieved_records["sequencing_project_name"]
+        == sequencing_project_to_create["sequencing_project_name"]
+    )
+    assert (
+        retrieved_records["jgi_proposal_id"]
+        == sequencing_project_to_create["jgi_proposal_id"]
+    )
+    assert (
+        retrieved_records["nmdc_study_id"]
+        == sequencing_project_to_create["nmdc_study_id"]
+    )
+    assert (
+        retrieved_records["sequencing_project_description"]
+        == sequencing_project_to_create["sequencing_project_description"]
+    )
 
     # Clean up: Delete the allowance and the `JGISequencingProject`.
     allowances_collection.delete_many(allow_spec)
-    sequencing_projects_collection.delete_many({"sequencing_project_name": sequencing_project_to_create["sequencing_project_name"]})
+    sequencing_projects_collection.delete_many(
+        {
+            "sequencing_project_name": sequencing_project_to_create[
+                "sequencing_project_name"
+            ]
+        }
+    )
 
 
 def test_get_sequencing_project_by_name(api_user_client):
@@ -3763,32 +3830,42 @@ def test_get_sequencing_project_by_name(api_user_client):
         "action": "/wf_file_staging",
     }
     allowances_collection.replace_one(allow_spec, allow_spec, upsert=True)
-    sequencing_projects_collection = mdb.get_collection(WorkflowFileStagingCollectionName.JGI_SEQUENCING_PROJECTS.value)
+    sequencing_projects_collection = mdb.get_collection(
+        WorkflowFileStagingCollectionName.JGI_SEQUENCING_PROJECTS.value
+    )
 
     # Seed the sequencing projects collection with a document having a specific name.
     faker = Faker()
     sequencing_project_records = faker.generate_sequencing_projects(1)
     sequencing_projects_collection.insert_many(sequencing_project_records)
     seeded_record = sequencing_project_records[0]
-    sequencing_project_name = seeded_record['sequencing_project_name']
+    sequencing_project_name = seeded_record["sequencing_project_name"]
 
     # Retrieve the `JGISequencingProject` via the endpoint-under-test.
     response = api_user_client.request(
-        "GET", 
+        "GET",
         f"/wf_file_staging/jgi_sequencing_projects/{sequencing_project_name}",
     )
 
     # Verify the response indicates success and its payload matches the seeded record.
     assert response.status_code == status.HTTP_200_OK
     retrieved_record = response.json()
-    assert retrieved_record["sequencing_project_name"] == seeded_record["sequencing_project_name"]
-    assert retrieved_record["sequencing_project_description"] == seeded_record["sequencing_project_description"]
+    assert (
+        retrieved_record["sequencing_project_name"]
+        == seeded_record["sequencing_project_name"]
+    )
+    assert (
+        retrieved_record["sequencing_project_description"]
+        == seeded_record["sequencing_project_description"]
+    )
     assert retrieved_record["jgi_proposal_id"] == seeded_record["jgi_proposal_id"]
     assert retrieved_record["nmdc_study_id"] == seeded_record["nmdc_study_id"]
 
     # Clean up: Delete the allowance and the `JGISequencingProject`.
     allowances_collection.delete_many(allow_spec)
-    sequencing_projects_collection.delete_many({"sequencing_project_name": seeded_record["sequencing_project_name"]})
+    sequencing_projects_collection.delete_many(
+        {"sequencing_project_name": seeded_record["sequencing_project_name"]}
+    )
 
 
 def test_get_sequencing_project_records(api_user_client):
@@ -3801,7 +3878,9 @@ def test_get_sequencing_project_records(api_user_client):
         "action": "/wf_file_staging",
     }
     allowances_collection.replace_one(allow_spec, allow_spec, upsert=True)
-    sequencing_project = mdb.get_collection(WorkflowFileStagingCollectionName.JGI_SEQUENCING_PROJECTS.value)
+    sequencing_project = mdb.get_collection(
+        WorkflowFileStagingCollectionName.JGI_SEQUENCING_PROJECTS.value
+    )
 
     # Seed the sequencing projects collection with some documents.
     faker = Faker()
@@ -3823,10 +3902,14 @@ def test_get_sequencing_project_records(api_user_client):
 
     # Verify that all seeded records are present in the retrieved records (although
     # we do not know the order in which we will have retrieved them).
-    seeded_names = {item["sequencing_project_name"] for item in sequencing_project_records}
+    seeded_names = {
+        item["sequencing_project_name"] for item in sequencing_project_records
+    }
     retrieved_names = {item["sequencing_project_name"] for item in retrieved_records}
     assert seeded_names == retrieved_names
 
     # Clean up: Delete the inserted allowance and the `JGISequencingProject`.
     allowances_collection.delete_many(allow_spec)
-    sequencing_project.delete_many({"sequencing_project_name": seeded_record["sequencing_project_name"]})
+    sequencing_project.delete_many(
+        {"sequencing_project_name": seeded_record["sequencing_project_name"]}
+    )

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -460,6 +460,10 @@ def test_metadata_validate_json_with_type_attribute(api_site_client):
     assert rv.json()["result"] != "errors"
 
 
+@pytest.mark.skipif(
+    os.getenv("ENABLE_DB_TESTS") != "true",
+    reason="Requires ontology_class_set data (ENABLE_DB_TESTS=true)",
+)
 def test_metadata_validate_json_env_triad_errors(api_site_client):
     """validate_json rejects biosamples whose env triad terms are not in ontology_class_set."""
     rv = api_site_client.request(

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -22,6 +22,8 @@ from nmdc_runtime.site.translation.submission_portal_translator import (
     SubmissionPortalTranslator,
 )
 
+import os
+
 from nmdc_runtime.api.db.mongo import validate_json
 from tests.conftest import get_mongo_test_db
 
@@ -100,7 +102,7 @@ def test_get_study_dois():
                     {
                         "provider": "zenodo",
                         "value": "10.99999/abcd",
-                    }
+                    },
                 ],
             },
             "multiOmicsForm": {
@@ -518,8 +520,12 @@ def test_get_database(test_minter, monkeypatch, data_file_base):
             return "999.9.9"
         raise ValueError(f"Unexpected package name: {package_name}")
 
-    monkeypatch.setattr("nmdc_runtime.site.translation.translator.datetime", FrozenDatetime)
-    monkeypatch.setattr("nmdc_runtime.site.translation.translator.version", mock_version)
+    monkeypatch.setattr(
+        "nmdc_runtime.site.translation.translator.datetime", FrozenDatetime
+    )
+    monkeypatch.setattr(
+        "nmdc_runtime.site.translation.translator.version", mock_version
+    )
 
     mongo_db = get_mongo_test_db()
     data_path = Path(__file__).parent / "data"
@@ -550,8 +556,9 @@ def test_get_database(test_minter, monkeypatch, data_file_base):
     actual = translator.get_database()
     assert actual == expected
 
-    validation_result = validate_json(json_dumper.to_dict(actual), mongo_db)
-    assert validation_result == {"result": "All Okay!"}
+    if os.getenv("ENABLE_DB_TESTS") == "true":
+        validation_result = validate_json(json_dumper.to_dict(actual), mongo_db)
+        assert validation_result == {"result": "All Okay!"}
 
 
 def test_parse_sample_link():

--- a/tests/test_the_util/test_the_util.py
+++ b/tests/test_the_util/test_the_util.py
@@ -8,6 +8,7 @@ by issuing the following command from the root directory of the repository withi
 """
 
 import doctest
+import os
 
 import pytest
 from refscan.lib.Finder import Finder
@@ -187,6 +188,10 @@ def test_validate_json_reports_multiple_broken_references_emanating_from_single_
     assert len(result["detail"]["study_set"]) == 2
 
 
+@pytest.mark.skipif(
+    os.getenv("ENABLE_DB_TESTS") != "true",
+    reason="Requires ontology_class_set data (ENABLE_DB_TESTS=true)",
+)
 def test_validate_json_checks_referential_integrity_after_applying_all_collections_changes(
     db,
 ):
@@ -390,17 +395,23 @@ def test_does_collection_have_unique_index_on_id_field(db):
     # Test: Collection has a unique index on its `id` field.
     collection = db.get_collection(collection_name)
     collection.create_index("id", unique=True)
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is True
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is True
+    )
     db.drop_collection(collection_name)
 
     # Test: Collection has a non-unique index on its `id` field.
     collection = db.get_collection(collection_name)
     collection.create_index("id", unique=False)
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is False
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is False
+    )
     db.drop_collection(collection_name)
 
     # Test: Collection has multiple indexes, including a unique index on its `id` field.
@@ -408,43 +419,61 @@ def test_does_collection_have_unique_index_on_id_field(db):
     collection.create_index("id", unique=True)
     collection.create_index("age", unique=False)
     collection.create_index("real_name", unique=False)
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is True
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is True
+    )
     db.drop_collection(collection_name)
 
     # Test: Collection has a unique index on a field _other_ than `id` only.
     collection = db.get_collection(collection_name)
     collection.create_index("username", unique=True)
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is False
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is False
+    )
     db.drop_collection(collection_name)
 
     # Test: Collection has a unique index that _includes_ `id`, but also other fields.
     collection = db.get_collection(collection_name)
     collection.create_index([("id", 1), ("username", 1)], unique=True)
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is False
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is False
+    )
     db.drop_collection(collection_name)
 
     # Test: Collection has _no_ indexes at all.
     collection = db.get_collection(collection_name)
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is False
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is False
+    )
     db.drop_collection(collection_name)
 
     # Test: Collection does not _exist_.
     assert collection_name not in db.list_collection_names()
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is False
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is False
+    )
 
     # Test: "Collection" is actually a _view_.
     db.command("create", collection_name, viewOn="study_set", pipeline=[])
-    assert does_collection_have_unique_index_on_id_field(
-        collection_name=collection_name, db=db
-    ) is False
+    assert (
+        does_collection_have_unique_index_on_id_field(
+            collection_name=collection_name, db=db
+        )
+        is False
+    )
     db.drop_collection(collection_name)

--- a/tests/test_validation/test_env_triad.py
+++ b/tests/test_validation/test_env_triad.py
@@ -22,7 +22,8 @@ from nmdc_runtime.site.validation.env_triad import (
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "files"
 
 
-def _make_term(curie, name="test term"):
+def _make_term(curie: str, name: str = "test term") -> dict:
+    """Build a ControlledIdentifiedTermValue dict for a given CURIE."""
     return {
         "type": "nmdc:ControlledIdentifiedTermValue",
         "term": {"id": curie, "name": name, "type": "nmdc:OntologyClass"},
@@ -30,11 +31,12 @@ def _make_term(curie, name="test term"):
 
 
 def _make_biosample(
-    bs_id="nmdc:bsm-00-test01",
-    broad="ENVO:01000253",
-    local="ENVO:03600095",
-    medium="ENVO:01001057",
-):
+    bs_id: str = "nmdc:bsm-00-test01",
+    broad: str | None = "ENVO:01000253",
+    local: str | None = "ENVO:03600095",
+    medium: str | None = "ENVO:01001057",
+) -> dict:
+    """Build a minimal biosample dict with the given env triad CURIEs."""
     bs = {"id": bs_id, "type": "nmdc:Biosample"}
     if broad is not None:
         bs["env_broad_scale"] = _make_term(broad)
@@ -114,10 +116,11 @@ ONTOLOGY_CLASS_DOCS = {
 class FakeCollection:
     """Minimal stand-in for a pymongo Collection that serves canned docs."""
 
-    def __init__(self, docs):
+    def __init__(self, docs: dict) -> None:
         self._docs = docs
 
-    def find(self, query, projection=None):
+    def find(self, query: dict, projection: dict | None = None) -> list[dict]:
+        """Return docs whose id is in the $in list of the query."""
         curie_list = query.get("id", {}).get("$in", [])
         return [self._docs[c] for c in curie_list if c in self._docs]
 
@@ -125,10 +128,11 @@ class FakeCollection:
 class FakeDB:
     """Minimal stand-in for a pymongo Database."""
 
-    def __init__(self, collections):
+    def __init__(self, collections: dict) -> None:
         self._collections = collections
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> FakeCollection:
+        """Return the named collection."""
         return self._collections[name]
 
 

--- a/tests/test_validation/test_env_triad.py
+++ b/tests/test_validation/test_env_triad.py
@@ -15,6 +15,7 @@ from nmdc_runtime.site.validation.env_triad import (
     ASTRONOMICAL_BODY_PART,
     BIOME,
     ENVIRONMENTAL_MATERIAL,
+    LOCAL_SCALE_EXTRA_PREFIXES,
     validate_env_triad,
 )
 
@@ -80,6 +81,24 @@ ONTOLOGY_CLASS_DOCS = {
         "relations": [
             {"predicate": "entailed_isa_partof_closure", "object": BIOME},
         ],
+    },
+    # A valid PO term for env_local_scale
+    "PO:0025034": {
+        "id": "PO:0025034",
+        "is_obsolete": False,
+        "relations": [],
+    },
+    # A valid UBERON term for env_local_scale
+    "UBERON:0000178": {
+        "id": "UBERON:0000178",
+        "is_obsolete": False,
+        "relations": [],
+    },
+    # An obsolete PO term
+    "PO:0000001": {
+        "id": "PO:0000001",
+        "is_obsolete": True,
+        "relations": [],
     },
     # A biome-typed term — invalid for env_medium / env_local_scale
     "ENVO:00000446": {
@@ -189,6 +208,36 @@ def test_duplicate_curie_across_fields(fake_db):
 def test_empty_biosamples_list(fake_db):
     result = validate_env_triad([], fake_db)
     assert result == {}
+
+
+def test_po_term_valid_for_env_local_scale(fake_db):
+    bs = _make_biosample(local="PO:0025034")
+    result = validate_env_triad([bs], fake_db)
+    assert result == {}
+
+
+def test_uberon_term_valid_for_env_local_scale(fake_db):
+    bs = _make_biosample(local="UBERON:0000178")
+    result = validate_env_triad([bs], fake_db)
+    assert result == {}
+
+
+def test_obsolete_po_term_rejected(fake_db):
+    bs = _make_biosample(local="PO:0000001")
+    result = validate_env_triad([bs], fake_db)
+    assert any("obsolete" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_unknown_po_term_rejected(fake_db):
+    bs = _make_biosample(local="PO:9999999")
+    result = validate_env_triad([bs], fake_db)
+    assert any("unknown term" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_po_term_not_allowed_for_env_broad_scale(fake_db):
+    bs = _make_biosample(broad="PO:0025034")
+    result = validate_env_triad([bs], fake_db)
+    assert any("not a descendant" in e for e in result["nmdc:bsm-00-test01"])
 
 
 def test_real_fixture(fake_db):

--- a/tests/test_validation/test_env_triad.py
+++ b/tests/test_validation/test_env_triad.py
@@ -1,0 +1,199 @@
+"""
+Tests for env triad (env_broad_scale, env_local_scale, env_medium) validation.
+
+Run from the repo root:
+
+    pytest -vv tests/test_validation/test_env_triad.py
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nmdc_runtime.site.validation.env_triad import (
+    ASTRONOMICAL_BODY_PART,
+    BIOME,
+    ENVIRONMENTAL_MATERIAL,
+    validate_env_triad,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "files"
+
+
+def _make_term(curie, name="test term"):
+    return {
+        "type": "nmdc:ControlledIdentifiedTermValue",
+        "term": {"id": curie, "name": name, "type": "nmdc:OntologyClass"},
+    }
+
+
+def _make_biosample(
+    bs_id="nmdc:bsm-00-test01",
+    broad="ENVO:01000253",
+    local="ENVO:03600095",
+    medium="ENVO:01001057",
+):
+    bs = {"id": bs_id, "type": "nmdc:Biosample"}
+    if broad is not None:
+        bs["env_broad_scale"] = _make_term(broad)
+    if local is not None:
+        bs["env_local_scale"] = _make_term(local)
+    if medium is not None:
+        bs["env_medium"] = _make_term(medium)
+    return bs
+
+
+# -- Fake MongoDB layer (no unittest.mock) --
+
+ONTOLOGY_CLASS_DOCS = {
+    "ENVO:01000253": {
+        "id": "ENVO:01000253",
+        "is_obsolete": False,
+        "relations": [
+            {"predicate": "entailed_isa_partof_closure", "object": BIOME},
+        ],
+    },
+    "ENVO:03600095": {
+        "id": "ENVO:03600095",
+        "is_obsolete": False,
+        "relations": [
+            {
+                "predicate": "entailed_isa_partof_closure",
+                "object": ASTRONOMICAL_BODY_PART,
+            },
+        ],
+    },
+    "ENVO:01001057": {
+        "id": "ENVO:01001057",
+        "is_obsolete": False,
+        "relations": [
+            {
+                "predicate": "entailed_isa_partof_closure",
+                "object": ENVIRONMENTAL_MATERIAL,
+            },
+        ],
+    },
+    "ENVO:99999999": {
+        "id": "ENVO:99999999",
+        "is_obsolete": True,
+        "relations": [
+            {"predicate": "entailed_isa_partof_closure", "object": BIOME},
+        ],
+    },
+    # A biome-typed term — invalid for env_medium / env_local_scale
+    "ENVO:00000446": {
+        "id": "ENVO:00000446",
+        "is_obsolete": False,
+        "relations": [
+            {"predicate": "entailed_isa_partof_closure", "object": BIOME},
+        ],
+    },
+}
+
+
+class FakeCollection:
+    """Minimal stand-in for a pymongo Collection that serves canned docs."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def find(self, query, projection=None):
+        curie_list = query.get("id", {}).get("$in", [])
+        return [self._docs[c] for c in curie_list if c in self._docs]
+
+
+class FakeDB:
+    """Minimal stand-in for a pymongo Database."""
+
+    def __init__(self, collections):
+        self._collections = collections
+
+    def __getitem__(self, name):
+        return self._collections[name]
+
+
+@pytest.fixture
+def fake_db():
+    return FakeDB({"ontology_class_set": FakeCollection(ONTOLOGY_CLASS_DOCS)})
+
+
+def test_valid_biosample(fake_db):
+    result = validate_env_triad([_make_biosample()], fake_db)
+    assert result == {}
+
+
+def test_multiple_valid_biosamples(fake_db):
+    result = validate_env_triad(
+        [_make_biosample(bs_id=f"nmdc:bsm-00-test{i:02d}") for i in range(3)],
+        fake_db,
+    )
+    assert result == {}
+
+
+def test_missing_field(fake_db):
+    bs = _make_biosample(broad=None)
+    result = validate_env_triad([bs], fake_db)
+    assert any("Missing required field" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_missing_term_id(fake_db):
+    bs = _make_biosample()
+    bs["env_broad_scale"] = {"type": "nmdc:ControlledIdentifiedTermValue"}
+    result = validate_env_triad([bs], fake_db)
+    assert any("missing term.id" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_unknown_term(fake_db):
+    bs = _make_biosample(broad="ENVO:00000000")
+    result = validate_env_triad([bs], fake_db)
+    assert any("unknown term" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_obsolete_term(fake_db):
+    bs = _make_biosample(broad="ENVO:99999999")
+    result = validate_env_triad([bs], fake_db)
+    assert any("obsolete" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_wrong_hierarchy_broad_scale(fake_db):
+    bs = _make_biosample(broad="ENVO:01001057")
+    result = validate_env_triad([bs], fake_db)
+    assert any("not a descendant" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_wrong_hierarchy_env_medium(fake_db):
+    bs = _make_biosample(medium="ENVO:01000253")
+    result = validate_env_triad([bs], fake_db)
+    assert any("not a descendant" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_biome_disallowed_in_env_medium(fake_db):
+    bs = _make_biosample(medium="ENVO:00000446")
+    result = validate_env_triad([bs], fake_db)
+    assert any("must not be a descendant" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_biome_disallowed_in_env_local_scale(fake_db):
+    bs = _make_biosample(local="ENVO:00000446")
+    result = validate_env_triad([bs], fake_db)
+    assert any("must not be a descendant" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_duplicate_curie_across_fields(fake_db):
+    bs = _make_biosample(broad="ENVO:01000253", local="ENVO:01000253")
+    result = validate_env_triad([bs], fake_db)
+    assert any("already used" in e for e in result["nmdc:bsm-00-test01"])
+
+
+def test_empty_biosamples_list(fake_db):
+    result = validate_env_triad([], fake_db)
+    assert result == {}
+
+
+def test_real_fixture(fake_db):
+    fixture_path = FIXTURES_DIR / "nmdc_bsm-12-7mysck21.json"
+    with open(fixture_path) as f:
+        bs = json.load(f)
+    result = validate_env_triad([bs], fake_db)
+    assert result == {}


### PR DESCRIPTION
- add env triad enum validation to validate_json() method (all ETLs call this)
- add tests to verify env triad validation. 

### Related issue(s)
partially fixes https://github.com/microbiomedata/nmdc-server/issues/1537 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by...
- add and execute tests locally and via CI/CD. 

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
