### PR TITLE
Disable strict `Content-Type` checking performed by FastAPI

### DIFF
--- a/nmdc_runtime/api/core/provenance.py
+++ b/nmdc_runtime/api/core/provenance.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Optional, Set
 
 from nmdc_runtime.api.models.query import UpdateStatement
 
-
 # Names of collections that can contain documents having the `provenance_metadata` field.
 NAMES_OF_COLLECTIONS_ALLOWING_DOCUMENTS_HAVING_PROVENANCE_METADATA_FIELD: Set[str] = {
     "biosample_set",

--- a/nmdc_runtime/api/endpoints/allowances.py
+++ b/nmdc_runtime/api/endpoints/allowances.py
@@ -9,7 +9,6 @@ from nmdc_runtime.api.endpoints.util import check_action_permitted, strip_oid
 from nmdc_runtime.api.models.user import User, get_current_active_user
 from nmdc_runtime.api.models.allowance import Allowance, AllowanceAction
 
-
 router = APIRouter()
 
 

--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -44,7 +44,6 @@ from nmdc_runtime.api.models.util import (
 )
 from nmdc_runtime.util import duration_logger
 
-
 router = APIRouter()
 
 

--- a/nmdc_runtime/api/endpoints/workflows.py
+++ b/nmdc_runtime/api/endpoints/workflows.py
@@ -41,7 +41,6 @@ from nmdc_schema.nmdc import (
 
 from nmdc_runtime.util import duration_logger
 
-
 router = APIRouter()
 
 

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -69,7 +69,6 @@ from nmdc_runtime.api.swagger_ui.swagger_ui import base_swagger_ui_parameters
 from nmdc_runtime.minter.bootstrap import bootstrap as minter_bootstrap
 from nmdc_runtime.minter.entrypoints.fastapi_app import router as minter_router
 
-
 # If the app is configured to use Sentry, initialize the Sentry SDK now.
 #
 # Note: The FastAPI integration will be automatically enabled, since we list `fastapi`
@@ -464,9 +463,7 @@ def custom_swagger_ui_html(
             banner.classList.add('nmdc-info', 'nmdc-info-banner', 'block', 'col-12');
             banner.innerHTML = `{info_banner_innerhtml.replace('"', '<double-quote>')}`;
             document.querySelector('.information-container').prepend(banner);
-        """.replace(
-            "\n", " "
-        )
+        """.replace("\n", " ")
     swagger_ui_parameters = base_swagger_ui_parameters.copy()
     # Note: The `nmdcInit` JavaScript event is a custom event we use to trigger anything that is listening for it.
     #       Reference: https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -370,6 +370,12 @@ app = FastAPI(
     openapi_tags=ordered_tag_descriptors,
     lifespan=lifespan,
     docs_url=None,
+    # Continue to allow incoming HTTP requests to lack a `Content-Type` header. In FastAPI version
+    # 0.132.0, FastAPI began requiring incoming HTTP requests that include a JSON payload to include
+    # a `Content-Type` header. In order to _not_ break downstream consumers (without adequately
+    # notifying them), we will disable that check (effectively preserving the pre-0.132.0 behavior).
+    # Docs: https://fastapi.tiangolo.com/advanced/strict-content-type/?h=strict#allowing-requests-without-content-type
+    strict_content_type=False,
 )
 app.include_router(api_router)
 

--- a/nmdc_runtime/api/openapi.py
+++ b/nmdc_runtime/api/openapi.py
@@ -27,9 +27,7 @@ class OpenAPITag(str, Enum):
 # Mapping from tag names to their (Markdown-formatted) descriptions.
 tag_descriptions: Dict[str, str] = {}
 
-tag_descriptions[
-    OpenAPITag.METADATA_ACCESS.value
-] = r"""
+tag_descriptions[OpenAPITag.METADATA_ACCESS.value] = r"""
 Retrieve and manage metadata.
 
 The metadata access endpoints fall into several subcategories:
@@ -42,9 +40,7 @@ The metadata access endpoints fall into several subcategories:
 - **JSON operations**: Insert or update metadata by submitting a JSON document representing a [Database](https://w3id.org/nmdc/Database/).
 """
 
-tag_descriptions[
-    OpenAPITag.WORKFLOWS.value
-] = r"""
+tag_descriptions[OpenAPITag.WORKFLOWS.value] = r"""
 Manage workflows and their execution.
 
 The workflow management endpoints fall into several subcategories:
@@ -88,21 +84,15 @@ The workflow management endpoints fall into several subcategories:
     - For off-site job runs, keep the Runtime appraised of run events.
 """
 
-tag_descriptions[
-    OpenAPITag.USERS.value
-] = r"""
+tag_descriptions[OpenAPITag.USERS.value] = r"""
 Create and manage user accounts.
 """
 
-tag_descriptions[
-    OpenAPITag.MINTER.value
-] = r"""
+tag_descriptions[OpenAPITag.MINTER.value] = r"""
 Mint and manage persistent identifiers.
 """
 
-tag_descriptions[
-    OpenAPITag.SYSTEM_ADMINISTRATION.value
-] = r"""
+tag_descriptions[OpenAPITag.SYSTEM_ADMINISTRATION.value] = r"""
 Retrieve information about the software components that make up the Runtime.
 """
 

--- a/nmdc_runtime/site/changesheets/scripts/neon_soils_add_ncbi_ids.py
+++ b/nmdc_runtime/site/changesheets/scripts/neon_soils_add_ncbi_ids.py
@@ -6,6 +6,7 @@ neon_soils_add_ncbi_ids.py: Add NCBI biosample accessions to neon soils
 biosamples, NCBI bioproject accessions to omics processing, and
 NCBI Umbrella bioproject accession to neon soils study.
 """
+
 import logging
 import time
 

--- a/nmdc_runtime/site/normalization/gold.py
+++ b/nmdc_runtime/site/normalization/gold.py
@@ -2,6 +2,7 @@
 """
 gold.py: Provides functions to normalize and validate JGI GOLD data.
 """
+
 import logging
 from typing import Dict, Any
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -111,7 +111,6 @@ from pymongo.database import Database as MongoDatabase
 from pymongo.collection import Collection as MongoCollection
 from toolz import get_in, valfilter, identity
 
-
 # batch size for writing documents to alldocs
 BULK_WRITE_BATCH_SIZE = 2000
 

--- a/nmdc_runtime/site/translation/neon_benthic_translator.py
+++ b/nmdc_runtime/site/translation/neon_benthic_translator.py
@@ -17,7 +17,6 @@ from nmdc_runtime.site.translation.neon_utils import (
     _create_text_value,
 )
 
-
 BENTHIC_BROAD_SCALE_MAPPINGS = {
     "stream": {"term_id": "ENVO:01000253", "term_name": "freshwater river biome"}
 }

--- a/nmdc_runtime/site/translation/neon_surface_water_translator.py
+++ b/nmdc_runtime/site/translation/neon_surface_water_translator.py
@@ -17,7 +17,6 @@ from nmdc_runtime.site.translation.neon_utils import (
     _create_text_value,
 )
 
-
 SURFACE_WATER_BROAD_SCALE_MAPPINGS = {
     "lake": {"term_id": "ENVO:01000252", "term_name": "freshwater lake biome"},
     "river": {"term_id": "ENVO:01000253", "term_name": "freshwater river biome"},

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -17,7 +17,6 @@ from toolz import concat, dissoc, get_in, groupby, valmap
 
 from nmdc_runtime.site.translation.translator import JSON_OBJECT, Translator
 
-
 DataUrlSet = namedtuple("DataUrlSet", ["url", "md5_checksum"])
 
 READ_1 = DataUrlSet("read_1_url", "read_1_md5_checksum")

--- a/nmdc_runtime/site/util.py
+++ b/nmdc_runtime/site/util.py
@@ -8,7 +8,6 @@ from refscan.lib.helpers import get_collection_names_from_schema
 from nmdc_runtime.site.resources import mongo_resource
 from nmdc_runtime.util import nmdc_schema_view
 
-
 mode_test = {
     "resource_defs": {"mongo": mongo_resource}
 }  # Connect to a real MongoDB instance for testing.

--- a/tests/e2e/test_minter_api.py
+++ b/tests/e2e/test_minter_api.py
@@ -1,6 +1,7 @@
-import os
 import pytest
 import requests
+
+from fastapi import status
 
 from nmdc_runtime.api.db.mongo import get_mongo_db
 from nmdc_runtime.minter.config import schema_classes
@@ -66,3 +67,40 @@ def test_minter_api_delete(mint_one_id_response, api_site_client):
         {"id_name": id_name},
     )
     assert rv.status_code == 200
+
+
+def test_mint_id(api_site_client):
+    """Confirm a site client can mint an ID."""
+
+    number_of_ids = 1
+    schema_class_uri = "nmdc:Study"
+    body = {"schema_class": {"id": schema_class_uri}, "how_many": number_of_ids}
+    response = api_site_client.request("POST", "/pids/mint", body)
+    assert response.status_code == status.HTTP_200_OK
+    response_body = response.json()
+    assert isinstance(response_body, list)
+    assert len(response_body) == number_of_ids
+
+
+def test_mint_id_rejects_invalid_typecode(api_site_client):
+    """Confirm a site client cannot mint an ID with an invalid schema class URI."""
+
+    number_of_ids = 1
+    schema_class_uri = "potato"
+    body = {"schema_class": {"id": schema_class_uri}, "how_many": number_of_ids}
+    
+    with pytest.raises(requests.HTTPError) as exc_info:
+        _ = api_site_client.request("POST", "/pids/mint", body)
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_mint_id_rejects_invalid_quantity(api_site_client):
+    """Confirm a site client cannot mint an invalid quantity of IDs."""
+
+    number_of_ids = -1
+    schema_class_uri = "nmdc:Study"
+    body = {"schema_class": {"id": schema_class_uri}, "how_many": number_of_ids}
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        _ = api_site_client.request("POST", "/pids/mint", body)
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/tests/e2e/test_minter_api.py
+++ b/tests/e2e/test_minter_api.py
@@ -88,7 +88,7 @@ def test_mint_id_rejects_invalid_typecode(api_site_client):
     number_of_ids = 1
     schema_class_uri = "potato"
     body = {"schema_class": {"id": schema_class_uri}, "how_many": number_of_ids}
-    
+
     with pytest.raises(requests.HTTPError) as exc_info:
         _ = api_site_client.request("POST", "/pids/mint", body)
     assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I disabled a recently-introduced check (of the `Content-Type` HTTP header) because it was a breaking change for downstream users/clients and we didn't adequately notify those users/clients. The changes on this branch effectively restore the original, [less strict](https://fastapi.tiangolo.com/advanced/strict-content-type/?h=strict#allowing-requests-without-content-type) behavior.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

I do expect to eventually enable the more strict behavior. Indeed, the developers of the NMDC Python Client (one of whom brought this breaking change to my attention) are planning to ensure the HTTP requests sent by that client proactively include the header.

While initially trying to figure out why the minter endpoint suddenly was rejecting HTTP requests that used to "work," I added some basic tests that exercise the endpoint. I have left those in on this branch. They do not modify HTTP headers (we can introduce tests that do that in the future).

The aforementioned changes are in the following two files only:
- `nmdc_runtime/api/main.py`
- `tests/e2e/test_minter_api.py`

A GHA workflow added a commit that reformats a bunch of other files. I think the reason it touched so many files is that this is the first Python-related PR to have been created since `black` was updated a few days ago by Dependabot. I assume the new version of `black` has slightly different formatting rules, and that this is the first time they've been applied to the repo.

I recommend reviewers review only `nmdc_runtime/api/main.py`.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1478 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Runtime API (except the Minter)
- [x] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by doing A/B/A testing with `curl`. Testing via Swagger UI was insufficient because it _always_ includes that header.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
