### PR TITLE
Create unique compound index on `(name, associated_studies)` in `biosample_set` collection

### DIFF
--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -759,7 +759,7 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
             # TODO: Apply the update commands to the "nmdc" MongoDB database within a transaction
             #       and return an error to the user if there are any errors. At this point, if we
             #       are going to perform the commands on the real database within a transaction for
-            #       validation purposes, we _may as well_ perform it for reals, without Dagster! 
+            #       validation purposes, we _may as well_ perform it for reals, without Dagster!
             pass
 
     validation_errors = []

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -599,6 +599,11 @@ def mongo_update_command_for(df_change: pds.DataFrame) -> Dict[str, list]:
     """
     Creates a dictionary of update commands to be executed against the Mongo database.
 
+    FIXME: The "Returns" section of this docstring is inaccurate. The return value's type hint
+           is also inaccurate. See how the return value is built within the function body to
+           get idea of the real data type and conceptual content of the value. Either fix this
+           or eliminate changesheet support altogether.
+
     Parameters
     ----------
     df_change : pds.DataFrame
@@ -717,6 +722,10 @@ def update_mongo_db(mdb: MongoDatabase, update_cmd: Dict):
 
 
 def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
+    """
+    TODO: Document this function.
+    """
+
     update_cmd = mongo_update_command_for(df_change)
     mdb_to_inspect = mdb.client["nmdc_changesheet_submission_results"]
     results_of_copy = copy_docs_in_update_cmd(
@@ -733,6 +742,26 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
         },
         "results_of_updates": results_of_updates,
     }
+
+    # TODO: Perform validation of (biosample name, associated study ID) combinations.
+    #
+    #       Since the `update_mongo_db` invocation above only simulates the updates to the documents that
+    #       are represented in the submitted _changesheet_, and (as of commit #3b4ee8b8 / April 11, 2026)
+    #       the "nmdc" MongoDB database has an index that prohibits multiple `biosample_set` documents
+    #       associated with the same `study_set` document to have the same name as one another, we check
+    #       for violations of that rule here so we can inform the user rather than the eventual Dagster
+    #       write operation failing downstream outside of the user's awareness.
+    #
+    # Docs: https://www.mongodb.com/docs/manual/reference/command/update/#mongodb-dbcommand-dbcmd.update
+    #
+    for _, mongo_update_cmd in update_cmd.items():  # `update_cmd` is a misnomer 😭
+        if mongo_update_cmd["update"] == "biosample_set":
+            # TODO: Apply the update commands to the "nmdc" MongoDB database within a transaction
+            #       and return an error to the user if there are any errors. At this point, if we
+            #       are going to perform the commands on the real database within a transaction for
+            #       validation purposes, we _may as well_ perform it for reals, without Dagster! 
+            pass
+
     validation_errors = []
     for result in results_of_updates:
         if len(result.get("validation_errors", [])) > 0:

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -748,9 +748,9 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
     #       Since the `update_mongo_db` invocation above only simulates the updates to the documents that
     #       are represented in the submitted _changesheet_, and (as of commit #3b4ee8b8 / April 11, 2026)
     #       the "nmdc" MongoDB database has an index that prohibits multiple `biosample_set` documents
-    #       associated with the same `study_set` document to have the same name as one another, we check
-    #       for violations of that rule here so we can inform the user rather than the eventual Dagster
-    #       write operation failing downstream outside of the user's awareness.
+    #       associated with the same `study_set` document to have the same name as one another, check
+    #       for violations of that rule here so we can inform the user now rather than the eventual
+    #       Dagster write operation failing downstream outside of the user's awareness.
     #
     # Docs: https://www.mongodb.com/docs/manual/reference/command/update/#mongodb-dbcommand-dbcmd.update
     #

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -651,6 +651,10 @@ def copy_docs_in_update_cmd(
     Copies data between Mongo databases.
     Useful to apply and inspect updates on a test database.
 
+    TODO: Document the `update_cmd` parameter and add a type hint to it.
+    
+    TODO: Document the `drop_mdb_to` parameter.
+
     Parameters
     ----------
     mdb_from : MongoDatbase
@@ -743,7 +747,7 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
         "results_of_updates": results_of_updates,
     }
 
-    # TODO: Perform validation of (biosample name, associated study ID) combinations.
+    # TODO: Perform validation of (biosample name, associated study ID) combination uniqueness.
     #
     #       Since the `update_mongo_db` invocation above only simulates the updates to the documents that
     #       are represented in the submitted _changesheet_, and (as of commit #3b4ee8b8 / April 11, 2026)
@@ -751,6 +755,14 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
     #       associated with the same `study_set` document to have the same name as one another, check
     #       for violations of that rule here so we can inform the user now rather than the eventual
     #       Dagster write operation failing downstream outside of the user's awareness.
+    #
+    #       We briefly considered inserting all of the remaining "biosample_set" documents into the
+    #       so-called inspection database and seeing whether any index violations occur when the
+    #       changesheet-specified insertions take place, but that database does not have any indexes;
+    #       and the idea of trying to replicate indexes there felt like going down a slippery slope
+    #       of trying to build up a realistic alternative database. I'd much rather switch to using
+    #       MongoDB transactions on the real database, than patch (and maintain) the current
+    #       "inspection" approach.
     #
     # Docs: https://www.mongodb.com/docs/manual/reference/command/update/#mongodb-dbcommand-dbcmd.update
     #

--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -652,7 +652,7 @@ def copy_docs_in_update_cmd(
     Useful to apply and inspect updates on a test database.
 
     TODO: Document the `update_cmd` parameter and add a type hint to it.
-    
+
     TODO: Document the `drop_mdb_to` parameter.
 
     Parameters

--- a/nmdc_runtime/api/db/mongo.py
+++ b/nmdc_runtime/api/db/mongo.py
@@ -367,7 +367,7 @@ def validate_json(
         #
         # a) Check for duplicate biosample names associated with a single study. This is something
         #    NMDC policy prohibits, but the NMDC schema allows. :(
-        # 
+        #
         #    We first check whether the user submitted a `biosample_set` collection. If not, pass.
         #    Otherwise, we check whether the submitted biosamples, themselves, violate this. If so,
         #    fail. Otherwise, we check whether any of the submitted combinations of biosample name
@@ -392,8 +392,14 @@ def validate_json(
                         biosample_names_by_study_id[study_id].add(biosample_name)
             # If we haven't found errors yet, check whether the database already contains any
             # of the submitted (biosample name, associated study ID) combinations.
-            if collection_name not in validation_errors or len(validation_errors[collection_name]) == 0:
-                for study_id, submitted_biosample_names in biosample_names_by_study_id.items():
+            if (
+                collection_name not in validation_errors
+                or len(validation_errors[collection_name]) == 0
+            ):
+                for (
+                    study_id,
+                    submitted_biosample_names,
+                ) in biosample_names_by_study_id.items():
                     biosample = mdb.biosample_set.find_one(
                         {
                             "associated_studies": study_id,

--- a/nmdc_runtime/api/db/mongo.py
+++ b/nmdc_runtime/api/db/mongo.py
@@ -3,7 +3,7 @@ import os
 from contextlib import AbstractContextManager
 from copy import deepcopy
 from functools import lru_cache
-from typing import Set
+from typing import Dict, List, Set
 from uuid import uuid4
 
 import bson
@@ -363,7 +363,53 @@ def validate_json(
         except Exception as e:
             return {"result": "errors", "detail": str(e)}
 
-        # Third pass (if enabled): Check inter-document references.
+        # Third pass: Perform custom validation that is not performed by schema-based validation.
+        #
+        # a) Check for duplicate biosample names associated with a single study. This is something
+        #    NMDC policy prohibits, but the NMDC schema allows. :(
+        # 
+        #    We first check whether the user submitted a `biosample_set` collection. If not, pass.
+        #    Otherwise, we check whether the submitted biosamples, themselves, violate this. If so,
+        #    fail. Otherwise, we check whether any of the submitted combinations of biosample name
+        #    & associated study ID occur in the database. If so, fail. If not, pass.
+        #
+        collection_name = "biosample_set"
+        if collection_name in docs:
+            biosamples = docs[collection_name]
+            biosample_names_by_study_id: Dict[str, Set[str]] = {}
+            for biosample in biosamples:
+                study_ids: List[str] = biosample.get("associated_studies", [])
+                biosample_name: str = biosample["name"]  # schema says name is required
+                for study_id in study_ids:
+                    if study_id not in biosample_names_by_study_id:
+                        biosample_names_by_study_id[study_id] = set()
+                    if biosample_name in biosample_names_by_study_id[study_id]:
+                        validation_errors[collection_name].append(
+                            f"Multiple submitted biosamples having name '{biosample_name}'"
+                            f"are associated with study '{study_id}'."
+                        )
+                    else:
+                        biosample_names_by_study_id[study_id].add(biosample_name)
+            # If we haven't found errors yet, check whether the database already contains any
+            # of the submitted (biosample name, associated study ID) combinations.
+            if collection_name not in validation_errors or len(validation_errors[collection_name]) == 0:
+                for study_id, submitted_biosample_names in biosample_names_by_study_id.items():
+                    biosample = mdb.biosample_set.find_one(
+                        {
+                            "associated_studies": study_id,
+                            "name": {"$in": list(submitted_biosample_names)},
+                        }
+                    )
+                    if biosample is not None:
+                        validation_errors[collection_name].append(
+                            f"There is already a biosample having name '{biosample['name']}' "
+                            f"that is associated with the study having ID '{study_id}'."
+                        )
+        # If any collection's error list is not empty, return an error response.
+        if any(len(v) > 0 for v in validation_errors.values()):
+            return {"result": "errors", "detail": validation_errors}
+
+        # Fourth pass (if enabled): Check inter-document references.
         if check_inter_document_references is True:
             # Prepare to use `refscan`.
             #

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -260,6 +260,11 @@ def _run_mdb_cmd(
     TODO: Consider splitting this function into multiple, smaller functions (if practical). It is currently ~370 lines.
     TODO: How does this function behave when the "batchSize" is invalid (e.g. 0, negative, non-numeric)?
 
+    TODO: For `UpdateCommand` commands that involve the "biosample_set" collection, validate the
+          (biosample name, associated study ID) uniqueness constraint (introduced in commit #3b4ee8b8
+          in April 11, 2026), so we can return an error response to the user, rather than them only
+          realizing later that the write operation eventually attempted by Dagster failed.
+
     :param cmd: Undocumented. TODO: Document this parameter.
     :param mdb: Undocumented. TODO: Document this parameter.
     :param allow_broken_refs: Under normal circumstances, if this function determines that performing

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -197,7 +197,7 @@ def ensure_allowance_is_indexed():
 
 def ensure_biosample_set_has_unique_compound_index_on_name_and_associated_studies():
     """
