### PR TITLE
Disambiguate `NucleotideSequencing` names for multi-run `dnaSampleIDs` in NEON soil translator

### DIFF
--- a/nmdc_runtime/site/translation/neon_soil_translator.py
+++ b/nmdc_runtime/site/translation/neon_soil_translator.py
@@ -390,6 +390,7 @@ class NeonSoilDataTranslator(Translator):
         processed_sample_id: str,
         raw_data_file_data: str,
         nucleotide_sequencing_row: pd.DataFrame,
+        run_label: Optional[str] = None,
     ):
         """Create nmdc NucleotideSequencing object. This class typically models the run of a
         Bioinformatics workflow on sequence data from a biosample. The input to an NucleotideSequencing
@@ -402,6 +403,9 @@ class NeonSoilDataTranslator(Translator):
         files embedded in them.
         :param nucleotide_sequencing_row: DataFrame with metadata for an NucleotideSequencing workflow
         process/run.
+        :param run_label: Optional run basename (e.g. ``BMI_HFWLLBGX7_Plate67WellB2``) appended in
+        parentheses to the object's ``name`` to disambiguate records when one ``dnaSampleID`` is sequenced
+        across multiple runs. Defaults to ``None`` for single-run samples, leaving the name unchanged.
         :return: NucleotideSequencing object that models a Bioinformatics workflow process/run.
         """
         processing_institution = None
@@ -425,7 +429,11 @@ class NeonSoilDataTranslator(Translator):
             instrument_used=self._get_instrument_id(
                 _get_value_or_none(nucleotide_sequencing_row, "instrument_model")
             ),
-            name=f"Terrestrial soil microbial communities - {_get_value_or_none(nucleotide_sequencing_row, 'dnaSampleID')}",
+            name=(
+                "Terrestrial soil microbial communities - "
+                f"{_get_value_or_none(nucleotide_sequencing_row, 'dnaSampleID')}"
+                + (f" ({run_label})" if run_label else "")
+            ),
             type="nmdc:NucleotideSequencing",
             associated_studies=["nmdc:sty-11-34xj1150"],
             analyte_category="metagenome",
@@ -721,7 +729,9 @@ class NeonSoilDataTranslator(Translator):
         # NucleotideSequencing record per pair of corresponding R1/R2 files.
         # Pairing is done by filename basename (not full URL path) because
         # R1 and R2 files live in different directories.
-        dna_sample_file_pairs: dict[str, list[tuple[Optional[str], Optional[str]]]] = {}
+        dna_sample_file_pairs: dict[
+            str, list[tuple[str, Optional[str], Optional[str]]]
+        ] = {}
         for dna_sample_id, filepaths in neon_raw_data_files_dict.items():
             pairs: dict[str, dict[str, str]] = {}
             for fp in filepaths:
@@ -732,8 +742,11 @@ class NeonSoilDataTranslator(Translator):
                 elif "_R2.fastq.gz" in filename:
                     base = filename.rsplit("_R2.fastq.gz", 1)[0]
                     pairs.setdefault(base, {})["R2"] = fp
+            # Keep the per-run basename (e.g. BMI_HFWLLBGX7_Plate67WellB2) so a
+            # multi-run dnaSampleID's NucleotideSequencing names can be
+            # disambiguated by run (see the name= in _translate_nucleotide_sequencing).
             dna_sample_file_pairs[dna_sample_id] = [
-                (p.get("R1"), p.get("R2")) for p in pairs.values()
+                (base, p.get("R1"), p.get("R2")) for base, p in pairs.items()
             ]
 
         # Build a flat list of (dnaSampleID, pair_index) keys for minting
@@ -916,7 +929,11 @@ class NeonSoilDataTranslator(Translator):
                             )
                         )
                 else:
-                    for pair_idx, (r1_path, r2_path) in enumerate(pairs):
+                    # When a dnaSampleID was sequenced on more than one run, tag
+                    # each NucleotideSequencing name with its run basename so the
+                    # records are distinguishable (single-run names are unchanged).
+                    multi_run = len(pairs) > 1
+                    for pair_idx, (run_base, r1_path, r2_path) in enumerate(pairs):
                         ntseq_id = ntseq_pair_to_id.get((dna_sample_id, pair_idx))
                         if not ntseq_id:
                             continue
@@ -934,6 +951,7 @@ class NeonSoilDataTranslator(Translator):
                                 processed_sample_id,
                                 has_output_do_ids,
                                 library_preparation_row,
+                                run_label=run_base if multi_run else None,
                             )
                         )
 

--- a/tests/test_data/test_neon_soil_data_translator.py
+++ b/tests/test_data/test_neon_soil_data_translator.py
@@ -9,7 +9,6 @@ from nmdc_runtime.site.translation.neon_utils import (
 )
 import pandas as pd
 
