### PR TITLE
Handle new Isolate tab data in Submission Portal translator

### DIFF
--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -194,13 +194,24 @@ def ensure_allowance_is_indexed():
     )
 
 
-def ensure_biosample_set_has_unique_compound_index_on_name_and_associated_studies():
+def ensure_sample_sets_have_unique_compound_index_on_name_and_associated_studies():
     """
     Ensures that there is a compound index on (name, associated_studies) in the `biosample_set`
-    collection; so that no two biosamples associated with the same study can have the same name.
+    and `organism_sample_set` collections; so that no two biosamples or two organism samples
+    associated with the same study can have the same name.
+
+    Note: this does **not** prevent a biosample and an organism sample from having the same name if
+    they are associated with the same study, since they are in different collections. It is an open
+    task to enforce that constraint across those collections (and also possibly the
+    `processed_sample_set` collection) in application code.
     """
     mdb = get_mongo_db()
     mdb["biosample_set"].create_index(
+        [("name", 1), ("associated_studies", 1)],
+        background=True,
+        unique=True,
+    )
+    mdb["organism_sample_set"].create_index(
         [("name", 1), ("associated_studies", 1)],
         background=True,
         unique=True,
@@ -301,7 +312,7 @@ async def lifespan(app: FastAPI):
     ensure_sequencing_project_name_is_indexed()
     ensure_jgi_samples_id_is_indexed()
     ensure_allowance_is_indexed()
-    ensure_biosample_set_has_unique_compound_index_on_name_and_associated_studies()
+    ensure_sample_sets_have_unique_compound_index_on_name_and_associated_studies()
 
     # Invoke a function—thereby priming its memoization cache—in order to speed up all future invocations.
     get_allowed_references()  # we ignore the return value here

--- a/nmdc_runtime/api/main.py
+++ b/nmdc_runtime/api/main.py
@@ -200,10 +200,10 @@ def ensure_sample_sets_have_unique_compound_index_on_name_and_associated_studies
     and `organism_sample_set` collections; so that no two biosamples or two organism samples
     associated with the same study can have the same name.
 
-    Note: this does **not** prevent a biosample and an organism sample from having the same name if
-    they are associated with the same study, since they are in different collections. It is an open
-    task to enforce that constraint across those collections (and also possibly the
-    `processed_sample_set` collection) in application code.
+    Note: this does **not** prevent a biosample and an organism sample from having the same name
+    if they are associated with the same study, since they are in different collections. There is
+    an outstanding task to enforce that constraint across those collections (and also possibly
+    the `processed_sample_set` collection) in application code.
     """
     mdb = get_mongo_db()
     mdb["biosample_set"].create_index(

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -817,7 +817,7 @@ class SubmissionPortalTranslator(Translator):
 
         # Automatically populate the `env_package` field in the sample data based on which
         # environmental data tab the sample data came from.
-        sample_data = metadata_submission_data.get("sampleData", {})
+        sample_data = get_in(["sampleData", "data"], metadata_submission_data, default={})
         for key in sample_data.keys():
             env = key.removesuffix("_data").upper()
             try:

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1079,8 +1079,8 @@ class SubmissionPortalTranslator(Translator):
                 isolation = nmdc.Isolation(
                     id=self._id_minter("nmdc:Isolation")[0],
                     type="nmdc:Isolation",
-                    has_input=sample_data_to_nmdc_biosample_ids[sample_link],
-                    has_output=nmdc_organism_sample_id,
+                    has_input=[sample_data_to_nmdc_biosample_ids[sample_link]],
+                    has_output=[nmdc_organism_sample_id],
                 )
                 database.material_processing_set.append(isolation)
 

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -648,7 +648,21 @@ class SubmissionPortalTranslator(Translator):
         self, value: Any, slot: SlotDefinition, unit: Optional[str] = None
     ):
         transformed_value = None
-        if slot.range == "TextValue":
+        # First do transformations based on specific slot names.
+        if slot.name == "estimated_size":
+            # In nmdc-schema, estimated_size is an integer representing the number of base pairs.
+            # In submission-schema, estimated_size is a float representing the number of megabases.
+            # If a value is provided, do the conversion from megabases to base pairs.
+            if value is not None:
+                try:
+                    transformed_value = int(float(value) * 1_000_000)
+                except ValueError:
+                    logging.warning(
+                        f"Could not convert estimated_size value '{value}' to an integer number of base pairs"
+                    )
+
+        # If the slot wasn't handled by name, do transformations based on the slot range.
+        elif slot.range == "TextValue":
             transformed_value = nmdc.TextValue(
                 has_raw_value=value,
                 type="nmdc:TextValue",
@@ -679,6 +693,8 @@ class SubmissionPortalTranslator(Translator):
             transformed_value = self._get_float(value)
         elif slot.range == "string":
             transformed_value = str(value).strip()
+
+        # If the slot wasn't handled by name or range, just return the value as-is.
         else:
             transformed_value = value
 

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -59,7 +59,7 @@ class DataFieldInfo(TypedDict):
 
 DATA_FIELDS: dict[str, DataFieldInfo] = {
     "air_data": {"env_package": "air", "type": "environmental"},
-    "biofilm_data": {"env_package": "microbial_mat_biofilm", "type": "environmental"},
+    "biofilm_data": {"env_package": "microbial mat_biofilm", "type": "environmental"},
     "built_env_data": {"env_package": "built environment", "type": "environmental"},
     "hcr_cores_data": {
         "env_package": "hydrocarbon resources-cores",

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1,13 +1,10 @@
 import logging
 import re
 from collections import namedtuple
-from datetime import datetime, timezone
 from decimal import Decimal
-from enum import Enum
 from functools import lru_cache
 from importlib import resources
-from importlib.metadata import version
-from typing import Any, List, Optional, Union, Tuple
+from typing import Any, List, Optional, Union, Tuple, TypedDict, Literal
 from urllib.parse import urlparse
 
 from linkml_runtime import SchemaView
@@ -55,27 +52,37 @@ UNIT_OVERRIDES: dict[str, dict[str, str]] = {
 }
 
 
-class EnvironmentPackage(Enum):
-    r"""
-    Enumeration of all possible environmental packages.
+class DataFieldInfo(TypedDict):
+    env_package: Optional[str]
+    type: Literal["environmental", "isolate"]
 
-    >>> EnvironmentPackage.AIR.value
-    'air'
-    >>> EnvironmentPackage.SEDIMENT.value
-    'sediment'
-    """
 
-    AIR = "air"
-    BIOFILM = "microbial mat_biofilm"
-    BUILT_ENV = "built environment"
-    HCR_CORES = "hydrocarbon resources-cores"
-    HRC_FLUID_SWABS = "hydrocarbon resources-fluids_swabs"
-    HOST_ASSOCIATED = "host-associated"
-    MISC_ENVS = "miscellaneous natural or artificial environment"
-    PLANT_ASSOCIATED = "plant-associated"
-    SEDIMENT = "sediment"
-    SOIL = "soil"
-    WATER = "water"
+DATA_FIELDS: dict[str, DataFieldInfo] = {
+    "air_data": {"env_package": "air", "type": "environmental"},
+    "biofilm_data": {"env_package": "microbial_mat_biofilm", "type": "environmental"},
+    "built_env_data": {"env_package": "built environment", "type": "environmental"},
+    "hcr_cores_data": {
+        "env_package": "hydrocarbon resources-cores",
+        "type": "environmental",
+    },
+    "hcr_fluids_swabs_data": {
+        "env_package": "hydrocarbon resources-fluids_swabs",
+        "type": "environmental",
+    },
+    "host_associated_data": {"env_package": "host-associated", "type": "environmental"},
+    "misc_envs_data": {
+        "env_package": "miscellaneous natural or artificial environment",
+        "type": "environmental",
+    },
+    "plant_associated_data": {
+        "env_package": "plant-associated",
+        "type": "environmental",
+    },
+    "sediment_data": {"env_package": "sediment", "type": "environmental"},
+    "soil_data": {"env_package": "soil", "type": "environmental"},
+    "water_data": {"env_package": "water", "type": "environmental"},
+    "isolate_data": {"env_package": None, "type": "isolate"},
+}
 
 
 @lru_cache
@@ -663,6 +670,11 @@ class SubmissionPortalTranslator(Translator):
             )
         elif slot.range == "GeolocationValue":
             transformed_value = self._get_geolocation_value(value)
+        elif slot.range == "NcbiTaxon":
+            transformed_value = nmdc.NcbiTaxon(
+                id=value,
+                type="nmdc:NcbiTaxon",
+            )
         elif slot.range == "float":
             transformed_value = self._get_float(value)
         elif slot.range == "string":
@@ -702,7 +714,8 @@ class SubmissionPortalTranslator(Translator):
                 unit = slot_mappings[column].get("subject_unit")
 
             if slot_name not in slot_names:
-                logging.warning(f"No slot '{slot_name}' on class '{class_name}'")
+                if slot_name != TAB_NAME_KEY:
+                    logging.warning(f"No slot '{slot_name}' on class '{class_name}'")
                 continue
 
             # This step handles cases where the submission portal/schema instructs a user to
@@ -786,6 +799,77 @@ class SubmissionPortalTranslator(Translator):
 
         return nmdc.Biosample(**slots, provenance_metadata=provenance_metadata)
 
+    def _translate_organism(
+        self,
+        sample_data: List[JSON_OBJECT],
+        nmdc_organism_id: str,
+    ) -> nmdc.Organism:
+        """Translate sample data from portal submission into an `nmdc:Organism` object.
+
+        sample_data is a list of objects where each object represents one row from a tab in
+        the submission portal. Each of the objects represents information about the same
+        underlying organism sample. For each of the rows, each of the columns is iterated over.
+        For each column, the corresponding slot from the nmdc:Organism class is identified.
+        The raw value from the submission portal is the transformed according to the range
+        of the nmdc:Organism slot.
+
+        :param sample_data: collection of rows representing data about a single organism sample
+                            from each applicable submission portal tab
+        :param nmdc_organism_id: Minted nmdc:Organism identifier for the translated object
+        :return: nmdc:Organism
+        """
+        slots = {}
+        for tab in sample_data:
+            transformed_tab = self._transform_dict_for_class(tab, "Organism")
+            slots.update(transformed_tab)
+
+        return nmdc.Organism(
+            **slots,
+            id=nmdc_organism_id,
+            type="nmdc:Organism",
+        )
+
+    def _translate_organism_sample(
+        self,
+        sample_data: List[JSON_OBJECT],
+        nmdc_organism_sample_id: str,
+        nmdc_study_id: str,
+        expected_organism_id: Optional[str],
+        provenance_metadata: nmdc.ProvenanceMetadata,
+    ) -> nmdc.OrganismSample:
+        """Translate sample data from portal submission into an `nmdc:OrganismSample` object.
+
+        sample_data is a list of objects where each object represents one row from a tab in
+        the submission portal. Each of the objects represents information about the same
+        underlying organism sample. For each of the rows, each of the columns is iterated over.
+        For each column, the corresponding slot from the nmdc:OrganismSample class is identified.
+        The raw value from the submission portal is the transformed according to the range
+        of the nmdc:OrganismSample slot.
+
+        :param sample_data: collection of rows representing data about a single organism sample
+                            from each applicable submission portal tab
+        :param nmdc_organism_sample_id: Minted nmdc:OrganismSample identifier
+        :param nmdc_study_id: Minted nmdc:Study identifier for the related Study
+        :param expected_organism_id: Minted nmdc:Organism identifier for the expected organism
+            associated with this sample, if it was provided in the submission
+        :param provenance_metadata: ProvenanceMetadata object to associate with the OrganismSample
+        :return: nmdc:OrganismSample
+        """
+        slots = {}
+        for tab in sample_data:
+            transformed_tab = self._transform_dict_for_class(tab, "OrganismSample")
+            slots.update(transformed_tab)
+
+        return nmdc.OrganismSample(
+            **slots,
+            id=nmdc_organism_sample_id,
+            type="nmdc:OrganismSample",
+            associated_studies=[nmdc_study_id],
+            expected_organism=expected_organism_id,
+            name=sample_data[0].get("samp_name", "").strip() or None,
+            provenance_metadata=provenance_metadata,
+        )
+
     def get_database(self) -> nmdc.Database:
         """Translate the submission portal entry to an nmdc:Database
 
@@ -817,36 +901,77 @@ class SubmissionPortalTranslator(Translator):
 
         # Automatically populate the `env_package` field in the sample data based on which
         # environmental data tab the sample data came from.
-        sample_data = get_in(["sampleData", "data"], metadata_submission_data, default={})
+        sample_data = get_in(
+            ["sampleData", "data"], metadata_submission_data, default={}
+        )
         for key in sample_data.keys():
-            env = key.removesuffix("_data").upper()
-            try:
-                package_name = EnvironmentPackage[env].value
-                for sample in sample_data[key]:
-                    sample["env_package"] = package_name
-            except KeyError:
-                # This is expected when processing rows from tabs like the JGI/EMSL tabs or external
-                # sequencing data tabs.
-                pass
+            data_field_info = DATA_FIELDS.get(key)
+            if data_field_info is None:
+                logging.warning(f"No data field info found for '{key}'")
+                continue
+            env_package = data_field_info["env_package"]
+            if env_package is None:
+                continue
+            for sample in sample_data[key]:
+                sample["env_package"] = env_package
 
         # Before regrouping the data by sample name, record which tab each object came from
         for tab_name in sample_data.keys():
             for tab in sample_data[tab_name]:
                 tab[TAB_NAME_KEY] = tab_name
 
-        # Reorganize the sample data by sample name and generate a unique NMDC ID for each
+        # Group the sample data by sample name. Each group should represent on underlying Biosample
+        # or OrganismSample/Organism pair.
         sample_data_by_id = groupby(
             BIOSAMPLE_UNIQUE_KEY_SLOT,
             concat(sample_data.values()),
         )
-        nmdc_biosample_ids = self._id_minter("nmdc:Biosample", len(sample_data_by_id))
+
+        # Filter sample_data_by_id by whether it contains data from an environmental data tab
+        biosample_data_by_id = {
+            sample_id: sample_data
+            for sample_id, sample_data in sample_data_by_id.items()
+            if any(
+                tab.get(TAB_NAME_KEY) in DATA_FIELDS
+                and DATA_FIELDS[tab.get(TAB_NAME_KEY)]["type"] == "environmental"
+                for tab in sample_data
+            )
+        }
+
+        # Filter sample_data_by_id by whether it contains data from an isolate data tab
+        organism_sample_data_by_id = {
+            sample_id: sample_data
+            for sample_id, sample_data in sample_data_by_id.items()
+            if any(
+                tab.get(TAB_NAME_KEY) in DATA_FIELDS
+                and DATA_FIELDS[tab.get(TAB_NAME_KEY)]["type"] == "isolate"
+                for tab in sample_data
+            )
+        }
+
+        # Mint NMDC identifiers for each sample
+        nmdc_biosample_ids = self._id_minter(
+            "nmdc:Biosample", len(biosample_data_by_id)
+        )
         sample_data_to_nmdc_biosample_ids = dict(
-            zip(sample_data_by_id.keys(), nmdc_biosample_ids)
+            zip(biosample_data_by_id.keys(), nmdc_biosample_ids)
+        )
+        nmdc_organism_sample_ids = self._id_minter(
+            "nmdc:OrganismSample", len(organism_sample_data_by_id)
+        )
+        nmdc_organism_ids = self._id_minter(
+            "nmdc:Organism", len(organism_sample_data_by_id)
+        )
+        sample_data_to_nmdc_organism_sample_ids = dict(
+            zip(organism_sample_data_by_id.keys(), nmdc_organism_sample_ids)
+        )
+        sample_data_to_nmdc_organism_ids = dict(
+            zip(organism_sample_data_by_id.keys(), nmdc_organism_ids)
         )
 
-        # Translate the sample data into nmdc:Biosample objects
+        # Translate the relevant sample data into nmdc:Biosample objects
         database.biosample_set = []
-        for sample_data_id, sample_data in sample_data_by_id.items():
+        for sample_data_id, sample_data in biosample_data_by_id.items():
             # This shouldn't happen, but just in case skip empty sample data
             if not sample_data:
                 continue
@@ -904,13 +1029,41 @@ class SubmissionPortalTranslator(Translator):
                 )
                 database.biosample_set.append(biosample)
 
