### PR TITLE
Update `materialize_alldocs` op to delete leftover temporary collections

### DIFF
--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1186,39 +1186,29 @@ def _add_linked_instances_to_alldocs(
     context.log.info(f"Pushed {update_count} updates in total")
 
 
-def drop_stale_temporary_alldocs_collections(
-    context: OpExecutionContext,
+def drop_temporary_alldocs_collections(
+    mdb: MongoDatabase,
     temporary_alldocs_collection_name_prefix: str = "_runtime.tmp.alldocs.",
-) -> None:
-    """Drops all temporary alldocs collections whose generation began at least an hour ago."""
+) -> Tuple[int, int]:
+    """
+    Drops all temporary alldocs collections.
 
-    # How long ago a collection must have been generated in order for this function to consider it
-    # to be "stale" (in which case, this function will drop that collection).
-    how_long_ago = timedelta(hours=1)
-    min_generation_time = now() - how_long_ago
+    :returns: Tuple of two numbers. First number is number of collections that were found,
+              and second number is number of collections that were dropped.
+    """
 
-    num_temp_alldocs_collections_found = 0
-    num_temp_alldocs_collections_dropped = 0
+    num_collections_initial = 0
+    num_collections_dropped = 0
 
-    mdb = context.resources.mongo.db
     for collection_name in mdb.list_collection_names():
-        # If this collection name doesn't start with the target prefix, skip it.
-        if not collection_name.startswith(temporary_alldocs_collection_name_prefix):
-            continue
+        num_collections_initial += 1
 
-        num_temp_alldocs_collections_found += 1
-        object_id_in_collection_name: str = collection_name.split(".")[-1]
-        if ObjectId(object_id_in_collection_name).generation_time < min_generation_time:
-            context.log.info(f"Dropping stale temporary collection: {collection_name}")
+        # If this collection's name begins with the specified prefix, drop the collection.
+        if collection_name.startswith(temporary_alldocs_collection_name_prefix):
+            num_collections_dropped += 1
             mdb.drop_collection(collection_name)
-            num_temp_alldocs_collections_dropped += 1
-
-    context.log.info(
-        f"Temporary collections found: {num_temp_alldocs_collections_found}"
-    )
-    context.log.info(
-        f"Temporary collections dropped: {num_temp_alldocs_collections_dropped}"
-    )
+    
+    return (num_collections_initial, num_collections_dropped)
 
 
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)
@@ -1290,12 +1280,14 @@ def materialize_alldocs(context: OpExecutionContext) -> int:
                 )
 
     # Before we generate a temporary `_runtime.tmp.alldocs.*` collection, drop any such collections
-    # left over from previous generation attempts that began at least an hour ago. This prevents
-    # the database from accumulating too many such collections as attempts fail over time.
+    # left over from previous generation attempts that failed. This prevents the database from
+    # accumulating too many such collections as generation attempts fail over time.
     temporary_alldocs_collection_name_prefix = "_runtime.tmp.alldocs."
