### PR TITLE
Fix pytest warnings emanating from first-party `nmdc-runtime` code

### DIFF
--- a/nmdc_runtime/api/core/metadata.py
+++ b/nmdc_runtime/api/core/metadata.py
@@ -786,7 +786,7 @@ def _validate_changesheet(df_change: pd.DataFrame, mdb: MongoDatabase):
 
     if validation_errors:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={
                 "update_cmd": rv["update_cmd"],
                 "validation_errors": validation_errors,

--- a/nmdc_runtime/api/endpoints/find.py
+++ b/nmdc_runtime/api/endpoints/find.py
@@ -163,7 +163,7 @@ def get_data_object_report(
     prefix: str = Query(
         "",
         description="A prefix, if any, a URL must begin with in order to be included in the report",
-        example="https://data.microbiomedata.org",
+        examples=["https://data.microbiomedata.org"],
     ),
 ):
     if not is_admin(user):

--- a/nmdc_runtime/api/endpoints/jobs.py
+++ b/nmdc_runtime/api/endpoints/jobs.py
@@ -93,7 +93,7 @@ def create_job(
         error_message = f"Invalid job. Details: {str(e)}"
         logging.warning(error_message)
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=error_message,
         )
 

--- a/nmdc_runtime/api/endpoints/metadata.py
+++ b/nmdc_runtime/api/endpoints/metadata.py
@@ -191,7 +191,7 @@ async def submit_json_nmdcdb(
     rv = validate_json(docs, mdb, check_inter_document_references=True)
     if rv["result"] == "errors":
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(rv),
         )
 

--- a/nmdc_runtime/api/endpoints/nmdcschema.py
+++ b/nmdc_runtime/api/endpoints/nmdcschema.py
@@ -531,5 +531,5 @@ def get_from_collection_by_id(
         )
     except pymongo.errors.OperationFailure as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)
         )