+        # Translate the relevant sample data into nmdc:OrganismSample and nmdc:Organism objects
+        database.organism_set = []
+        database.organism_sample_set = []
+        for sample_data_id, sample_data in organism_sample_data_by_id.items():
+            # This shouldn't happen, but just in case skip empty sample data
+            if not sample_data:
+                continue
+
+            nmdc_organism_id = sample_data_to_nmdc_organism_ids[sample_data_id]
+            nmdc_organism_sample_id = sample_data_to_nmdc_organism_sample_ids[
+                sample_data_id
+            ]
+
+            organism = self._translate_organism(
+                sample_data,
+                nmdc_organism_id=nmdc_organism_id,
+            )
+            organism_sample = self._translate_organism_sample(
+                sample_data,
+                nmdc_organism_sample_id=nmdc_organism_sample_id,
+                nmdc_study_id=nmdc_study_id,
+                expected_organism_id=organism.id,
+                provenance_metadata=provenance_metadata,
+            )
+
+            database.organism_set.append(organism)
+            database.organism_sample_set.append(organism_sample)
+
         # This section handles the translation of information in the external sequencing tabs into
         # various NMDC objects.
         database.data_generation_set = []
         database.data_object_set = []
         database.instrument_set = []
         database.manifest_set = []
-        for sample_data_id, sample_data in sample_data_by_id.items():
+        for sample_data_id, sample_data in biosample_data_by_id.items():
             for tab in sample_data:
                 tab_name = tab.get(TAB_NAME_KEY)
                 analyte_category = TAB_NAME_TO_ANALYTE_CATEGORY.get(tab_name)

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1037,6 +1037,8 @@ class SubmissionPortalTranslator(Translator):
             if not sample_data:
                 continue
 