-
 # Mock data for testing
 mms_data = {
     "mms_metagenomeDnaExtraction": pd.DataFrame(
@@ -795,6 +794,19 @@ BLAN_005-M-20200713-COMP-DNA1\tHVT2HBGXJ\t20S_08_0661\tBMI_HVT2HBGXJ_20S_08_0661
     return pd.read_csv(StringIO(tsv_data_dna), delimiter="\t")
 
 
+def neon_raw_data_file_mappings_file_multi_run():
+    """Same BLAN_005 sample as the single-run fixture, but sequenced on two
+    runs (HVT2HBGXJ and HABCDBGXJ) — exercises the multi-run NucleotideSequencing
+    name disambiguation and Manifest creation."""
+    tsv_data_dna = """dnaSampleID\tsequencerRunID\tinternalLabID\trawDataFileName\trawDataFileDescription\trawDataFilePath\tcheckSum
+BLAN_005-M-20200713-COMP-DNA1\tHVT2HBGXJ\t20S_08_0661\tBMI_HVT2HBGXJ_20S_08_0661_R1.fastq.gz\tR1 metagenomic archive of fastq files\thttps://storage.neonscience.org/neon-microbial-raw-seq-files/2021/BMI_HVT2HBGXJ_mms_R1/BMI_HVT2HBGXJ_20S_08_0661_R1.fastq.gz\t8b5794e91b1e79e02f1a3e7ef53a73b3
+BLAN_005-M-20200713-COMP-DNA1\tHVT2HBGXJ\t20S_08_0661\tBMI_HVT2HBGXJ_20S_08_0661_R2.fastq.gz\tR2 metagenomic archive of fastq files\thttps://storage.neonscience.org/neon-microbial-raw-seq-files/2021/BMI_HVT2HBGXJ_mms_R2/BMI_HVT2HBGXJ_20S_08_0661_R2.fastq.gz\t44dc66147143a6eb1e806defa7f3706e
+BLAN_005-M-20200713-COMP-DNA1\tHABCDBGXJ\t20S_08_0661\tBMI_HABCDBGXJ_20S_08_0661_R1.fastq.gz\tR1 metagenomic archive of fastq files\thttps://storage.neonscience.org/neon-microbial-raw-seq-files/2021/BMI_HABCDBGXJ_mms_R1/BMI_HABCDBGXJ_20S_08_0661_R1.fastq.gz\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+BLAN_005-M-20200713-COMP-DNA1\tHABCDBGXJ\t20S_08_0661\tBMI_HABCDBGXJ_20S_08_0661_R2.fastq.gz\tR2 metagenomic archive of fastq files\thttps://storage.neonscience.org/neon-microbial-raw-seq-files/2021/BMI_HABCDBGXJ_mms_R2/BMI_HABCDBGXJ_20S_08_0661_R2.fastq.gz\tbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"""
+
+    return pd.read_csv(StringIO(tsv_data_dna), delimiter="\t")
+
+
 mock_gold_nmdc_instrument_map_df = pd.DataFrame(
     {
         "NEON sequencingMethod": [
@@ -824,6 +836,47 @@ class TestNeonDataTranslator:
             site_code_mapping=site_code_mapping(),
             neon_nmdc_instrument_map_df=mock_gold_nmdc_instrument_map_df,
             id_minter=test_minter,
+        )
+
+    def test_multi_run_nucleotide_sequencing_names(self, test_minter):
+        """A dnaSampleID sequenced on >1 run gets one NucleotideSequencing per
+        run, each name disambiguated with its run basename, plus a
+        poolable_replicates Manifest. Single-run naming is covered by
+        test_neon_soil_data_translator (BLAN_005, untagged)."""
+        translator = NeonSoilDataTranslator(
+            mms_data=mms_data,
+            sls_data=sls_data,
+            neon_envo_mappings_file=neon_envo_mappings_file(),
+            neon_raw_data_file_mappings_file=neon_raw_data_file_mappings_file_multi_run(),
+            site_code_mapping=site_code_mapping(),
+            neon_nmdc_instrument_map_df=mock_gold_nmdc_instrument_map_df,
+            id_minter=test_minter,
+        )
+        database = translator.get_database()
+
+        nuc_seqs = [
+            d
+            for d in database.data_generation_set
+            if d["type"] == "nmdc:NucleotideSequencing"
+        ]
+        # One NucleotideSequencing per run, each name tagged with its run base.
+        assert sorted(d["name"] for d in nuc_seqs) == [
+            "Terrestrial soil microbial communities - BLAN_005-M-20200713-COMP-DNA1 (BMI_HABCDBGXJ_20S_08_0661)",
+            "Terrestrial soil microbial communities - BLAN_005-M-20200713-COMP-DNA1 (BMI_HVT2HBGXJ_20S_08_0661)",
+        ]
+        # Each run carries its own R1/R2 DataObject pair.
+        for d in nuc_seqs:
+            assert len(d["has_output"]) == 2
+
+        # Multi-run => a poolable_replicates Manifest, and every raw DataObject
+        # points at it.
+        assert len(database.manifest_set) == 1
+        assert "poolable_replicates" in str(
+            database.manifest_set[0]["manifest_category"]
+        )
+        manifest_id = database.manifest_set[0]["id"]
+        assert all(
+            do["in_manifest"] == [manifest_id] for do in database.data_object_set
         )
 
     def test_missing_mms_table(self, test_minter):


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

When a single `dnaSampleID` from one of the NEON studies (say NEON soil study) is sequenced across more than one run, the translator generates multiple `NucleotideSequencing` (data generation) records that all shared the same `name` (`Terrestrial soil microbial communities - <dnaSampleID>`), making them indistinguishable to downstream consumers.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

In this PR, we are proposing to track the per-run file basename (e.g. `BMI_HFWLLBGX7_Plate67WellB2`) alongside each R1/R2 file pair and thread it into `_translate_nucleotide_sequencing()` via a new optional `run_label` parameter. When a `dnaSampleID` has multiple runs, the run basename is appended in parentheses to the record's `name`. Single-run samples will remain unaffected.

This PR was motivated by some of the changes in https://github.com/microbiomedata/issues/issues/1740 and https://github.com/microbiomedata/issues/issues/1755 where we followed the same naming scheme/syntax to disambiguate samples with more than one sequencing runs.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Compatibility with https://github.com/microbiomedata/issues/issues/1755

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by writing a unit test in the NEON translator test suite called `neon_raw_data_file_mappings_file_multi_run()`

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