--- a/nmdc_runtime/api/endpoints/queries.py
+++ b/nmdc_runtime/api/endpoints/queries.py
@@ -283,7 +283,7 @@ def _run_mdb_cmd(
         collection_name = cmd.delete
         if collection_name not in get_nonempty_nmdc_schema_collection_names(mdb):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
                     "Can only delete documents from collections that are "
                     "not empty and are described by the NMDC schema."
@@ -370,7 +370,7 @@ def _run_mdb_cmd(
                         #       would increase the response size (consider the case where the
                         #       user-specified filter matches many, many documents).
                         raise HTTPException(
-                            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                             detail=(
                                 f"The operation was not performed, because performing it would "
                                 f"have left behind one or more broken references. For example: "
@@ -403,7 +403,7 @@ def _run_mdb_cmd(
         for update_statement in cmd.updates:
             if not any(k.startswith("$") for k in update_statement.u.keys()):
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail=(
                         "Updates must be specified via operations documents "
                         "(e.g., {“$set”: {“field”: “newValue”}}). "
@@ -419,7 +419,7 @@ def _run_mdb_cmd(
         collection_name = cmd.update
         if collection_name not in get_nonempty_nmdc_schema_collection_names(mdb):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
                     "Can only update documents in collections that are "
                     "not empty and are described by the NMDC schema."
@@ -459,7 +459,7 @@ def _run_mdb_cmd(
             )
             if rv["result"] == "errors":
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail=f"Schema document(s) would be invalid after proposed update: {rv['detail']}",
                 )
 
@@ -482,7 +482,7 @@ def _run_mdb_cmd(
                 logging.warning(detail)
             else:
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail=detail,
                 )
 
@@ -544,7 +544,7 @@ def _run_mdb_cmd(
             cmd = AggregateCommand(**modified_cmd_doc)
         else:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="The specified 'getMore' value resolved to an invalid command.",
             )
 
@@ -602,7 +602,7 @@ def _run_mdb_cmd(
             and len(cmd_response.writeErrors) > 0
         ):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=cmd_response.writeErrors,
             )
 
@@ -723,7 +723,7 @@ def _run_delete_nonschema(
     # Handle write errors if any occurred
     if isinstance(cmd_response.writeErrors, list) and len(cmd_response.writeErrors) > 0:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=cmd_response.writeErrors,
         )
 

--- a/nmdc_runtime/api/endpoints/util.py
+++ b/nmdc_runtime/api/endpoints/util.py
@@ -79,14 +79,14 @@ def check_filter(filter_: str):
     filter_ = filter_.strip()
     if not filter_.startswith("{") or not filter_.endswith("}"):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"The given `filter` is not a valid JSON object, which must start with '{{' and end with '}}'.",
         )
     try:
         json_util.loads(filter_)
     except JSONDecodeError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Given `filter` is not valid JSON: {e}",
         )
     return filter_

--- a/nmdc_runtime/api/endpoints/workflows.py
+++ b/nmdc_runtime/api/endpoints/workflows.py
@@ -195,7 +195,7 @@ async def post_workflow_execution(
             or "workflow_execution_set" not in database_in
         ):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
                     "Request payload must represent a valid 'nmdc:Database' instance "
                     "that includes a 'workflow_execution_set' collection. "
@@ -225,7 +225,7 @@ async def post_workflow_execution(
                         )
                         if run_number is None:
                             raise HTTPException(
-                                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                                 detail=(
                                     f"The ID of WorkflowExecution '{submitted_wfe_id}' is not in the "
                                     "format required by our supersession management processes."

--- a/nmdc_runtime/minter/entrypoints/fastapi_app.py
+++ b/nmdc_runtime/minter/entrypoints/fastapi_app.py
@@ -53,7 +53,7 @@ def mint_ids(
         return [d.id for d in minted]
     except MinterError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)
         )
 
     except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,16 @@ docs = [
     "mkdocs-mermaid2-plugin",
 ]
 
+[tool.uv]
+# Note: This parameter allows us to define dependency version constraints,
+#       without making the package a direct depdendency of our project.
+build-constraint-dependencies = [
+    # Ensure that, _if_ uv installs `starlette`, it installs a version newer than `0.48.0`
+    # (which is where `status.HTTP_422_UNPROCESSABLE_CONTENT` was introduced).
+    # Reference: https://github.com/Kludex/starlette/pull/2939
+    "starlette >= 0.48.0",
+]
+
 [project.urls]
 # > "A list of URLs associated with your project, displayed on the left sidebar of your PyPI project page."
 # Source: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

--- a/tests/e2e/test_minter_api.py
+++ b/tests/e2e/test_minter_api.py
@@ -91,7 +91,7 @@ def test_mint_id_rejects_invalid_typecode(api_site_client):
 
     with pytest.raises(requests.HTTPError) as exc_info:
         _ = api_site_client.request("POST", "/pids/mint", body)
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_mint_id_rejects_invalid_quantity(api_site_client):
@@ -103,4 +103,4 @@ def test_mint_id_rejects_invalid_quantity(api_site_client):
 
     with pytest.raises(requests.HTTPError) as exc_info:
         _ = api_site_client.request("POST", "/pids/mint", body)
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/tests/test_api/test_allowances.py
+++ b/tests/test_api/test_allowances.py
@@ -276,4 +276,4 @@ def test_delete_allowance_missing_parameters(api_user_client):
             "/admin/allowances?username=user_1"
         )
 
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/tests/test_api/test_create_workflow_execution.py
+++ b/tests/test_api/test_create_workflow_execution.py
@@ -283,7 +283,7 @@ class TestPostWorkflowWorkflowExecutions:
                     {"workflow_execution_set": [workflow_execution]},
                 )
             response = exc.value.response
-            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
             # Assert that the "detail" property of the response payload contains the words "errors",
             # "workflow_execution_set" (i.e. the problematic collection), and "was_informed_by"

--- a/tests/test_api/test_endpoints.py
+++ b/tests/test_api/test_endpoints.py
@@ -248,7 +248,7 @@ def test_queries_run_invalid_update(api_user_client):
             }
         ]
     }
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     assert exc_info.value.response.json() == expected_response
 
     # test incorrect delete
@@ -348,7 +348,7 @@ def test_queries_run_invalid_update(api_user_client):
             },
         ]
     }
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     assert exc_info.value.response.json() == expected_response
 
     # 🧹 Clean up.
@@ -513,7 +513,7 @@ def test_metadata_json_submit_rejects_document_containing_broken_reference(
             {"study_set": [my_study]},
         )
     response = exc.value.response
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Assert that the "detail" property of the response payload contains the words "errors",
     # "study_set" (i.e. the problematic collection), and "part_of" (i.e. the problematic field).
@@ -580,7 +580,7 @@ def test_json_submit_rejects_payload_introducing_biosample_having_duplicate_name
                 {"biosample_set": [biosample_b]},
             )
         response = exc.value.response
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
         # Assert that the biosample_set collection does not contain the biosample we submitted.
         assert biosample_set.count_documents({"id": biosample_b["id"]}) == 0
