### PR TITLE
Decrease TTL of temporary `linked_instances` collections from 1 day to 1 hour

### DIFF
--- a/nmdc_runtime/api/endpoints/lib/linked_instances.py
+++ b/nmdc_runtime/api/endpoints/lib/linked_instances.py
@@ -60,7 +60,10 @@ def drop_stale_temp_linked_instances_collections() -> None:
     for collection_name in mdb.list_collection_names(
         filter={"name": {"$regex": r"^_runtime.tmp.linked_instances\..*"}}
     ):
-        if ObjectId(collection_name.split(".")[-1]).generation_time < min_generation_time:
+        if (
+            ObjectId(collection_name.split(".")[-1]).generation_time
+            < min_generation_time
+        ):
             mdb.drop_collection(collection_name)
 
 

--- a/nmdc_runtime/api/endpoints/lib/linked_instances.py
+++ b/nmdc_runtime/api/endpoints/lib/linked_instances.py
@@ -45,13 +45,22 @@ def generate_temp_linked_instances_collection_name(
 
 
 def drop_stale_temp_linked_instances_collections() -> None:
-    """Drop any temporary linked-instances collections that were generated earlier than one day ago."""
+    """
+    Drop any temporary linked-instances collections that were generated earlier than some cutoff.
+    """
+
+    # How long ago a collection must have been generated in order for this function to consider it
+    # to be "stale" (in which case, this function will drop that collection). By setting it to an
+    # hour (which we arrived at heuristically), we are implying that we think anyone paginating
+    # through the collection will have finished doing so within one hour from when they began.
+    how_long_ago = timedelta(hours=1)
+    min_generation_time = now() - how_long_ago
+
     mdb = get_mongo_db()
-    one_day_ago = now() - timedelta(days=1)
     for collection_name in mdb.list_collection_names(
         filter={"name": {"$regex": r"^_runtime.tmp.linked_instances\..*"}}
     ):
-        if ObjectId(collection_name.split(".")[-1]).generation_time < one_day_ago:
+        if ObjectId(collection_name.split(".")[-1]).generation_time < min_generation_time:
             mdb.drop_collection(collection_name)
 
 


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the function that drops temporary `linked_instances` collections from waiting 1 day to waiting only 1 hour.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

My assumption is that anyone paginating through the documents in the collection will have finished doing so within an hour of when they began.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1433

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming all existing tests pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