-    Ensures that there is a compound index on {name, associated_studies} in the `biosample_set`
+    Ensures that there is a compound index on (name, associated_studies) in the `biosample_set`
     collection; so that no two biosamples associated with the same study can have the same name.
     """
     mdb = get_mongo_db()

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -195,6 +195,17 @@ def ensure_allowance_is_indexed():
     )
 
 
+def ensure_biosample_set_has_unique_compound_index_on_name_and_associated_studies():
+    """
+    Ensures that there is a compound index on {name, associated_studies} in the `biosample_set`
+    collection; so that no two biosamples associated with the same study can have the same name.
+    """
+    mdb = get_mongo_db()
+    mdb["biosample_set"].create_index(
+        [("name", 1), ("associated_studies", 1)], background=True, unique=True,
+    )
+
+
 def ensure_attribute_indexes():
     r"""
     Ensures that the MongoDB collection identified by each key (i.e. collection name) in the
@@ -289,6 +300,8 @@ async def lifespan(app: FastAPI):
     ensure_sequencing_project_name_is_indexed()
     ensure_jgi_samples_id_is_indexed()
     ensure_allowance_is_indexed()
+    ensure_biosample_set_has_unique_compound_index_on_name_and_associated_studies()
+
     # Invoke a function—thereby priming its memoization cache—in order to speed up all future invocations.
     get_allowed_references()  # we ignore the return value here
 

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -202,7 +202,9 @@ def ensure_biosample_set_has_unique_compound_index_on_name_and_associated_studie
     """
     mdb = get_mongo_db()
     mdb["biosample_set"].create_index(
-        [("name", 1), ("associated_studies", 1)], background=True, unique=True,
+        [("name", 1), ("associated_studies", 1)],
+        background=True,
+        unique=True,
     )
 
 

--- a/tests/lib/faker.py
+++ b/tests/lib/faker.py
@@ -144,7 +144,11 @@ class Faker:
     def generate_biosamples(self, quantity: int, associated_studies: List[str], **overrides) -> List[dict]:
         """
         Generates the specified number of schema-compliant `biosample_set` documents.
