### PR TITLE
Rename `--migrator-git-tag` to `--migrator-git-ref` and simplify `--help` output

### DIFF
--- a/db/migrations/cli/src/nmdc_migration_cli/lib/config.py
+++ b/db/migrations/cli/src/nmdc_migration_cli/lib/config.py
@@ -10,10 +10,11 @@ from typing import Iterator
 
 import typer
 
-# Note: These are basically "sentinel" values that users can specify for the `migrator_git_tag`
-#       parameter to get special behavior. Ensure each one begins with a hyphen, since I don't
-#       think Git, itself, would allow a tag to begin with a hyphen.
-RESERVED_GIT_TAGS: dict[str, str] = {
+# Note: These are basically "sentinel" values that users can specify for the `migrator_git_ref`
+#       parameter to get special behavior. Ensure each one begins with a hyphen, since branch names
+#       and tag names cannot start with a hyphen, and commit SHA hashes cannot contain hyphens.
+#       Reference: https://git-scm.com/docs/git-check-ref-format
+RESERVED_GIT_REFS: dict[str, str] = {
     "-INSTALLED": (
         "Use the nmdc-schema package already installed in the Python environment "
         "(useful for rapid development and avoiding rate limiting by the Git repository host)."
@@ -21,9 +22,9 @@ RESERVED_GIT_TAGS: dict[str, str] = {
 }
 
 
-def get_reserved_git_tags_help_snippet() -> str:
-    """Get a help snippet describing the reserved Git tags."""
-    return ", ".join(f"'{tag}': {description}" for tag, description in RESERVED_GIT_TAGS.items())
+def get_reserved_git_refs_help_snippet() -> str:
+    """Get a help snippet describing the reserved Git refs."""
+    return ", ".join(f"'{ref}': {description}" for ref, description in RESERVED_GIT_REFS.items())
 
 
 class ParamValidators:
@@ -310,7 +311,7 @@ class MigrationConfig:
     mongorestore_path: Path
     origin_mongo_database_config: DatabaseConfig
     transformer_mongo_database_config: DatabaseConfig
-    migrator_git_tag: str
+    migrator_git_ref: str
     migrator_module_name: str
     schema_repo_url: str
     collection_names: list[str]

--- a/db/migrations/cli/src/nmdc_migration_cli/main.py
+++ b/db/migrations/cli/src/nmdc_migration_cli/main.py
@@ -314,7 +314,6 @@ def migrate(
     show_diff: Annotated[
         bool,
         typer.Option(
-            "--show-diff",  # we explicitly state this, so Typer doesn't also display `--no-show-diff` (which is redundant with the default value)
             envvar="SHOW_DIFF",
             help="Whether to show a before-and-after-migration diff of the specified collections.",
         ),
@@ -322,7 +321,6 @@ def migrate(
     skip_origin_writes: Annotated[
         bool,
         typer.Option(
-            "--skip-origin-writes",  # we explicitly state this, so Typer doesn't also display `--no-origin-writes` (which is redundant with the default value)
             envvar="SKIP_ORIGIN_WRITES",
             help="When set, the app won't make [bold]any[/bold] changes to the origin MongoDB server (e.g. no revoking/restoring user access, no persisting transformed data) and, therefore, does not require write access to it.",
         ),

--- a/db/migrations/cli/src/nmdc_migration_cli/main.py
+++ b/db/migrations/cli/src/nmdc_migration_cli/main.py
@@ -85,18 +85,23 @@ def migrate(
             envvar="MIGRATOR_GIT_REF",
             help=(
                 "Git branch name, tag name, or commit hash of nmdc-schema, containing the migrator "
-                "you want to run (e.g., 'main', 'v1.0.0')."
+                "you want to run (e.g., 'main', 'v1.0.0'). "
                 f"Special values: {get_reserved_git_refs_help_snippet()}"
             ),
             rich_help_panel=RichHelpPanelName.MIGRATOR.value,
+            show_default=False,
         ),
     ],
     migrator_module_name: Annotated[
         str,
         typer.Option(
             envvar="MIGRATOR_MODULE_NAME",
-            help="Name of the Python module that constitutes the migrator you want to run.",
+            help=(
+                "Name of the Python module that constitutes the migrator you want to run "
+                "(e.g. 'migrator_from_1_0_0_to_2_0_0')."
+            ),
             rich_help_panel=RichHelpPanelName.MIGRATOR.value,
+            show_default=False,
         ),
     ],
     collection_names: Annotated[
@@ -108,6 +113,7 @@ def migrate(
             help="Names of MongoDB collections to migrate. You can specify this option multiple times, or populate the environment variable with a space-delimited list of names.",
             callback=ParamValidators.validate_collection_names,
             rich_help_panel=RichHelpPanelName.MIGRATOR.value,
+            show_default=False,
         ),
     ],
     origin_mongo_host: Annotated[
@@ -116,6 +122,7 @@ def migrate(
             envvar="ORIGIN_MONGO_HOST",
             help="Hostname for the origin MongoDB server.",
             rich_help_panel=RichHelpPanelName.ORIGIN_DATABASE.value,
+            show_default=False,
         ),
     ],
     origin_mongo_port: Annotated[
@@ -307,6 +314,7 @@ def migrate(
     show_diff: Annotated[
         bool,
         typer.Option(
+            "--show-diff",  # we explicitly state this, so Typer doesn't also display `--no-show-diff` (which is redundant with the default value)
             envvar="SHOW_DIFF",
             help="Whether to show a before-and-after-migration diff of the specified collections.",
         ),
@@ -314,6 +322,7 @@ def migrate(
     skip_origin_writes: Annotated[
         bool,
         typer.Option(
+            "--skip-origin-writes",  # we explicitly state this, so Typer doesn't also display `--no-origin-writes` (which is redundant with the default value)
             envvar="SKIP_ORIGIN_WRITES",
             help="When set, the app won't make [bold]any[/bold] changes to the origin MongoDB server (e.g. no revoking/restoring user access, no persisting transformed data) and, therefore, does not require write access to it.",
         ),

--- a/db/migrations/cli/src/nmdc_migration_cli/main.py
+++ b/db/migrations/cli/src/nmdc_migration_cli/main.py
@@ -13,11 +13,11 @@ from mongo_diff.mongo_diff import Comparator
 
 from nmdc_migration_cli.lib.bookkeeping import Bookkeeper, MigrationEvent
 from nmdc_migration_cli.lib.config import (
-    RESERVED_GIT_TAGS,
+    RESERVED_GIT_REFS,
     DatabaseConfig,
     MigrationConfig,
     ParamValidators,
-    get_reserved_git_tags_help_snippet,
+    get_reserved_git_refs_help_snippet,
 )
 from nmdc_migration_cli.lib.display import (
     make_progress_indicator_for_bounded_task,
@@ -79,13 +79,14 @@ class RichHelpPanelName(Enum):
 
 @app.command()
 def migrate(
-    migrator_git_tag: Annotated[
+    migrator_git_ref: Annotated[
         str,
         typer.Option(
-            envvar="MIGRATOR_GIT_TAG",
+            envvar="MIGRATOR_GIT_REF",
             help=(
-                "Git tag of an nmdc-schema commit containing the migrator you want to run. "
-                f"Special values: {get_reserved_git_tags_help_snippet()}"
+                "Git branch name, tag name, or commit hash of nmdc-schema, containing the migrator "
+                "you want to run (e.g., 'main', 'v1.0.0')."
+                f"Special values: {get_reserved_git_refs_help_snippet()}"
             ),
             rich_help_panel=RichHelpPanelName.MIGRATOR.value,
         ),
@@ -365,7 +366,7 @@ def migrate(
         mongorestore_path=mongorestore_path,
         origin_mongo_database_config=origin_mongo_database_config,
         transformer_mongo_database_config=transformer_mongo_database_config,
-        migrator_git_tag=migrator_git_tag,
+        migrator_git_ref=migrator_git_ref,
         migrator_module_name=migrator_module_name,
         schema_repo_url=schema_repo_url,
         collection_names=collection_names,
@@ -459,15 +460,17 @@ def migrate(
             )
 
     # Use pip to install the `nmdc-schema` version specified by the user.
-    if cfg.migrator_git_tag in RESERVED_GIT_TAGS.keys():
-        if cfg.migrator_git_tag == "-INSTALLED":
+    if cfg.migrator_git_ref in RESERVED_GIT_REFS.keys():
+        if cfg.migrator_git_ref == "-INSTALLED":
             print(f"Using the currently-installed nmdc-schema package: {version('nmdc_schema')}")
         else:
-            # If execution gets here, it means a developer introduced a new reserved Git tag into
-            # the `RESERVED_GIT_TAGS` dictionary, but did not update these conditions accordingly.
-            raise typer.BadParameter(f"Unsupported reserved Git tag: {cfg.migrator_git_tag}")
+            # If execution gets here, it means a developer introduced a new item into the
+            # `RESERVED_GIT_REFS` dictionary, but did not update these conditions accordingly.
+            raise typer.BadParameter(f"Unsupported reserved Git ref: {cfg.migrator_git_ref}")
     else:
-        package_identifier = f"{cfg.schema_repo_url}@{cfg.migrator_git_tag}"
+        # Build a `pip install`-compatible package identifier for the `nmdc-schema` package.
+        # Reference: https://pip.pypa.io/en/stable/topics/vcs-support/#git
+        package_identifier = f"{cfg.schema_repo_url}@{cfg.migrator_git_ref}"
         ensure_pip_is_available(sys.executable)
         command_parts = [sys.executable, "-m", "pip", "install", f"git+{package_identifier}"]
         run_subprocess_with_live_display(


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I renamed the `--migrator-git-tag` CLI option to `--migrator-git-ref` and refine other `--help` output (of the `nmdc-migration-cli` app).

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

See diff for details.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1518 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [x] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by viewing the `--help` output locally.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