-    drop_stale_temporary_alldocs_collections(
-        context, temporary_alldocs_collection_name_prefix
+    _, num_dropped = drop_temporary_alldocs_collections(
+        mdb=mdb,
+        temporary_alldocs_collection_name_prefix=temporary_alldocs_collection_name_prefix,
     )
+    context.log.info(f"Dropped {num_dropped} collections from past attempts")
 
     # Build `alldocs` to a temporary collection for atomic replacement
     # https://www.mongodb.com/docs/v6.0/reference/method/db.collection.renameCollection/#resource-locking-in-replica-sets

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1289,11 +1289,15 @@ def materialize_alldocs(context: OpExecutionContext) -> int:
     # left over from previous generation attempts that began at least an hour ago. This prevents
     # the database from accumulating too many such collections as attempts fail over time.
     temporary_alldocs_collection_name_prefix = "_runtime.tmp.alldocs."
-    drop_stale_temporary_alldocs_collections(context, temporary_alldocs_collection_name_prefix)
+    drop_stale_temporary_alldocs_collections(
+        context, temporary_alldocs_collection_name_prefix
+    )
 
     # Build `alldocs` to a temporary collection for atomic replacement
     # https://www.mongodb.com/docs/v6.0/reference/method/db.collection.renameCollection/#resource-locking-in-replica-sets
-    temp_alldocs_collection_name = f"{temporary_alldocs_collection_name_prefix}{ObjectId()}"
+    temp_alldocs_collection_name = (
+        f"{temporary_alldocs_collection_name_prefix}{ObjectId()}"
+    )
     temp_alldocs_collection = mdb[temp_alldocs_collection_name]
     context.log.info(f"constructing `{temp_alldocs_collection.name}` collection")
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from importlib.metadata import version
 from io import BytesIO
 from pprint import pformat

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1213,8 +1213,12 @@ def drop_stale_temporary_alldocs_collections(
             mdb.drop_collection(collection_name)
             num_temp_alldocs_collections_dropped += 1
 
-    context.log.info(f"Temporary collections found: {num_temp_alldocs_collections_found}")
-    context.log.info(f"Temporary collections dropped: {num_temp_alldocs_collections_dropped}")
+    context.log.info(
+        f"Temporary collections found: {num_temp_alldocs_collections_found}"
+    )
+    context.log.info(
+        f"Temporary collections dropped: {num_temp_alldocs_collections_dropped}"
+    )
 
 
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1207,7 +1207,7 @@ def drop_temporary_alldocs_collections(
         if collection_name.startswith(temporary_alldocs_collection_name_prefix):
             num_collections_dropped += 1
             mdb.drop_collection(collection_name)
-    
+
     return (num_collections_initial, num_collections_dropped)
 
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from importlib.metadata import version
 from io import BytesIO
 from pprint import pformat
@@ -1186,6 +1186,32 @@ def _add_linked_instances_to_alldocs(
     context.log.info(f"Pushed {update_count} updates in total")
 
 
+def drop_stale_temporary_alldocs_collections(context: OpExecutionContext) -> None:
+    """
+    Drops temporary `_runtime.tmp.alldocs.*` collections that were generated over an hour ago.
+    """
+
+    # How long ago a collection must have been generated in order for this function to consider it
+    # to be "stale" (in which case, this function will drop that collection).
+    how_long_ago = timedelta(hours=1)
+    min_generation_time = now() - how_long_ago
+
+    num_collections_found = 0
+    num_collections_dropped = 0
+
+    mdb = context.resources.mongo.db
+    for collection_name in mdb.list_collection_names():
+        num_collections_found += 1
+        object_id_in_collection_name: str = collection_name.split(".")[-1]
+        if ObjectId(object_id_in_collection_name).generation_time < min_generation_time:
+            context.log.info(f"Dropping stale temporary collection: {collection_name}")
+            mdb.drop_collection(collection_name)
+            num_collections_dropped += 1
+
+    context.log.info(f"Temporary alldocs collections found: {num_collections_found}")
+    context.log.info(f"Temporary alldocs collections dropped: {num_collections_dropped}")
+
+
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)
 #       pass an argument to the op (in order to specify the order of the ops in the graph)
 #       while also telling Dagster that this op doesn't need the _value_ of that argument.
@@ -1253,6 +1279,11 @@ def materialize_alldocs(context: OpExecutionContext) -> int:
                 document_reference_ranged_slots_by_type[f"nmdc:{cls_name}"].append(
                     slot_name
                 )
+
+    # Before we generate a temporary `_runtime.tmp.alldocs.*` collection, drop any such collections
+    # left over from previous generation attempts that began at least an hour ago. This prevents
+    # the database from accumulating too many such collections as attempts fail over time.
+    drop_stale_temporary_alldocs_collections(context)
 
     # Build `alldocs` to a temporary collection for atomic replacement
     # https://www.mongodb.com/docs/v6.0/reference/method/db.collection.renameCollection/#resource-locking-in-replica-sets

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1209,7 +1209,9 @@ def drop_stale_temporary_alldocs_collections(context: OpExecutionContext) -> Non
             num_collections_dropped += 1
 
     context.log.info(f"Temporary alldocs collections found: {num_collections_found}")
-    context.log.info(f"Temporary alldocs collections dropped: {num_collections_dropped}")
+    context.log.info(
+        f"Temporary alldocs collections dropped: {num_collections_dropped}"
+    )
 
 
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1256,7 +1256,7 @@ def materialize_alldocs(context: OpExecutionContext) -> int:
 
     # Build `alldocs` to a temporary collection for atomic replacement
     # https://www.mongodb.com/docs/v6.0/reference/method/db.collection.renameCollection/#resource-locking-in-replica-sets
-    temp_alldocs_collection_name = f"tmp.alldocs.{ObjectId()}"
+    temp_alldocs_collection_name = f"_runtime.tmp.alldocs.{ObjectId()}"
     temp_alldocs_collection = mdb[temp_alldocs_collection_name]
     context.log.info(f"constructing `{temp_alldocs_collection.name}` collection")
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1186,32 +1186,35 @@ def _add_linked_instances_to_alldocs(
     context.log.info(f"Pushed {update_count} updates in total")
 
 
-def drop_stale_temporary_alldocs_collections(context: OpExecutionContext) -> None:
-    """
-    Drops temporary `_runtime.tmp.alldocs.*` collections that were generated over an hour ago.
-    """
+def drop_stale_temporary_alldocs_collections(
+    context: OpExecutionContext,
+    temporary_alldocs_collection_name_prefix: str = "_runtime.tmp.alldocs.",
+) -> None:
+    """Drops all temporary alldocs collections whose generation began at least an hour ago."""
 
     # How long ago a collection must have been generated in order for this function to consider it
     # to be "stale" (in which case, this function will drop that collection).
     how_long_ago = timedelta(hours=1)
     min_generation_time = now() - how_long_ago
 
-    num_collections_found = 0
-    num_collections_dropped = 0
+    num_temp_alldocs_collections_found = 0
+    num_temp_alldocs_collections_dropped = 0
 
     mdb = context.resources.mongo.db
     for collection_name in mdb.list_collection_names():
-        num_collections_found += 1
+        # If this collection name doesn't start with the target prefix, skip it.
+        if not collection_name.startswith(temporary_alldocs_collection_name_prefix):
+            continue
+
+        num_temp_alldocs_collections_found += 1
         object_id_in_collection_name: str = collection_name.split(".")[-1]
         if ObjectId(object_id_in_collection_name).generation_time < min_generation_time:
             context.log.info(f"Dropping stale temporary collection: {collection_name}")
             mdb.drop_collection(collection_name)
-            num_collections_dropped += 1
+            num_temp_alldocs_collections_dropped += 1
 
-    context.log.info(f"Temporary alldocs collections found: {num_collections_found}")
-    context.log.info(
-        f"Temporary alldocs collections dropped: {num_collections_dropped}"
-    )
+    context.log.info(f"Collections found: {num_temp_alldocs_collections_found}")
+    context.log.info(f"Collections dropped: {num_temp_alldocs_collections_dropped}")
 
 
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)
@@ -1285,11 +1288,12 @@ def materialize_alldocs(context: OpExecutionContext) -> int:
     # Before we generate a temporary `_runtime.tmp.alldocs.*` collection, drop any such collections
     # left over from previous generation attempts that began at least an hour ago. This prevents
     # the database from accumulating too many such collections as attempts fail over time.
-    drop_stale_temporary_alldocs_collections(context)
+    temporary_alldocs_collection_name_prefix = "_runtime.tmp.alldocs."
+    drop_stale_temporary_alldocs_collections(context, temporary_alldocs_collection_name_prefix)
 
     # Build `alldocs` to a temporary collection for atomic replacement
     # https://www.mongodb.com/docs/v6.0/reference/method/db.collection.renameCollection/#resource-locking-in-replica-sets
-    temp_alldocs_collection_name = f"_runtime.tmp.alldocs.{ObjectId()}"
+    temp_alldocs_collection_name = f"{temporary_alldocs_collection_name_prefix}{ObjectId()}"
     temp_alldocs_collection = mdb[temp_alldocs_collection_name]
     context.log.info(f"constructing `{temp_alldocs_collection.name}` collection")
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -1213,8 +1213,8 @@ def drop_stale_temporary_alldocs_collections(
             mdb.drop_collection(collection_name)
             num_temp_alldocs_collections_dropped += 1
 
-    context.log.info(f"Collections found: {num_temp_alldocs_collections_found}")
-    context.log.info(f"Collections dropped: {num_temp_alldocs_collections_dropped}")
+    context.log.info(f"Temporary collections found: {num_temp_alldocs_collections_found}")
+    context.log.info(f"Temporary collections dropped: {num_temp_alldocs_collections_dropped}")
 
 
 # Note: Here, we define a so-called "Nothing dependency," which allows us to (in a graph)


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated the `materialize_alldocs` Dagster op so that, whenever it runs (typically once per hour), it drops any `_runtime.tmp.alldocs.*` collections that exist in the database. Those were left over by previous runs of the op that terminated early.

I **also** made it so the name of the collection starts with `_runtime`, like our other temporary collections.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

None.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1435 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by confirming all existing tests pass.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