-        The documents comply with schema v11.8.0.
+
+        Unless overridden, the `name` value will be unique for each document generated
+        during a given invocation of this function.
+
+        The documents comply with schema v11.18.0.
 
         Reference: https://microbiomedata.github.io/nmdc-schema/Biosample/
 
@@ -182,7 +186,7 @@ class Faker:
                 "id": self.make_unique_id("nmdc:bsm-00-"),
                 "type": Biosample.class_class_curie,
                 "associated_studies": associated_studies,
-                "name": "my_biosample",
+                "name": f"name_{i}",
                 "env_broad_scale": {
                     "has_raw_value": "ENVO_00000446",
                     "term": {

--- a/tests/test_api/test_db_mongo.py
+++ b/tests/test_api/test_db_mongo.py
@@ -228,24 +228,23 @@ def test_unique_compound_indexes_including_arrays_check_all_permutations(test_db
     collection.create_index([("pasta", 1), ("sauces", 1)], name="my_index", unique=True)
 
     # Insert documents with various combinations of pasta and sauces.
-    assert collection.count_documents({}) == 0
-    collection.insert_one({"pasta": "spaghetti", "sauces": ["marinara", "alfredo"]})
-    collection.insert_one({"pasta": "rigatoni", "sauces": ["alfredo", "pesto"]})
-    collection.insert_one({"pasta": "rigatoni", "sauces": ["marinara"]})
-    collection.insert_one({"pasta": "fettuccine", "sauces": ["pesto"]})
+    collection.insert_one({"pasta": "Spaghetti", "sauces": ["Marinara", "Alfredo"]})
+    collection.insert_one({"pasta": "Rigatoni", "sauces": ["Alfredo", "Pesto"]})
+    collection.insert_one({"pasta": "Rigatoni", "sauces": ["Marinara"]})
+    assert collection.count_documents({}) == 3
 
-    # Try inserting some documents that violate the unique constraint, and confirm they are rejected.
-    assert collection.count_documents({}) == 4
+    # Try inserting some documents that violate the unique constraint.
+    # Note: These will both be rejected because the combination of "Rigatoni" + "Pesto" exists.
     with pytest.raises(Exception):
-        collection.insert_one({"pasta": "rigatoni", "sauces": ["pesto"]})
+        collection.insert_one({"pasta": "Rigatoni", "sauces": ["Pesto"]})
     with pytest.raises(Exception):
-        collection.insert_one({"pasta": "fettuccine", "sauces": ["pesto"]})
+        collection.insert_one({"pasta": "Rigatoni", "sauces": ["Pesto", "Carbonara"]})
+    assert collection.count_documents({}) == 3
     
-    # Get rid of the index and see that we can insert them now.
+    # Get rid of the index.
     collection.drop_index("my_index")
 
     # Now, try inserting those same documents.
-    assert collection.count_documents({}) == 4
-    collection.insert_one({"pasta": "rigatoni", "sauces": ["pesto"]})
-    collection.insert_one({"pasta": "fettuccine", "sauces": ["pesto"]})
-    assert collection.count_documents({}) == 6
+    collection.insert_one({"pasta": "Rigatoni", "sauces": ["Pesto"]})
+    collection.insert_one({"pasta": "Rigatoni", "sauces": ["Pesto", "Carbonara"]})
+    assert collection.count_documents({}) == 5

--- a/tests/test_api/test_db_mongo.py
+++ b/tests/test_api/test_db_mongo.py
@@ -217,3 +217,35 @@ def test_check_mongo_ok_autoreconnect(test_db):
     collection = test_db.get_collection("_runtime.healthcheck")
     assert check_mongo_ok_autoreconnect(mdb=test_db) is True
     assert collection.count_documents({"status": "ok"}) == 0
+
+
+def test_unique_compound_indexes_including_arrays_check_all_permutations(test_db):
+    """
+    This test demonstrates how MongoDB's compound indexes work when one of the fields is an array.
+    """
+    # Create the composite index.
+    collection = test_db.get_collection("test")
+    collection.create_index([("pasta", 1), ("sauces", 1)], name="my_index", unique=True)
+
+    # Insert documents with various combinations of pasta and sauces.
+    assert collection.count_documents({}) == 0
+    collection.insert_one({"pasta": "spaghetti", "sauces": ["marinara", "alfredo"]})
+    collection.insert_one({"pasta": "rigatoni", "sauces": ["alfredo", "pesto"]})
+    collection.insert_one({"pasta": "rigatoni", "sauces": ["marinara"]})
+    collection.insert_one({"pasta": "fettuccine", "sauces": ["pesto"]})
+
+    # Try inserting some documents that violate the unique constraint, and confirm they are rejected.
+    assert collection.count_documents({}) == 4
+    with pytest.raises(Exception):
+        collection.insert_one({"pasta": "rigatoni", "sauces": ["pesto"]})
+    with pytest.raises(Exception):
+        collection.insert_one({"pasta": "fettuccine", "sauces": ["pesto"]})
+    
+    # Get rid of the index and see that we can insert them now.
+    collection.drop_index("my_index")
+
+    # Now, try inserting those same documents.
+    assert collection.count_documents({}) == 4
+    collection.insert_one({"pasta": "rigatoni", "sauces": ["pesto"]})
+    collection.insert_one({"pasta": "fettuccine", "sauces": ["pesto"]})
+    assert collection.count_documents({}) == 6

--- a/tests/test_api/test_db_mongo.py
+++ b/tests/test_api/test_db_mongo.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
-from pymongo.errors import DuplicateKeyError
 import pytest
+from pymongo.errors import DuplicateKeyError
 from toolz import dissoc
 
 from nmdc_runtime.api.db.mongo import (

--- a/tests/test_api/test_db_mongo.py
+++ b/tests/test_api/test_db_mongo.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from pymongo.errors import DuplicateKeyError
 import pytest
 from toolz import dissoc
 
@@ -235,9 +236,9 @@ def test_unique_compound_indexes_including_arrays_check_all_permutations(test_db
 
     # Try inserting some documents that violate the unique constraint.
     # Note: These will both be rejected because the combination of "Rigatoni" + "Pesto" exists.
-    with pytest.raises(Exception):
+    with pytest.raises(DuplicateKeyError):
         collection.insert_one({"pasta": "Rigatoni", "sauces": ["Pesto"]})
-    with pytest.raises(Exception):
+    with pytest.raises(DuplicateKeyError):
         collection.insert_one({"pasta": "Rigatoni", "sauces": ["Pesto", "Carbonara"]})
     assert collection.count_documents({}) == 3
     

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -559,18 +559,18 @@ def test_json_submit_rejects_payload_introducing_biosample_having_duplicate_name
     assert study_set.count_documents({"id": {"$in": study_ids}}) == 0
     assert biosample_set.count_documents({"id": {"$in": biosample_ids}}) == 0
 
+    # 👤 Give the user permission to use this API endpoint if it doesn't already have such permission.
+    allowances_collection = db.get_collection("_runtime.api.allow")
+    user_allowance = {"username": api_user_client.username, "action": "/metadata/json:submit"}
+    user_was_not_allowed = allowances_collection.find_one(user_allowance) is None
+    if user_was_not_allowed:
+        allowances_collection.insert_one(user_allowance)
+
     # We use a try/finally block so we can clean up the database even if an assertion fails.
     try:
         # Insert both studies and the first biosample into the database.
         study_set.insert_many([study_a, study_b])
         biosample_set.insert_one(biosample_a)
-
-        # 👤 Give the user permission to use this API endpoint if it doesn't already have such permission.
-        allowances_collection = db.get_collection("_runtime.api.allow")
-        user_allowance = {"username": api_user_client.username, "action": "/metadata/json:submit"}
-        user_was_not_allowed = allowances_collection.find_one(user_allowance) is None
-        if user_was_not_allowed:
-            allowances_collection.insert_one(user_allowance)
 
         # Try using the API endpoint to introduce the second biosample.
         with pytest.raises(requests.exceptions.HTTPError) as exc:
@@ -609,13 +609,17 @@ def test_json_submit_rejects_payload_introducing_biosample_having_duplicate_name
             {"id": {"$in": [biosample_b["id"], biosample_c["id"]]}}
         ) == 0
 
-    # Clean up: Delete all inserted studies and biosamples (only one biosample was ever inserted).
+    # Clean up: Delete all inserted studies and biosamples (only one biosample was ever inserted),
+    #           and delete the allowance (if one was inserted).
+    #
     # TODO: Since the endpoint uses Dagster to perform the insertions, there may be a race condition
     #       where these deletions are performed before Dagster has even performed the insertions.
+    #
     finally:
         study_set.delete_many({"id": {"$in": study_ids}})
         biosample_set.delete_many({"id": {"$in": biosample_ids}})
-
+        if user_was_not_allowed is True:
+            allowances_collection.delete_one(user_allowance)
 
 # TODO: Add a test that demonstrates the "success" behavior of the `/metadata/json:submit` API endpoint.
 #       Note that that behavior involves Dagster.

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -539,6 +539,84 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(
         allowances_collection.delete_one(user_allowance)
 
 
+def test_json_submit_rejects_payload_introducing_biosample_having_duplicate_name_under_same_study(
+    api_user_client,
+):
+    faker = Faker()
+    study_a, study_b = faker.generate_studies(2)
+    biosample_a, biosample_b, biosample_c = faker.generate_biosamples(
+        quantity=3,
+        name="recurring_name",
+        associated_studies=[study_a["id"]],
+    )
+    study_ids = [study_a["id"], study_b["id"]]
+    biosample_ids = [biosample_a["id"], biosample_b["id"], biosample_c["id"]]
+
+    # Confirm documents having those IDs don't exist in the database yet.
+    db = get_mongo_db()
+    study_set = db.get_collection("study_set")
+    biosample_set = db.get_collection("biosample_set")
+    assert study_set.count_documents({"id": {"$in": study_ids}}) == 0
+    assert biosample_set.count_documents({"id": {"$in": biosample_ids}}) == 0
+
+    # We use a try/finally block so we can clean up the database even if an assertion fails.
+    try:
+        # Insert both studies and the first biosample into the database.
+        study_set.insert_many([study_a, study_b])
+        biosample_set.insert_one(biosample_a)
+
+        # 👤 Give the user permission to use this API endpoint if it doesn't already have such permission.
+        allowances_collection = db.get_collection("_runtime.api.allow")
+        user_allowance = {"username": api_user_client.username, "action": "/metadata/json:submit"}
+        user_was_not_allowed = allowances_collection.find_one(user_allowance) is None
+        if user_was_not_allowed:
+            allowances_collection.insert_one(user_allowance)
+
+        # Try using the API endpoint to introduce the second biosample.
+        with pytest.raises(requests.exceptions.HTTPError) as exc:
+            api_user_client.request(
+                "POST",
+                "/metadata/json:submit",
+                {"biosample_set": [biosample_b]},
+            )
+        response = exc.value.response
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+        # Assert that the biosample_set collection does not contain the biosample we submitted.
+        assert biosample_set.count_documents({"id": biosample_b["id"]}) == 0
+
+        # At this point, we've shown that the endpoint rejects it when the submitted biosample has the
+        # same name as an _existing_ one (associated with the same study). Next, we'll show that the
+        # endpoint rejects it when submitted two biosamples (associated with the same study) have the
+        # same name, although no biosample in the database (associated with that study) has that name.
+
+        # Associate the second and third biosamples with a different study from the first biosample.
+        biosample_b["associated_studies"] = [study_b["id"]]
+        biosample_c["associated_studies"] = [study_b["id"]]
+
+        # Try using the API endpoint to introduce the second and third biosamples.
+        with pytest.raises(requests.exceptions.HTTPError) as exc:
+            api_user_client.request(
+                "POST",
+                "/metadata/json:submit",
+                {"biosample_set": [biosample_b, biosample_c]},
+            )
+        response = exc.value.response
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+        # Assert that the biosample_set collection does not contain the biosample we submitted.
+        assert biosample_set.count_documents(
+            {"id": {"$in": [biosample_b["id"], biosample_c["id"]]}}
+        ) == 0
+
+    # Clean up: Delete all inserted studies and biosamples (only one biosample was ever inserted).
+    # TODO: Since the endpoint uses Dagster to perform the insertions, there may be a race condition
+    #       where these deletions are performed before Dagster has even performed the insertions.
+    finally:
+        study_set.delete_many({"id": {"$in": study_ids}})
+        biosample_set.delete_many({"id": {"$in": biosample_ids}})
+
+
 # TODO: Add a test that demonstrates the "success" behavior of the `/metadata/json:submit` API endpoint.
 #       Note that that behavior involves Dagster.
 

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -1103,7 +1103,12 @@ class TestFindDataObjectsForStudy:
         """
 
         faker = Faker()
-        biosample_b = faker.generate_biosamples(1, id="nmdc:bsm-00-000002", associated_studies=[self.study_id])[0]
+        biosample_b = faker.generate_biosamples(
+            quantity=1,
+            id="nmdc:bsm-00-000002",
+            name="biosample_b",  # since biosample names must be unique within a given study
+            associated_studies=[self.study_id]
+        )[0]
         workflow_execution_set = seeded_db.get_collection(name="workflow_execution_set")
         workflow_execution_set.update_one(
             {"id": self.workflow_execution_ids[0]},


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the Runtime's bootup routine to ensure the Mongo database has a unique compound index on `(name, associated_studies)`, so that no two biosamples associated with the same study can have the same name.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I also implemented a generic test that demonstrates that such a unique compound index works the way I expect.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1417

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming all tests pass, including the newly-introduced one.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