@@ -602,7 +602,7 @@ def test_json_submit_rejects_payload_introducing_biosample_having_duplicate_name
                 {"biosample_set": [biosample_b, biosample_c]},
             )
         response = exc.value.response
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
         # Assert that the biosample_set collection does not contain the biosample we submitted.
         assert biosample_set.count_documents(
@@ -1761,7 +1761,7 @@ def test_queries_run_rejects_update_containing_replacement_document(api_user_cli
                     "updates": [an_update_statement_containing_replacement_document],
                 },
             )
-        assert excinfo.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert excinfo.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     finally:
         if did_insert_allowance:
             allowances_collection.delete_many(allow_spec)
@@ -1967,7 +1967,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(
                 ],
             },
         )
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Case 2: We cannot delete Study B because Biosample B is referencing it.
     with pytest.raises(requests.HTTPError) as exc_info:
@@ -1984,7 +1984,7 @@ def test_queries_run_rejects_deletions_that_would_leave_broken_references(
                 ],
             },
         )
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Case 3: We can delete both Biosample A and Biosample B because nothing is referencing them.
     response = api_user_client.request(
@@ -2053,7 +2053,7 @@ def test_queries_run_allows_ref_breaking_deletions_when_user_opts_to_allow_broke
                 ],
             },
         )
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Case 2: We can do it if we opt out of the referential integrity checks.
     response = api_user_client.request(
@@ -2110,7 +2110,7 @@ def test_queries_run_rejects_updates_that_would_leave_broken_references(
                 ],
             },
         )
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     response_body = exc_info.value.response.json()
     assert "study_set" in response_body["detail"]
 
@@ -2147,7 +2147,7 @@ def test_queries_run_allows_ref_breaking_updates_when_user_opts_to_allow_broken_
                 ],
             },
         )
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     response_body = exc_info.value.response.json()
     assert "study_set" in response_body["detail"]
 
@@ -3542,7 +3542,7 @@ def test_create_invalid_job(api_site_client):
     # Send the dictionary as JSON to the API endpoint to create a new job.
     with pytest.raises(requests.HTTPError) as exc_info:
         _ = api_site_client.request("POST", "/jobs", invalid_job)
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Verify no job was created.
     assert jobs_collection.count_documents({}) == num_jobs_initial

--- a/tests/test_api/test_site_clients.py
+++ b/tests/test_api/test_site_clients.py
@@ -106,7 +106,7 @@ def test_update_site_client_secret(
             f"/admin/site_clients/{site_client_id}",
             {"secret": "2short"},
         )
-    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Test: When the secret is updated successfully, we get an HTTP 200.
     new_secret = "my_new_secret!"

--- a/uv.lock
+++ b/uv.lock
@@ -1422,6 +1422,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -5628,14 +5629,14 @@ wheels = [
 
 [[package]]
 name = "url-normalize"
-version = "2.2.1"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/31/febb777441e5fcdaacb4522316bf2a527c44551430a4873b052d545e3279/url_normalize-2.2.1.tar.gz", hash = "sha256:74a540a3b6eba1d95bdc610c24f2c0141639f3ba903501e61a52a8730247ff37", size = 18846, upload-time = "2025-04-26T20:37:58.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/cd/846d87d6d49d963b04ef4429b73d71d3c17468059956bab360866a9b0aec/url_normalize-3.0.0.tar.gz", hash = "sha256:0552cbf2831a32a28994a13d29bca58a60e10ff6c0380e343ec6d1c2a0d232d8", size = 21777, upload-time = "2026-04-25T00:31:59.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/d9/5ec15501b675f7bc07c5d16aa70d8d778b12375686b6efd47656efdc67cd/url_normalize-2.2.1-py3-none-any.whl", hash = "sha256:3deb687587dc91f7b25c9ae5162ffc0f057ae85d22b1e15cf5698311247f567b", size = 14728, upload-time = "2025-04-26T20:37:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/13/8a/f72344eab18674fd7b174f35abbce41ed88fea72927f111726732d0ca779/url_normalize-3.0.0-py3-none-any.whl", hash = "sha256:95234bd359f86831c1fd87c248877f2a6887db2f3b5087120083f2fffcba4889", size = 16854, upload-time = "2026-04-25T00:31:58.271Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+build-constraints = [{ name = "starlette", specifier = ">=0.48.0" }]
+
 [[package]]
 name = "airium"
 version = "0.2.6"
@@ -1422,7 +1425,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I updated some code that used deprecated things so that they no longer use deprecated things. That made it so the `pytest` output no longer contains certain warnings.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

The `pytest` output still contains some warnings, but all of them are coming from dependencies. This PR fixes the ones that were comes from our own code.

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1415 

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [x] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by running `pytest` and checking the warnings that do/don't appear.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