+            # Each row from an isolate tab should translate into a pair of OrganismSample and
+            # Organism objects with a one-to-one relationship.
             nmdc_organism_id = sample_data_to_nmdc_organism_ids[sample_data_id]
             nmdc_organism_sample_id = sample_data_to_nmdc_organism_sample_ids[
                 sample_data_id
@@ -1056,6 +1058,31 @@ class SubmissionPortalTranslator(Translator):
 
             database.organism_set.append(organism)
             database.organism_sample_set.append(organism_sample)
+
+            # If the organism isolate was derived from an environmental sample in the submission,
+            # this will be indicated by the sample_link column of the relevant tabs. If a
+            # sample_link was provided and it maps to an environmental sample name, then create a
+            # name:Isolation record linking the OrganismSample to the Biosample.
+            sample_link = next(
+                (
+                    tab.get("sample_link")
+                    for tab in sample_data
+                    if tab.get("sample_link") is not None
+                ),
+                None,
+            )
+            if sample_link:
+                if sample_link not in sample_data_to_nmdc_biosample_ids:
+                    raise ValueError(
+                        f"Could not find sample_link '{sample_link}' for organism sample '{organism_sample.name}'"
+                    )
+                isolation = nmdc.Isolation(
+                    id=self._id_minter("nmdc:Isolation")[0],
+                    type="nmdc:Isolation",
+                    has_input=sample_data_to_nmdc_biosample_ids[sample_link],
+                    has_output=nmdc_organism_sample_id,
+                )
+                database.material_processing_set.append(isolation)
 
         # This section handles the translation of information in the external sequencing tabs into
         # various NMDC objects.

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -969,6 +969,9 @@ class SubmissionPortalTranslator(Translator):
             zip(organism_sample_data_by_id.keys(), nmdc_organism_ids)
         )
 
+        # These NMDC IDs will be populated dynamically
+        sample_data_to_nmdc_processed_sample_ids = {}
+
         # Translate the relevant sample data into nmdc:Biosample objects
         database.biosample_set = []
         for sample_data_id, sample_data in biosample_data_by_id.items():
@@ -998,12 +1001,14 @@ class SubmissionPortalTranslator(Translator):
                         f"Could not find all input samples in sample_link '{sample_link}'"
                     )
                 processed_sample_id = self._id_minter("nmdc:ProcessedSample")[0]
-                database.processed_sample_set.append(
-                    nmdc.ProcessedSample(
-                        id=processed_sample_id,
-                        type="nmdc:ProcessedSample",
-                        name=sample_data[0].get(BIOSAMPLE_UNIQUE_KEY_SLOT, "").strip(),
-                    )
+                processed_sample = nmdc.ProcessedSample(
+                    id=processed_sample_id,
+                    type="nmdc:ProcessedSample",
+                    name=sample_data[0].get(BIOSAMPLE_UNIQUE_KEY_SLOT, "").strip(),
+                )
+                database.processed_sample_set.append(processed_sample)
+                sample_data_to_nmdc_processed_sample_ids[processed_sample.name] = (
+                    processed_sample_id
                 )
 
                 processing_class = getattr(nmdc, processing_type)
@@ -1072,14 +1077,26 @@ class SubmissionPortalTranslator(Translator):
                 None,
             )
             if sample_link:
-                if sample_link not in sample_data_to_nmdc_biosample_ids:
+                # If the sample_link is present, check if it maps to the name of a Biosample
+                # or ProcessedSample. If it does, get the corresponding NMDC ID.
+                input_sample_id = sample_data_to_nmdc_biosample_ids.get(sample_link)
+                if input_sample_id is None:
+                    input_sample_id = sample_data_to_nmdc_processed_sample_ids.get(
+                        sample_link
+                    )
+
+                # If the input sample ID is still None, that means the sample_link does not
+                # correspond to any known sample in the submission. In this case, raise an exception
+                # to indicate that the sample_link could not be resolved.
+                if input_sample_id is None:
                     raise ValueError(
                         f"Could not find sample_link '{sample_link}' for organism sample '{organism_sample.name}'"
                     )
+
                 isolation = nmdc.Isolation(
                     id=self._id_minter("nmdc:Isolation")[0],
                     type="nmdc:Isolation",
-                    has_input=[sample_data_to_nmdc_biosample_ids[sample_link]],
+                    has_input=[input_sample_id],
                     has_output=[nmdc_organism_sample_id],
                 )
                 database.material_processing_set.append(isolation)

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1062,7 +1062,7 @@ class SubmissionPortalTranslator(Translator):
             # If the organism isolate was derived from an environmental sample in the submission,
             # this will be indicated by the sample_link column of the relevant tabs. If a
             # sample_link was provided and it maps to an environmental sample name, then create a
