### PR TITLE
Fix precision of `depth` slot values in NEON translator helper method

### DIFF
--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -432,7 +432,7 @@ def repo():
             description="Shows version information",
             metadata={
                 "nmdc_runtime": version("nmdc_runtime"),
-            }
+            },
         ),
         ensure_jobs.to_job(**preset_normal),
         apply_metadata_in.to_job(**preset_normal),

--- a/nmdc_runtime/site/translation/neon_utils.py
+++ b/nmdc_runtime/site/translation/neon_utils.py
@@ -1,4 +1,5 @@
 import math
+from decimal import Decimal
 from typing import Optional, Union
 
 import pandas as pd
@@ -29,9 +30,9 @@ def _get_value_or_none(data: pd.DataFrame, column_name: str) -> Union[str, float
         ):
             return data[column_name].values[0].lower()
         elif column_name == "sampleTopDepth":
-            return float(data[column_name].values[0]) / 100
+            return float(Decimal(str(data[column_name].values[0])) / Decimal(100))
         elif column_name == "sampleBottomDepth":
-            return float(data[column_name].values[0]) / 100
+            return float(Decimal(str(data[column_name].values[0])) / Decimal(100))
         else:
             return data[column_name].values[0]
 

--- a/tests/test_data/test_neon_soil_data_translator.py
+++ b/tests/test_data/test_neon_soil_data_translator.py
@@ -866,6 +866,14 @@ class TestNeonDataTranslator:
         actual_maximum_depth = _get_value_or_none(test_biosample, "sampleBottomDepth")
         assert expected_maximum_depth == actual_maximum_depth
 
+        # cm -> m conversion must not introduce floating point artifacts
+        # (e.g. 21.9 / 100 == 0.21899999999999997 under plain float division)
+        fp_biosample = pd.DataFrame(
+            [{"sampleTopDepth": 21.9, "sampleBottomDepth": 7.4}]
+        )
+        assert _get_value_or_none(fp_biosample, "sampleTopDepth") == 0.219
+        assert _get_value_or_none(fp_biosample, "sampleBottomDepth") == 0.074
+
         expected_sample_id = "BLAN_005-M-8-0-20200713"
         actual_sample_id = _get_value_or_none(test_biosample, "sampleID")
         assert expected_sample_id == actual_sample_id


### PR DESCRIPTION
Fix precision of `depth.has_maximum_numeric_value` / `depth.has_minimum_numeric_value` that are being populated from NEON source columns called "sampleBottomDepth" and "SampleTopDepth" respectively.

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fix applied in `nmdc_runtime/site/translation/neon_utils.py:32-34`. The division now goes through `Decimal(str(...)) / Decimal(100)` so for example `21.9` → `0.219` works exactly, regardless of source precision.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes https://github.com/microbiomedata/issues/issues/1688

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by adding regression assertions to `tests/test_data/test_neon_soil_data_translator.py` right after the existing depth asserts, with a brief comment explaining what they guard against. Verified they pass against the Decimal-based implementation.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