-            # name:Isolation record linking the OrganismSample to the Biosample.
+            # nmdc:Isolation record linking the OrganismSample to the Biosample.
             sample_link = next(
                 (
                     tab.get("sample_link")

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1079,9 +1079,9 @@ class SubmissionPortalTranslator(Translator):
             if sample_link:
                 # If the sample_link is present, check if it maps to the name of a Biosample
                 # or ProcessedSample. If it does, get the corresponding NMDC ID.
-                input_sample_id = sample_data_to_nmdc_biosample_ids.get(sample_link)
+                input_sample_id = sample_data_to_nmdc_processed_sample_ids.get(sample_link)
                 if input_sample_id is None:
-                    input_sample_id = sample_data_to_nmdc_processed_sample_ids.get(
+                    input_sample_id = sample_data_to_nmdc_biosample_ids.get(
                         sample_link
                     )
 

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -57,6 +57,9 @@ class DataFieldInfo(TypedDict):
     type: Literal["environmental", "isolate"]
 
 
+# This is a mapping from names of fields used in Submission Portal records to information about the
+# type of data they contain. This influences how the data is processed and the resulting NMDC schema
+# objects that are created.
 DATA_FIELDS: dict[str, DataFieldInfo] = {
     "air_data": {"env_package": "air", "type": "environmental"},
     "biofilm_data": {"env_package": "microbial mat_biofilm", "type": "environmental"},
@@ -826,7 +829,7 @@ class SubmissionPortalTranslator(Translator):
         the submission portal. Each of the objects represents information about the same
         underlying organism sample. For each of the rows, each of the columns is iterated over.
         For each column, the corresponding slot from the nmdc:Organism class is identified.
-        The raw value from the submission portal is the transformed according to the range
+        The raw value from the submission portal is then transformed according to the range
         of the nmdc:Organism slot.
 
         :param sample_data: collection of rows representing data about a single organism sample
@@ -859,7 +862,7 @@ class SubmissionPortalTranslator(Translator):
         the submission portal. Each of the objects represents information about the same
         underlying organism sample. For each of the rows, each of the columns is iterated over.
         For each column, the corresponding slot from the nmdc:OrganismSample class is identified.
-        The raw value from the submission portal is the transformed according to the range
+        The raw value from the submission portal is then transformed according to the range
         of the nmdc:OrganismSample slot.
 
         :param sample_data: collection of rows representing data about a single organism sample
@@ -936,7 +939,7 @@ class SubmissionPortalTranslator(Translator):
             for tab in sample_data[tab_name]:
                 tab[TAB_NAME_KEY] = tab_name
 
-        # Group the sample data by sample name. Each group should represent on underlying Biosample
+        # Group the sample data by sample name. Each group should represent one underlying Biosample
         # or OrganismSample/Organism pair.
         sample_data_by_id = groupby(
             BIOSAMPLE_UNIQUE_KEY_SLOT,
@@ -997,7 +1000,7 @@ class SubmissionPortalTranslator(Translator):
         # Translate the relevant sample data into nmdc:Biosample objects
         database.biosample_set = []
         for sample_data_id, sample_data in biosample_data_by_id.items():
-            # This shouldn't happen, but just in case skip empty sample data
+            # This shouldn't happen, but (just in case) skip empty sample data
             if not sample_data:
                 continue
 

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -950,17 +950,23 @@ class SubmissionPortalTranslator(Translator):
         }
 
         # Mint NMDC identifiers for each sample
-        nmdc_biosample_ids = self._id_minter(
-            "nmdc:Biosample", len(biosample_data_by_id)
+        nmdc_biosample_ids = (
+            self._id_minter("nmdc:Biosample", len(biosample_data_by_id))
+            if len(biosample_data_by_id) > 0
+            else []
         )
         sample_data_to_nmdc_biosample_ids = dict(
             zip(biosample_data_by_id.keys(), nmdc_biosample_ids)
         )
-        nmdc_organism_sample_ids = self._id_minter(
-            "nmdc:OrganismSample", len(organism_sample_data_by_id)
+        nmdc_organism_sample_ids = (
+            self._id_minter("nmdc:OrganismSample", len(organism_sample_data_by_id))
+            if len(organism_sample_data_by_id) > 0
+            else []
         )
-        nmdc_organism_ids = self._id_minter(
-            "nmdc:Organism", len(organism_sample_data_by_id)
+        nmdc_organism_ids = (
+            self._id_minter("nmdc:Organism", len(organism_sample_data_by_id))
+            if len(organism_sample_data_by_id) > 0
+            else []
         )
         sample_data_to_nmdc_organism_sample_ids = dict(
             zip(organism_sample_data_by_id.keys(), nmdc_organism_sample_ids)

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1079,11 +1079,11 @@ class SubmissionPortalTranslator(Translator):
             if sample_link:
                 # If the sample_link is present, check if it maps to the name of a Biosample
                 # or ProcessedSample. If it does, get the corresponding NMDC ID.
-                input_sample_id = sample_data_to_nmdc_processed_sample_ids.get(sample_link)
+                input_sample_id = sample_data_to_nmdc_processed_sample_ids.get(
+                    sample_link
+                )
                 if input_sample_id is None:
-                    input_sample_id = sample_data_to_nmdc_biosample_ids.get(
-                        sample_link
-                    )
+                    input_sample_id = sample_data_to_nmdc_biosample_ids.get(sample_link)
 
                 # If the input sample ID is still None, that means the sample_link does not
                 # correspond to any known sample in the submission. In this case, raise an exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # We use `nmdc-schema` to interpret data residing in—and validate data
     # destined for—the NMDC database (i.e. the MongoDB database named `nmdc`).
     # Docs: https://microbiomedata.github.io/nmdc-schema/
-    "nmdc-schema==11.20.0",
+    "nmdc-schema==11.20.2",
     "pandas",
     "passlib[bcrypt]",
     "pymongo",

--- a/tests/test_data/conftest.py
+++ b/tests/test_data/conftest.py
@@ -11,6 +11,9 @@ def test_minter():
     typecode_list = typecodes()
 
     def mint(type, how_many=1):
+        if how_many < 1:
+            raise ValueError("how_many must be >= 1")
+
         typecode = next(t for t in typecode_list if t["schema_class"] == type)
         return [
             "nmdc:"

--- a/tests/test_data/data/isolate_only_input.yaml
+++ b/tests/test_data/data/isolate_only_input.yaml
@@ -1,0 +1,123 @@
+metadata_submission:
+  metadata_submission:
+    sampleEnvironmentForm:
+      packageName:
+        - isolate
+      validation: []
+    senderShippingInfoForm:
+      shipper:
+        name: ""
+        email: ""
+        phone: ""
+        line1: ""
+        line2: ""
+        city: ""
+        state: ""
+        postalCode: ""
+        country: ""
+      expectedShippingDate: null
+      shippingConditions: ""
+      sample: ""
+      description: ""
+      experimentalGoals: ""
+      randomization: ""
+      usdaRegulated: null
+      permitNumber: ""
+      biosafetyLevel: ""
+      irbOrHipaa: null
+      comments: ""
+      validation: null
+    templates:
+      - isolate
+    studyForm:
+      studyName: Isolate Only
+      piName: ""
+      piEmail: tester@example.gov
+      piOrcid: ""
+      fundingSources: []
+      dataDois: []
+      publicationDois: []
+      linkOutWebpage: []
+      studyDate: null
+      description: ""
+      notes: ""
+      contributors: []
+      validation: []
+      alternativeNames: []
+      GOLDStudyId: ""
+      NCBIBioProjectId: ""
+    multiOmicsForm:
+      award: null
+      awardDois: []
+      dataGenerated: false
+      doe: false
+      facilities: []
+      facilityGenerated: null
+      JGIStudyId: ""
+      mgCompatible: null
+      mgInterleaved: null
+      mtCompatible: null
+      mtInterleaved: null
+      omicsProcessingTypes:
+        - isolate-genome
+        - isolate-transcriptome
+      otherAward: null
+      ship: null
+      studyNumber: ""
+      unknownDoi: null
+      mpProtocols: null
+      mbProtocols: null
+      mbGcProtocols: null
+      lipProtocols: null
+      nomProtocols: null
+      nomLcProtocols: null
+      validation: []
+    sampleData:
+      data:
+        isolate_data:
+          - ploidy: haploid
+            samp_name: "0001"
+            gc_content: 50
+            strain_name: Shewanella loihica PV-4
+            isolate_name: Bd21-3
+            analysis_type:
+              - isolate genome sequencing
+            classified_as: NCBITaxon:562
+            organism_genus: Shewanella
+            collection_date: 2013-03-25
+            organism_species: Shewanella loihica
+            isolate_single_colony: yes
+            isolate_known_contaminants: Bacillus subtilis ~5%
+      validation:
+        invalidCells:
+          isolate: {}
+        tabsValidated:
+          isolate: true
+  status: InProgress
+  source_client: submission_portal
+  is_test_submission: false
+  id: 91213966-e36d-40b1-841d-4f6c10c1af21
+  author:
+    id: 43cefaba-704f-4c4d-b20c-1e86236d601f
+    orcid: 0000-0000-0000-000X
+    name: Test Testerdottir
+    email: tester@example.gov
+    is_admin: true
+  study_name: Isolate Only
+  templates:
+    - isolate
+  date_last_modified: 2026-06-18T00:03:42.507587
+  created: 2026-06-18T00:03:07.804543
+  sample_count: 0
+  reviewers: []
+  contributors:
+    - 0000-0000-0000-000X
+  author_orcid: 0000-0000-0000-000X
+  field_notes_metadata: null
+  nmdc_study_id: null
+  lock_updated: 2026-06-18T00:13:19.569336
+  locked_by: null
+  permission_level: owner
+  pi_image_url: null
+  primary_study_image_url: null
+  study_image_urls: []

--- a/tests/test_data/data/isolate_only_output.yaml
+++ b/tests/test_data/data/isolate_only_output.yaml
@@ -1,0 +1,54 @@
+organism_sample_set:
+- id: nmdc:osm-00-4wn6isig
+  type: nmdc:OrganismSample
+  name: '0001'
+  associated_studies:
+  - nmdc:sty-00-y0cq65zt
+  expected_organism: nmdc:orgn-00-q8jtgev4
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - 91213966-e36d-40b1-841d-4f6c10c1af21
+  collection_date:
+    type: nmdc:TimestampValue
+    has_raw_value: '2013-03-25'
+  samp_name: '0001'
+  ploidy: haploid
+  analysis_type:
+  - isolate genome sequencing
+organism_set:
+- id: nmdc:orgn-00-q8jtgev4
+  type: nmdc:Organism
+  classified_as:
+  - id: NCBITaxon:562
+    type: nmdc:NcbiTaxon
+  organism_genus: Shewanella
+  organism_species: Shewanella loihica
+  strain_name: Shewanella loihica PV-4
+  isolate_name: Bd21-3
+  gc_content: 50.0
+study_set:
+- id: nmdc:sty-00-y0cq65zt
+  type: nmdc:Study
+  name: Isolate Only
+  study_category: research_study
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - 91213966-e36d-40b1-841d-4f6c10c1af21
+  principal_investigator:
+    type: nmdc:PersonValue
+    email: tester@example.gov
+    name: ''
+    orcid: ''
+  title: Isolate Only

--- a/tests/test_data/data/isolate_soil_input.yaml
+++ b/tests/test_data/data/isolate_soil_input.yaml
@@ -3,6 +3,7 @@ metadata_submission:
     sampleEnvironmentForm:
       packageName:
         - isolate
+        - soil
       validation: []
     senderShippingInfoForm:
       shipper:
@@ -29,8 +30,9 @@ metadata_submission:
       validation: null
     templates:
       - isolate
+      - soil
     studyForm:
-      studyName: Isolate Only
+      studyName: Isolate + Soil
       piName: ""
       piEmail: tester@example.gov
       piOrcid: ""
@@ -60,7 +62,6 @@ metadata_submission:
       mtInterleaved: null
       omicsProcessingTypes:
         - isolate-genome
-        - isolate-transcriptome
       otherAward: null
       ship: null
       studyNumber: ""
@@ -74,50 +75,69 @@ metadata_submission:
       validation: []
     sampleData:
       data:
+        soil_data:
+          - elev: 0
+            depth: 0 - 1
+            lat_lon: 0 0
+            samp_name: soil-001
+            env_medium: acidic soil [ENVO:01001185]
+            store_cond: frozen
+            geo_loc_name: "USA: Fake, Fake"
+            growth_facil: experimental_garden
+            analysis_type:
+              - metagenomics
+            collection_date: "2021"
+            env_broad_scale: alpine tundra biome [ENVO:01001505]
+            env_local_scale: active permafrost layer [ENVO:04000009]
+            samp_store_temp: 0
         isolate_data:
-          - ploidy: haploid
-            samp_name: "0001"
-            gc_content: 50
-            strain_name: Shewanella loihica PV-4
-            isolate_name: Bd21-3
+          - ploidy: triploid
+            samp_name: isolate-001
+            sample_link: soil-001
+            gc_content: 0
+            strain_name: Lorem ipsum dolor sit
+            isolate_name: Lorem ipsum dolor sit 0001
             analysis_type:
               - isolate genome sequencing
-            classified_as: NCBITaxon:562
-            organism_genus: Shewanella
-            collection_date: 2013-03-25
-            organism_species: Shewanella loihica
+            classified_as: NCBITaxon:0001
+            organism_genus: Lorem
+            collection_date: 2021-01-01
+            organism_species: Lorem ipsum
             isolate_single_colony: yes
-            isolate_known_contaminants: Bacillus subtilis ~5%
+            isolate_known_contaminants: Consectetur adipiscing 1%
       validation:
         invalidCells:
+          soil: {}
           isolate: {}
         tabsValidated:
+          soil: true
           isolate: true
   status: InProgress
   source_client: submission_portal
   is_test_submission: false
-  id: 91213966-e36d-40b1-841d-4f6c10c1af21
+  id: ef59f345-8c89-4201-bcdc-28ca1f6919ca
   author:
-    id: 43cefaba-704f-4c4d-b20c-1e86236d601f
+    id: 237a0086-bae8-4412-890c-e2a44f4e1749
     orcid: 0000-0000-0000-000X
     name: Test Testerdóttir
     email: tester@example.gov
     is_admin: true
-  study_name: Isolate Only
+  study_name: Isolate + Soil
   templates:
     - isolate
-  date_last_modified: 2026-06-18T00:03:42.507587
-  created: 2026-06-18T00:03:07.804543
-  sample_count: 0
+    - soil
+  date_last_modified: 2026-06-18T18:19:43.435496
+  created: 2026-06-18T18:19:19.301941
+  sample_count: 1
   reviewers: []
   contributors:
     - 0000-0000-0000-000X
   author_orcid: 0000-0000-0000-000X
   field_notes_metadata: null
   nmdc_study_id: null
-  lock_updated: 2026-06-18T00:13:19.569336
+  lock_updated: 2026-06-18T18:24:16.425730
   locked_by: null
-  permission_level: owner
+  permission_level: null
   pi_image_url: null
   primary_study_image_url: null
   study_image_urls: []

--- a/tests/test_data/data/isolate_soil_jgi_input.yaml
+++ b/tests/test_data/data/isolate_soil_jgi_input.yaml
@@ -1,0 +1,168 @@
+metadata_submission:
+  metadata_submission:
+    sampleEnvironmentForm:
+      packageName:
+        - isolate
+        - soil
+      validation: [ ]
+    senderShippingInfoForm:
+      shipper:
+        name: ""
+        email: ""
+        phone: ""
+        line1: ""
+        line2: ""
+        city: ""
+        state: ""
+        postalCode: ""
+        country: ""
+      expectedShippingDate: null
+      shippingConditions: ""
+      sample: ""
+      description: ""
+      experimentalGoals: ""
+      randomization: ""
+      usdaRegulated: null
+      permitNumber: ""
+      biosafetyLevel: ""
+      irbOrHipaa: null
+      comments: ""
+      validation: null
+    templates:
+      - isolate
+      - soil
+      - jgi_isolate_genome
+    studyForm:
+      studyName: Soil + Isolate + JGI
+      piName: ""
+      piEmail: tester@example.gov
+      piOrcid: ""
+      fundingSources: [ ]
+      dataDois: [ ]
+      publicationDois: [ ]
+      linkOutWebpage: [ ]
+      studyDate: null
+      description: ""
+      notes: ""
+      contributors: [ ]
+      validation: [ ]
+      alternativeNames: [ ]
+      GOLDStudyId: ""
+      NCBIBioProjectId: ""
+    multiOmicsForm:
+      award: CSP
+      awardDois:
+        - value: "10.123/abcd"
+          provider: "jgi"
+      dataGenerated: false
+      doe: true
+      facilities:
+        - JGI
+      facilityGenerated: null
+      JGIStudyId: "123456"
+      mgCompatible: null
+      mgInterleaved: null
+      mtCompatible: null
+      mtInterleaved: null
+      omicsProcessingTypes:
+        - isolate-genome-jgi
+      otherAward: ""
+      ship: null
+      studyNumber: ""
+      unknownDoi: false
+      mpProtocols: null
+      mbProtocols: null
+      mbGcProtocols: null
+      lipProtocols: null
+      nomProtocols: null
+      nomLcProtocols: null
+      validation: [ ]
+    sampleData:
+      data:
+        soil_data:
+          - elev: 0
+            depth: 0 - 1
+            lat_lon: 0 0
+            samp_name: soil-001
+            env_medium: acidic soil [ENVO:01001185]
+            store_cond: fresh
+            geo_loc_name: "USA: Test, Test"
+            growth_facil: experimental_garden
+            analysis_type:
+              - metagenomics
+            collection_date: "2021"
+            env_broad_scale: alpine tundra biome [ENVO:01001505]
+            env_local_scale: active permafrost layer [ENVO:04000009]
+            samp_store_temp: 0
+        isolate_data:
+          - ploidy: haploid
+            samp_name: isolate-001
+            gc_content: 0
+            sample_link: soil-001
+            strain_name: Lorem ipsum dolor sit
+            isolate_name: Lorem ipsum dolor sit 0001
+            analysis_type:
+              - isolate genome sequencing
+            classified_as: NCBITaxon:0001
+            organism_genus: Lorem
+            collection_date: 2021-01-01
+            organism_species: Lorem ipsum
+            isolate_single_colony: yes
+            isolate_known_contaminants: Consectetur adipiscing 1%
+        jgi_isolate_genome_data:
+          - dnase: no
+            cont_type: plate
+            cont_well: B1
+            samp_name: isolate-001
+            analysis_type:
+              - isolate genome sequencing
+            container_name: plate 1
+            estimated_size: 4.6
+            jgi_sample_name: JGI_pond_041618
+            replicate_group: SampleGroup1
+            dna_isolate_meth: phenol/chloroform extraction
+            nuc_acid_absorb1: 2.02
+            nuc_acid_absorb2: 2.02
+            biosafety_mat_cat: Alga
+            jgi_sample_format: Water
+            jgi_sample_volume: 25
+            sample_isolated_from: soil
+            nuc_acid_concentration: 100
+      validation:
+        invalidCells:
+          soil: { }
+          isolate: { }
+          jgi_isolate_genome: { }
+        tabsValidated:
+          soil: true
+          isolate: true
+          jgi_isolate_genome: true
+  status: InProgress
+  source_client: submission_portal
+  is_test_submission: false
+  id: ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  author:
+    id: 237a0086-bae8-4412-890c-e2a44f4e1749
+    orcid: 0000-0000-0000-000X
+    name: Test Testerdóttir
+    email: tester@example.gov
+    is_admin: true
+  study_name: Isolate + Soil
+  templates:
+    - isolate
+    - soil
+  date_last_modified: 2026-06-18T18:19:43.435496
+  created: 2026-06-18T18:19:19.301941
+  sample_count: 1
+  reviewers: []
+  contributors:
+    - 0000-0000-0000-000X
+  author_orcid: 0000-0000-0000-000X
+  field_notes_metadata: null
+  nmdc_study_id: null
+  lock_updated: 2026-06-18T18:24:16.425730
+  locked_by: null
+  permission_level: null
+  pi_image_url: null
+  primary_study_image_url: null
+  study_image_urls: []

--- a/tests/test_data/data/isolate_soil_jgi_output.yaml
+++ b/tests/test_data/data/isolate_soil_jgi_output.yaml
@@ -1,0 +1,140 @@
+biosample_set:
+- id: nmdc:bsm-00-4wn6isig
+  type: nmdc:Biosample
+  name: soil-001
+  associated_studies:
+  - nmdc:sty-00-y0cq65zt
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: alpine tundra biome [ENVO:01001505]
+    term:
+      id: ENVO:01001505
+      type: nmdc:OntologyClass
+      name: alpine tundra biome
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: active permafrost layer [ENVO:04000009]
+    term:
+      id: ENVO:04000009
+      type: nmdc:OntologyClass
+      name: active permafrost layer
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: acidic soil [ENVO:01001185]
+    term:
+      id: ENVO:01001185
+      type: nmdc:OntologyClass
+      name: acidic soil
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  collection_date:
+    type: nmdc:TimestampValue
+    has_raw_value: '2021'
+  depth:
+    type: nmdc:QuantityValue
+    has_raw_value: 0 - 1
+    has_unit: m
+    has_maximum_numeric_value: 1
+    has_minimum_numeric_value: 0
+  elev: 0.0
+  env_package:
+    type: nmdc:TextValue
+    has_raw_value: soil
+  geo_loc_name:
+    type: nmdc:TextValue
+    has_raw_value: 'USA: Test, Test'
+  growth_facil:
+    type: nmdc:ControlledTermValue
+    has_raw_value: experimental_garden
+  lat_lon:
+    type: nmdc:GeolocationValue
+    has_raw_value: 0 0
+    latitude: 0.0
+    longitude: 0.0
+  samp_name: soil-001
+  samp_store_temp:
+    type: nmdc:QuantityValue
+    has_raw_value: '0'
+    has_unit: Cel
+    has_numeric_value: 0
+  store_cond:
+    type: nmdc:TextValue
+    has_raw_value: fresh
+  analysis_type:
+  - metagenomics
+material_processing_set:
+- id: nmdc:isnp-00-27qd9afz
+  type: nmdc:Isolation
+  has_input:
+  - nmdc:bsm-00-4wn6isig
+  has_output:
+  - nmdc:osm-00-q8jtgev4
+organism_sample_set:
+- id: nmdc:osm-00-q8jtgev4
+  type: nmdc:OrganismSample
+  name: isolate-001
+  associated_studies:
+  - nmdc:sty-00-y0cq65zt
+  expected_organism: nmdc:orgn-00-9gw1un94
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  collection_date:
+    type: nmdc:TimestampValue
+    has_raw_value: '2021-01-01'
+  samp_name: isolate-001
+  ploidy: haploid
+  analysis_type:
+  - isolate genome sequencing
+organism_set:
+- id: nmdc:orgn-00-9gw1un94
+  type: nmdc:Organism
+  classified_as:
+  - id: NCBITaxon:0001
+    type: nmdc:NcbiTaxon
+  organism_genus: Lorem
+  organism_species: Lorem ipsum
+  strain_name: Lorem ipsum dolor sit
+  isolate_name: Lorem ipsum dolor sit 0001
+  gc_content: 0.0
+  estimated_size: 4600000
+study_set:
+- id: nmdc:sty-00-y0cq65zt
+  type: nmdc:Study
+  name: Soil + Isolate + JGI
+  study_category: research_study
+  jgi_portal_study_identifiers:
+    - jgi.proposal:123456
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  associated_dois:
+    - doi_value: doi:10.123/abcd
+      doi_category: award_doi
+      doi_provider: jgi
+      type: nmdc:DOI
+  principal_investigator:
+    type: nmdc:PersonValue
+    email: tester@example.gov
+    name: ''
+    orcid: ''
+  title: Soil + Isolate + JGI

--- a/tests/test_data/data/isolate_soil_output.yaml
+++ b/tests/test_data/data/isolate_soil_output.yaml
@@ -1,0 +1,132 @@
+biosample_set:
+- id: nmdc:bsm-00-4wn6isig
+  type: nmdc:Biosample
+  name: soil-001
+  associated_studies:
+  - nmdc:sty-00-y0cq65zt
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: alpine tundra biome [ENVO:01001505]
+    term:
+      id: ENVO:01001505
+      type: nmdc:OntologyClass
+      name: alpine tundra biome
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: active permafrost layer [ENVO:04000009]
+    term:
+      id: ENVO:04000009
+      type: nmdc:OntologyClass
+      name: active permafrost layer
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: acidic soil [ENVO:01001185]
+    term:
+      id: ENVO:01001185
+      type: nmdc:OntologyClass
+      name: acidic soil
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  collection_date:
+    type: nmdc:TimestampValue
+    has_raw_value: '2021'
+  depth:
+    type: nmdc:QuantityValue
+    has_raw_value: 0 - 1
+    has_unit: m
+    has_maximum_numeric_value: 1
+    has_minimum_numeric_value: 0
+  elev: 0.0
+  env_package:
+    type: nmdc:TextValue
+    has_raw_value: soil
+  geo_loc_name:
+    type: nmdc:TextValue
+    has_raw_value: 'USA: Fake, Fake'
+  growth_facil:
+    type: nmdc:ControlledTermValue
+    has_raw_value: experimental_garden
+  lat_lon:
+    type: nmdc:GeolocationValue
+    has_raw_value: 0 0
+    latitude: 0.0
+    longitude: 0.0
+  samp_name: soil-001
+  samp_store_temp:
+    type: nmdc:QuantityValue
+    has_raw_value: '0'
+    has_unit: Cel
+    has_numeric_value: 0
+  store_cond:
+    type: nmdc:TextValue
+    has_raw_value: frozen
+  analysis_type:
+  - metagenomics
+material_processing_set:
+- id: nmdc:isnp-00-27qd9afz
+  type: nmdc:Isolation
+  has_input:
+  - nmdc:bsm-00-4wn6isig
+  has_output:
+  - nmdc:osm-00-q8jtgev4
+organism_sample_set:
+- id: nmdc:osm-00-q8jtgev4
+  type: nmdc:OrganismSample
+  name: isolate-001
+  associated_studies:
+  - nmdc:sty-00-y0cq65zt
+  expected_organism: nmdc:orgn-00-9gw1un94
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  collection_date:
+    type: nmdc:TimestampValue
+    has_raw_value: '2021-01-01'
+  samp_name: isolate-001
+  ploidy: triploid
+  analysis_type:
+  - isolate genome sequencing
+organism_set:
+- id: nmdc:orgn-00-9gw1un94
+  type: nmdc:Organism
+  classified_as:
+  - id: NCBITaxon:0001
+    type: nmdc:NcbiTaxon
+  organism_genus: Lorem
+  organism_species: Lorem ipsum
+  strain_name: Lorem ipsum dolor sit
+  isolate_name: Lorem ipsum dolor sit 0001
+  gc_content: 0.0
+study_set:
+- id: nmdc:sty-00-y0cq65zt
+  type: nmdc:Study
+  name: Isolate + Soil
+  study_category: research_study
+  provenance_metadata:
+    type: nmdc:ProvenanceMetadata
+    add_date: '2023-10-17T09:00:00+00:00'
+    git_url: https://github.com/microbiomedata/nmdc-runtime
+    mod_date: '2023-10-17T09:00:00+00:00'
+    version: 999.9.9
+    source_system_of_record: NMDC_Submission_Portal
+    submission_portal_identifier:
+    - ef59f345-8c89-4201-bcdc-28ca1f6919ca
+  principal_investigator:
+    type: nmdc:PersonValue
+    email: tester@example.gov
+    name: ''
+    orcid: ''
+  title: Isolate + Soil

--- a/tests/test_data/data/nucleotide_sequencing_mapping_input.yaml
+++ b/tests/test_data/data/nucleotide_sequencing_mapping_input.yaml
@@ -3,26 +3,27 @@ metadata_submission:
   metadata_submission:
     packageName: plant-associated
     sampleData:
-      plant_associated_data:
-        - analysis_type:
-            - metagenomics
-          collection_date: '2016-05-09'
-          depth: '0'
-          ecosystem: Environmental
-          ecosystem_category: Terrestrial
-          ecosystem_subtype: Leaf
-          ecosystem_type: Plant-associated
-          elev: '286'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          lat_lon: 42.39 -85.37
-          samp_name: G5R1_MAIN_09MAY2016
-          samp_store_temp: -80 Cel
-          source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
-          specific_ecosystem: Phyllosphere
+      data:
+        plant_associated_data:
+          - analysis_type:
+              - metagenomics
+            collection_date: '2016-05-09'
+            depth: '0'
+            ecosystem: Environmental
+            ecosystem_category: Terrestrial
+            ecosystem_subtype: Leaf
+            ecosystem_type: Plant-associated
+            elev: '286'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            lat_lon: 42.39 -85.37
+            samp_name: G5R1_MAIN_09MAY2016
+            samp_store_temp: -80 Cel
+            source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
+            specific_ecosystem: Phyllosphere
     studyForm:
       GOLDStudyId: ''
       alternativeNames: [ ]

--- a/tests/test_data/data/plant_air_jgi_input.yaml
+++ b/tests/test_data/data/plant_air_jgi_input.yaml
@@ -87,213 +87,214 @@ metadata_submission:
       otherAward: ''
       studyNumber: '45678'
     sampleData:
-      plant_associated_data:
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R1_MAIN_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R2_MAIN_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:774bb4b9-5ebe-48d5-8236-1a60baa6af7a
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R3_MAIN_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:c0bb595b-9992-4475-8019-775189b5250a
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R4_MAIN_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:d74181a3-6fb9-406e-89f8-2d4861a4646c
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R1_NF_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:edfd5080-ccc2-495b-b17a-190ad6649291
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R2_NF_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:483921c0-7fa9-4a31-b281-e09565a0d6f9
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R3_NF_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:3b9aab19-0110-415b-8e29-849f0696de47
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G5R4_NF_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:579ec4b9-57c4-4431-8df9-432138233b0b
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G6R1_MAIN_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:69dd84ff-d777-4d1e-ac22-9cdac87074f5
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-        - elev: 286
-          depth: '0'
-          lat_lon: 42.39 -85.37
-          ecosystem: Environmental
-          samp_name: "G6R2_MAIN_09MAY2016"
-          env_medium: plant-associated biome [ENVO:01001001]
-          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          source_mat_id: UUID:c0c4a2b5-0382-450a-8728-a176fa438efe
-          ecosystem_type: Plant-associated
-          collection_date: '2016-05-09'
-          env_broad_scale: agricultural biome [ENVO:01001442]
-          env_local_scale: phyllosphere biome [ENVO:01001442]
-          samp_store_temp: "-80 Cel"
-          ecosystem_subtype: Leaf
-          ecosystem_category: Terrestrial
-          specific_ecosystem: Phyllosphere
-      air_data:
-        - elev: 225
-          lat_lon: 50.586825 6.408977
-          samp_name: "wedw"
-          env_medium: abcd [ENVO:00001998]
-          geo_loc_name: "USA: Maryland, Bethesda"
-          analysis_type:
-            - metaproteomics
-          collection_date: 2021
-          env_broad_scale: ewdwed [ENVO:123]
-          env_local_scale: asdxasd [ENV:234]
-          samp_store_temp: "-80 Cel"
-      jgi_mg_data:
-        - samp_name: "G6R2_MAIN_09MAY2016"
-          analysis_type:
-            - metagenomics
+      data:
+        plant_associated_data:
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R1_MAIN_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R2_MAIN_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:774bb4b9-5ebe-48d5-8236-1a60baa6af7a
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R3_MAIN_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:c0bb595b-9992-4475-8019-775189b5250a
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R4_MAIN_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:d74181a3-6fb9-406e-89f8-2d4861a4646c
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R1_NF_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:edfd5080-ccc2-495b-b17a-190ad6649291
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R2_NF_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:483921c0-7fa9-4a31-b281-e09565a0d6f9
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R3_NF_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:3b9aab19-0110-415b-8e29-849f0696de47
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G5R4_NF_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:579ec4b9-57c4-4431-8df9-432138233b0b
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G6R1_MAIN_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:69dd84ff-d777-4d1e-ac22-9cdac87074f5
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+          - elev: 286
+            depth: '0'
+            lat_lon: 42.39 -85.37
+            ecosystem: Environmental
+            samp_name: "G6R2_MAIN_09MAY2016"
+            env_medium: plant-associated biome [ENVO:01001001]
+            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            source_mat_id: UUID:c0c4a2b5-0382-450a-8728-a176fa438efe
+            ecosystem_type: Plant-associated
+            collection_date: '2016-05-09'
+            env_broad_scale: agricultural biome [ENVO:01001442]
+            env_local_scale: phyllosphere biome [ENVO:01001442]
+            samp_store_temp: "-80 Cel"
+            ecosystem_subtype: Leaf
+            ecosystem_category: Terrestrial
+            specific_ecosystem: Phyllosphere
+        air_data:
+          - elev: 225
+            lat_lon: 50.586825 6.408977
+            samp_name: "wedw"
+            env_medium: abcd [ENVO:00001998]
+            geo_loc_name: "USA: Maryland, Bethesda"
+            analysis_type:
+              - metaproteomics
+            collection_date: 2021
+            env_broad_scale: ewdwed [ENVO:123]
+            env_local_scale: asdxasd [ENV:234]
+            samp_store_temp: "-80 Cel"
+        jgi_mg_data:
+          - samp_name: "G6R2_MAIN_09MAY2016"
+            analysis_type:
+              - metagenomics
   status: in-progress
   id: d32b5eb6-71e8-4c98-8a57-3e64d05718b4
   author_orcid: 0000-0002-7705-343X

--- a/tests/test_data/data/sequencing_data_input.yaml
+++ b/tests/test_data/data/sequencing_data_input.yaml
@@ -64,80 +64,81 @@ metadata_submission:
       studyNumber: "12312"
       unknownDoi: true
     sampleData:
-      soil_data:
-        - elev: 1325
-          depth: 0 - 1
-          lat_lon: 43 -120
-          samp_name: "001"
-          env_medium: bulk soil [ENVO:00005802]
-          store_cond: frozen
-          geo_loc_name: "USA: Fake, Fake"
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-          collection_date: 2025-01-01
-          env_broad_scale: mixed forest biome [ENVO:01000198]
-          env_local_scale: area of evergreen forest [ENVO:01000843]
-          samp_store_temp: -80 Cel
-          slope_gradient: 8%
-        - elev: 1325
-          depth: 0 - 1
-          lat_lon: 43 -120
-          samp_name: "002"
-          env_medium: bulk soil [ENVO:00005802]
-          store_cond: frozen
-          geo_loc_name: "USA: Fake, Fake"
-          growth_facil: field
-          analysis_type:
-            - metagenomics
-            - metatranscriptomics
-          collection_date: 2025-01-01
-          env_broad_scale: mixed forest biome [ENVO:01000198]
-          env_local_scale: area of evergreen forest [ENVO:01000843]
-          samp_store_temp: -80 Cel
-          slope_gradient: 0%
-        - elev: 1325
-          depth: 0 - 1
-          lat_lon: 43 -120
-          samp_name: "003"
-          env_medium: bulk soil [ENVO:00005802]
-          store_cond: frozen
-          geo_loc_name: "USA: Fake, Fake"
-          growth_facil: field
-          analysis_type:
-            - metatranscriptomics
-          collection_date: 2025-01-01
-          env_broad_scale: mixed forest biome [ENVO:01000198]
-          env_local_scale: area of evergreen forest [ENVO:01000843]
-          samp_store_temp: -80 Cel
-          slope_gradient: 0.5%
-      metagenome_sequencing_non_interleaved_data:
-        - model: hiseq_1500
-          samp_name: "001"
-          read_1_url: http://example.com/001-1.fastq.gz
-          read_2_url: http://example.com/001-2.fastq.gz
-          analysis_type:
-            - metagenomics
-          protocol_link: http://example.com
-          read_1_md5_checksum: b1946ac92492d2347c6235b4d2611184
-          read_2_md5_checksum: 94baaad4d1347ec6e15ae35c88ee8bc8
-          processing_institution: UCSD
-          insdc_bioproject_identifiers: bioproject:PRJNA366857
-          insdc_experiment_identifiers: insdc.sra:ERX000000
-        - model: hiseq_1500
-          samp_name: "002"
-          read_1_url: http://example.com/002-1.fastq.gz
-          read_2_url: http://example.com/002-2.fastq.gz
-          analysis_type:
-            - metagenomics
-            - metatranscriptomics
-          protocol_link: http://example.com
-          read_1_md5_checksum: 916f4c31aaa35d6b867dae9a7f54270d
-          read_2_md5_checksum: 764efa883dda1e11db47671c4a3bbd9e
-          processing_institution: UCSD
-          insdc_bioproject_identifiers: bioproject:PRJNA366857
-          insdc_experiment_identifiers: insdc.sra:ERX000000
-      metatranscriptome_sequencing_interleaved_data:
+      data:
+        soil_data:
+          - elev: 1325
+            depth: 0 - 1
+            lat_lon: 43 -120
+            samp_name: "001"
+            env_medium: bulk soil [ENVO:00005802]
+            store_cond: frozen
+            geo_loc_name: "USA: Fake, Fake"
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+            collection_date: 2025-01-01
+            env_broad_scale: mixed forest biome [ENVO:01000198]
+            env_local_scale: area of evergreen forest [ENVO:01000843]
+            samp_store_temp: -80 Cel
+            slope_gradient: 8%
+          - elev: 1325
+            depth: 0 - 1
+            lat_lon: 43 -120
+            samp_name: "002"
+            env_medium: bulk soil [ENVO:00005802]
+            store_cond: frozen
+            geo_loc_name: "USA: Fake, Fake"
+            growth_facil: field
+            analysis_type:
+              - metagenomics
+              - metatranscriptomics
+            collection_date: 2025-01-01
+            env_broad_scale: mixed forest biome [ENVO:01000198]
+            env_local_scale: area of evergreen forest [ENVO:01000843]
+            samp_store_temp: -80 Cel
+            slope_gradient: 0%
+          - elev: 1325
+            depth: 0 - 1
+            lat_lon: 43 -120
+            samp_name: "003"
+            env_medium: bulk soil [ENVO:00005802]
+            store_cond: frozen
+            geo_loc_name: "USA: Fake, Fake"
+            growth_facil: field
+            analysis_type:
+              - metatranscriptomics
+            collection_date: 2025-01-01
+            env_broad_scale: mixed forest biome [ENVO:01000198]
+            env_local_scale: area of evergreen forest [ENVO:01000843]
+            samp_store_temp: -80 Cel
+            slope_gradient: 0.5%
+        metagenome_sequencing_non_interleaved_data:
+          - model: hiseq_1500
+            samp_name: "001"
+            read_1_url: http://example.com/001-1.fastq.gz
+            read_2_url: http://example.com/001-2.fastq.gz
+            analysis_type:
+              - metagenomics
+            protocol_link: http://example.com
+            read_1_md5_checksum: b1946ac92492d2347c6235b4d2611184
+            read_2_md5_checksum: 94baaad4d1347ec6e15ae35c88ee8bc8
+            processing_institution: UCSD
+            insdc_bioproject_identifiers: bioproject:PRJNA366857
+            insdc_experiment_identifiers: insdc.sra:ERX000000
+          - model: hiseq_1500
+            samp_name: "002"
+            read_1_url: http://example.com/002-1.fastq.gz
+            read_2_url: http://example.com/002-2.fastq.gz
+            analysis_type:
+              - metagenomics
+              - metatranscriptomics
+            protocol_link: http://example.com
+            read_1_md5_checksum: 916f4c31aaa35d6b867dae9a7f54270d
+            read_2_md5_checksum: 764efa883dda1e11db47671c4a3bbd9e
+            processing_institution: UCSD
+            insdc_bioproject_identifiers: bioproject:PRJNA366857
+            insdc_experiment_identifiers: insdc.sra:ERX000000
+        metatranscriptome_sequencing_interleaved_data:
         - model: nextseq
           samp_name: "002"
           analysis_type:

--- a/tests/test_data/data/soil_sample_link_input.yaml
+++ b/tests/test_data/data/soil_sample_link_input.yaml
@@ -47,50 +47,51 @@ metadata_submission:
       otherAward:
       studyNumber:
     sampleData:
-      soil_data:
-        - elev: 123
-          analysis_type:
-            - metagenomics
-          collection_date: '2022-01-15'
-          depth: "0 - 1"
-          env_broad_scale: 'urban biome [ENVO:01000249]'
-          env_local_scale: 'tunnel [ENVO:00000068]'
-          env_medium: 'bare soil [ENVO:01001616]'
-          geo_loc_name: 'USA: Nowhere, Oklahoma'
-          growth_facil: greenhouse
-          lat_lon: 35.211445 -98.464612
-          samp_name: "00001"
-          samp_store_temp: "-80 Cel"
-          store_cond: frozen
-        - elev: 123
-          analysis_type:
-            - metagenomics
-          collection_date: '2022-01-15'
-          depth: "0 - 1"
-          env_broad_scale: 'urban biome [ENVO:01000249]'
-          env_local_scale: 'tunnel [ENVO:00000068]'
-          env_medium: 'bare soil [ENVO:01001616]'
-          geo_loc_name: 'USA: Nowhere, Oklahoma'
-          growth_facil: greenhouse
-          lat_lon: 35.211445 -98.464612
-          samp_name: "00002"
-          samp_store_temp: "-80 Cel"
-          store_cond: frozen
-        - elev: 123
-          analysis_type:
-            - metagenomics
-          collection_date: '2022-01-15'
-          depth: "0 - 1"
-          env_broad_scale: 'urban biome [ENVO:01000249]'
-          env_local_scale: 'tunnel [ENVO:00000068]'
-          env_medium: 'bare soil [ENVO:01001616]'
-          geo_loc_name: 'USA: Nowhere, Oklahoma'
-          growth_facil: greenhouse
-          lat_lon: 35.211445 -98.464612
-          sample_link: "Pooling:00001,00002"
-          samp_name: "00003-POOLED"
-          samp_store_temp: "-80 Cel"
-          store_cond: frozen
+      data:
+        soil_data:
+          - elev: 123
+            analysis_type:
+              - metagenomics
+            collection_date: '2022-01-15'
+            depth: "0 - 1"
+            env_broad_scale: 'urban biome [ENVO:01000249]'
+            env_local_scale: 'tunnel [ENVO:00000068]'
+            env_medium: 'bare soil [ENVO:01001616]'
+            geo_loc_name: 'USA: Nowhere, Oklahoma'
+            growth_facil: greenhouse
+            lat_lon: 35.211445 -98.464612
+            samp_name: "00001"
+            samp_store_temp: "-80 Cel"
+            store_cond: frozen
+          - elev: 123
+            analysis_type:
+              - metagenomics
+            collection_date: '2022-01-15'
+            depth: "0 - 1"
+            env_broad_scale: 'urban biome [ENVO:01000249]'
+            env_local_scale: 'tunnel [ENVO:00000068]'
+            env_medium: 'bare soil [ENVO:01001616]'
+            geo_loc_name: 'USA: Nowhere, Oklahoma'
+            growth_facil: greenhouse
+            lat_lon: 35.211445 -98.464612
+            samp_name: "00002"
+            samp_store_temp: "-80 Cel"
+            store_cond: frozen
+          - elev: 123
+            analysis_type:
+              - metagenomics
+            collection_date: '2022-01-15'
+            depth: "0 - 1"
+            env_broad_scale: 'urban biome [ENVO:01000249]'
+            env_local_scale: 'tunnel [ENVO:00000068]'
+            env_medium: 'bare soil [ENVO:01001616]'
+            geo_loc_name: 'USA: Nowhere, Oklahoma'
+            growth_facil: greenhouse
+            lat_lon: 35.211445 -98.464612
+            sample_link: "Pooling:00001,00002"
+            samp_name: "00003-POOLED"
+            samp_store_temp: "-80 Cel"
+            store_cond: frozen
   status: in-progress
   id: 406e6ce5-ec5f-4617-badd-dc061358da24
   author_orcid: 0000-0000-0000-000X

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -437,28 +437,30 @@ def test_instruments(test_minter):
                 "piEmail": "fake@fake.com",
             },
             "sampleData": {
-                "soil_data": [
-                    _mock_soil_data("001"),
-                    _mock_soil_data("002"),
-                ],
-                "metagenome_sequencing_interleaved_data": [
-                    {
-                        "model": "hiseq_1500",
-                        "samp_name": "001",
-                        "interleaved_url": "http://example.com/001-1.fastq",
-                        "analysis_type": ["metagenomics"],
-                        "interleaved_checksum": "b1946ac92492d2347c6235b4d2611184",
-                    },
-                    {
-                        "model": "hiseq_2500",
-                        "samp_name": "002",
-                        "interleaved_url": "http://example.com/002-1.fastq",
-                        "analysis_type": [
-                            "metagenomics",
-                        ],
-                        "interleaved_checksum": "916f4c31aaa35d6b867dae9a7f54270d",
-                    },
-                ],
+                "data": {
+                    "soil_data": [
+                        _mock_soil_data("001"),
+                        _mock_soil_data("002"),
+                    ],
+                    "metagenome_sequencing_interleaved_data": [
+                        {
+                            "model": "hiseq_1500",
+                            "samp_name": "001",
+                            "interleaved_url": "http://example.com/001-1.fastq",
+                            "analysis_type": ["metagenomics"],
+                            "interleaved_checksum": "b1946ac92492d2347c6235b4d2611184",
+                        },
+                        {
+                            "model": "hiseq_2500",
+                            "samp_name": "002",
+                            "interleaved_url": "http://example.com/002-1.fastq",
+                            "analysis_type": [
+                                "metagenomics",
+                            ],
+                            "interleaved_checksum": "916f4c31aaa35d6b867dae9a7f54270d",
+                        },
+                    ],
+                },
             },
         },
     }

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -492,10 +492,11 @@ def test_instruments(test_minter):
 @pytest.mark.parametrize(
     "data_file_base",
     [
+        "isolate_only",
         "plant_air_jgi",
-        "nucleotide_sequencing_mapping",
-        "sequencing_data",
-        "soil_sample_link",
+        # "nucleotide_sequencing_mapping",
+        # "sequencing_data",
+        # "soil_sample_link",
     ],
 )
 def test_get_database(test_minter, monkeypatch, data_file_base):

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -493,10 +493,11 @@ def test_instruments(test_minter):
     "data_file_base",
     [
         "isolate_only",
+        "isolate_soil",
+        "nucleotide_sequencing_mapping",
         "plant_air_jgi",
-        # "nucleotide_sequencing_mapping",
-        # "sequencing_data",
-        # "soil_sample_link",
+        "sequencing_data",
+        "soil_sample_link",
     ],
 )
 def test_get_database(test_minter, monkeypatch, data_file_base):

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -494,6 +494,7 @@ def test_instruments(test_minter):
     [
         "isolate_only",
         "isolate_soil",
+        "isolate_soil_jgi",
         "nucleotide_sequencing_mapping",
         "plant_air_jgi",
         "sequencing_data",

--- a/uv.lock
+++ b/uv.lock
@@ -3071,7 +3071,7 @@ requires-dist = [
     { name = "linkml" },
     { name = "linkml-runtime" },
     { name = "lxml" },
-    { name = "nmdc-schema", specifier = "==11.20.0" },
+    { name = "nmdc-schema", specifier = "==11.20.2" },
     { name = "ontology-loader", specifier = "==0.2.2" },
     { name = "pandas" },
     { name = "passlib", extras = ["bcrypt"] },
@@ -3115,7 +3115,7 @@ docs = [
 
 [[package]]
 name = "nmdc-schema"
-version = "11.20.0"
+version = "11.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3134,9 +3134,9 @@ dependencies = [
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/fc/3778c6e380d8e78f994297d9268a5d285dba343271571177634d9a1538ae/nmdc_schema-11.20.0.tar.gz", hash = "sha256:6eafd0bc92b0435b93e9f0064438e55e31ff7ac9a0c9b47e569c8676b713eef5", size = 771868, upload-time = "2026-06-10T21:21:08.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/d5/cbfe802e5b23dd2bd6f643664c5403c6a6a9c4cd6617d56c1264378c000e/nmdc_schema-11.20.2.tar.gz", hash = "sha256:9ecaff739fd863a3b00e55668dc0ac7662ba3c06638b3e46330ed9420fbee091", size = 772415, upload-time = "2026-06-18T01:56:20.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/8b/050dd7e311b5fb3be39ebce5e986f10ac6f758f0f1870d69513343cf7f0f/nmdc_schema-11.20.0-py3-none-any.whl", hash = "sha256:5321201d5f085b12f9b6fddf5cda5019461c281811c7840193845235d825c6da", size = 845561, upload-time = "2026-06-10T21:21:06.434Z" },
+    { url = "https://files.pythonhosted.org/packages/34/12/d00ed7174452b279e6dbd944452ba66f594d675683882d619031e97f4fd8/nmdc_schema-11.20.2-py3-none-any.whl", hash = "sha256:3ff27adb16b6e572a415f02acab5002c50f18be200857cec90e3310356cb7fb2", size = 847964, upload-time = "2026-06-18T01:56:18.202Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
On this branch, I implemented the translation of data from the new Isolate Submission Portal tab in the `SubmissionPortalTranslator` class.

### Details

* Rows from the new Isolate tab need to be processed a bit differently than other tabs. 
  * Data from other tabs (e.g. the Soil or Water tabs -- collectively known as environmental tabs) are translated into `nmdc:Biosample` records. However data from the Isolate tab are translated into a pair of `nmdc:OrganismSample` and `nmdc:Organism` records (linked via the `expected_organism` slot on `nmdc:OrganismSample`).
  * Additionally, if both the Isolate tab _and_ one or more environmental tabs are present, the `sample_link` column on the Isolate tab can be used to indicate a connection between rows on different tabs. This connection manifests as an `nmdc:Isolation` instance with a `has_input` that points to a `nmdc:Biosample` (translated from one of the environmental tab rows) and a `has_output` that points to a `nmdc:OrganismSample` instance (translated from one of the Isolate tab rows).
  * You can see concrete examples of this transformation by looking at the new test fixtures:
    * `tests/test_data/data/isolate_only_input.yaml` (submission data with only the Isolate tab)
    * `tests/test_data/data/isolate_only_output.yaml` (the expected translation output)
    * `tests/test_data/data/isolate_soil_input.yaml` (submission data with the Isolate and Soil tabs)
    * `tests/test_data/data/isolate_soil_output.yaml` (the expected translation output)
* There is a bit of churn in the existing test fixtures in `tests/test_data/data` because the actual sample metadata in submission records got bumped down a level from `sampleData` to `sampleData.data` (see https://github.com/microbiomedata/nmdc-server/pull/2119). These changes bring the test fixtures inline with what the Submission Portal actually provides.
* Similar to `nmdc:Biosample` records, `nmdc:OrganismSample` records should have unique names within a study. These changes add a unique compound index on the `organism_sample_set` collection. Technically, we'd probably want unique names across the union of `nmdc:Biosample` _and_ `nmdc:OrganismSample` records within one study. But that would require more thought and design than we want to take on for now.
* These changes also upgrade the `nmdc-schema` dependency to 11.20.2. This is redundant with #1543 but doesn't cause any merge conflicts. 

### Related issue(s)

Fixes #1438 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by:
* Updating/adding to existing unit tests
* Running the relevant Dagster jobs locally against the dev Submission Portal

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

Not externally documented functionality.

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
