### PR TITLE
Update submission translation to account for sample sets

### DIFF
--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -69,6 +69,7 @@ from nmdc_runtime.site.ops import (
     finalize_submission,
     fetch_nmdc_portal_submission_sample_set_by_id,
     finalize_sample_set,
+    validate_submission_sample_set_id,
 )
 from nmdc_runtime.site.export.study_metadata import get_biosamples_by_study_id
 
@@ -193,7 +194,10 @@ def translate_metadata_submission_to_nmdc_schema_database():
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
-    sample_set = fetch_nmdc_portal_submission_sample_set_by_id(sample_set_id)
+    validated_sample_set_id = validate_submission_sample_set_id(
+        metadata_submission, sample_set_id
+    )
+    sample_set = fetch_nmdc_portal_submission_sample_set_by_id(validated_sample_set_id)
     nucleotide_sequencing_mapping = get_csv_rows_from_url(
         nucleotide_sequencing_mapping_file_url
     )
@@ -238,7 +242,10 @@ def ingest_metadata_submission():
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
-    sample_set = fetch_nmdc_portal_submission_sample_set_by_id(sample_set_id)
+    validated_sample_set_id = validate_submission_sample_set_id(
+        metadata_submission, sample_set_id
+    )
+    sample_set = fetch_nmdc_portal_submission_sample_set_by_id(validated_sample_set_id)
     nucleotide_sequencing_mapping = get_csv_rows_from_url(
         nucleotide_sequencing_mapping_file_url
     )

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -264,7 +264,15 @@ def ingest_metadata_submission():
     run_id = submit_metadata_to_db(database)
     run_summary = poll_for_run_completion(run_id)
 
-    finalize_submission(run_summary, database, metadata_submission)
+    finalized_study_database = finalize_submission(
+        run_summary, database, metadata_submission
+    )
+    finalized_study_run_id = submit_metadata_to_db.alias(
+        "submit_finalized_study_to_db"
+    )(finalized_study_database)
+    poll_for_run_completion.alias("poll_for_finalized_study_update_completion")(
+        finalized_study_run_id
+    )
     finalize_sample_set(run_summary, sample_set)
 
 

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -264,16 +264,18 @@ def ingest_metadata_submission():
     run_id = submit_metadata_to_db(database)
     run_summary = poll_for_run_completion(run_id)
 
-    finalized_study_database = finalize_submission(
+    finalized_submission = finalize_submission(
         run_summary, database, metadata_submission
     )
     finalized_study_run_id = submit_metadata_to_db.alias(
         "submit_finalized_study_to_db"
-    )(finalized_study_database)
+    )(finalized_submission.finalized_study_database)
     poll_for_run_completion.alias("poll_for_finalized_study_update_completion")(
         finalized_study_run_id
     )
-    finalize_sample_set(run_summary, sample_set)
+    finalize_sample_set(
+        run_summary, sample_set, finalized_submission.submission_finalize_result
+    )
 
 
 @graph

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -66,8 +66,9 @@ from nmdc_runtime.site.ops import (
     generate_data_generation_set_post_biosample_ingest,
     get_instrument_ids_by_model,
     log_database_ids,
-    add_public_image_urls,
+    finalize_submission,
     fetch_nmdc_portal_submission_sample_set_by_id,
+    finalize_sample_set,
 )
 from nmdc_runtime.site.export.study_metadata import get_biosamples_by_study_id
 
@@ -258,12 +259,13 @@ def ingest_metadata_submission():
         instrument_mapping=instrument_mapping,
         study_id=study_id,
     )
-    database = add_public_image_urls(database, submission_id)
-
     log_database_ids(database)
 
     run_id = submit_metadata_to_db(database)
-    poll_for_run_completion(run_id)
+    run_summary = poll_for_run_completion(run_id)
+
+    finalize_submission(run_summary, database, metadata_submission)
+    finalize_sample_set(run_summary, sample_set)
 
 
 @graph

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -67,6 +67,7 @@ from nmdc_runtime.site.ops import (
     get_instrument_ids_by_model,
     log_database_ids,
     add_public_image_urls,
+    fetch_nmdc_portal_submission_sample_set_by_id,
 )
 from nmdc_runtime.site.export.study_metadata import get_biosamples_by_study_id
 
@@ -182,6 +183,7 @@ def gold_study_to_database():
 def translate_metadata_submission_to_nmdc_schema_database():
     (
         submission_id,
+        sample_set_id,
         nucleotide_sequencing_mapping_file_url,
         data_object_mapping_file_url,
         biosample_extras_file_url,
@@ -190,6 +192,7 @@ def translate_metadata_submission_to_nmdc_schema_database():
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
+    sample_set = fetch_nmdc_portal_submission_sample_set_by_id(sample_set_id)
     nucleotide_sequencing_mapping = get_csv_rows_from_url(
         nucleotide_sequencing_mapping_file_url
     )
@@ -202,6 +205,7 @@ def translate_metadata_submission_to_nmdc_schema_database():
 
     database = translate_portal_submission_to_nmdc_schema_database(
         metadata_submission,
+        sample_set,
         nucleotide_sequencing_mapping=nucleotide_sequencing_mapping,
         data_object_mapping=data_object_mapping,
         biosample_extras=biosample_extras,
@@ -224,6 +228,7 @@ def translate_metadata_submission_to_nmdc_schema_database():
 def ingest_metadata_submission():
     (
         submission_id,
+        sample_set_id,
         nucleotide_sequencing_mapping_file_url,
         data_object_mapping_file_url,
         biosample_extras_file_url,
@@ -232,6 +237,7 @@ def ingest_metadata_submission():
     ) = get_submission_portal_pipeline_inputs()
 
     metadata_submission = fetch_nmdc_portal_submission_by_id(submission_id)
+    sample_set = fetch_nmdc_portal_submission_sample_set_by_id(sample_set_id)
     nucleotide_sequencing_mapping = get_csv_rows_from_url(
         nucleotide_sequencing_mapping_file_url
     )
@@ -244,6 +250,7 @@ def ingest_metadata_submission():
 
     database = translate_portal_submission_to_nmdc_schema_database(
         metadata_submission,
+        sample_set,
         nucleotide_sequencing_mapping=nucleotide_sequencing_mapping,
         data_object_mapping=data_object_mapping,
         biosample_extras=biosample_extras,

--- a/nmdc_runtime/site/graphs.py
+++ b/nmdc_runtime/site/graphs.py
@@ -281,7 +281,7 @@ def ingest_metadata_submission():
         finalized_study_run_id
     )
     finalize_sample_set(
-        run_summary, sample_set, finalized_submission.submission_finalize_result
+        run_summary, sample_set, finalized_submission.finalize_submission_result
     )
 
 

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -674,15 +674,17 @@ def translate_portal_submission_to_nmdc_schema_database(
     return database
 
 
-@op(required_resource_keys={"nmdc_portal_api_client"})
+@op(required_resource_keys={"nmdc_portal_api_client"}, out=Out(is_required=False))
 def finalize_submission(
     context: OpExecutionContext,
     run_summary: RunSummary,
     database: nmdc.Database,
     metadata_submission: Dict[str, Any],
-) -> None:
+):
     """Finalize a submission by calling the /api/metadata_submission/{submission_id}/finalize
-    endpoint and using the response to add public image URLs to the translated nmdc:Study.
+    endpoint and using the response to add public image URLs to the translated nmdc:Study. When
+    image URLs are added, emit a minimal nmdc:Database containing only the updated nmdc:Study so
+    it can be persisted through /metadata/json:submit.
 
     Skip this step if:
       - the preceding insert into MongoDB failed (as indicated by the run_summary.status not being
@@ -720,12 +722,27 @@ def finalize_submission(
 
     study_id = database.study_set[0].id
     public_images = client.finalize_submission(submission_id, study_id=study_id)
+
+    if not any(
+        public_images.get(image_field)
+        for image_field in (
+            "pi_image_url",
+            "primary_study_image_url",
+            "study_image_urls",
+        )
+    ):
+        context.log.info(
+            f"Submission '{submission_id}' finalization did not return public image URLs; skipping Study update submission."
+        )
+        return
+
     SubmissionPortalTranslator.set_study_images(
         database.study_set[0],
         public_images.get("pi_image_url"),
         public_images.get("primary_study_image_url"),
         public_images.get("study_image_urls"),
     )
+    yield Output(nmdc.Database(study_set=[database.study_set[0]]))
 
 
 @op(required_resource_keys={"nmdc_portal_api_client"})

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from importlib.metadata import version
 from io import BytesIO
 from pprint import pformat
+
+from nmdc_schema.nmdc import SubmissionStatusEnum
 from toolz.dicttoolz import keyfilter
 from typing import Optional, Set, Tuple
 from zipfile import ZipFile
@@ -638,22 +640,22 @@ def translate_portal_submission_to_nmdc_schema_database(
     if study_id:
         # If a study_id is provided, check that it exists in Mongo. If it exists, use that one. If
         # it doesn't exist, raise an error.
-        mdb = context.resources.mongo.db
-        existing_study = mdb.study_set.find_one({"id": study_id})
-        if existing_study is None:
+        study_doc = mdb.study_set.find_one({"id": study_id}, {"_id": 0})
+        if study_doc is None:
             raise Exception(f"Study with ID '{study_id}' does not exist in Mongo.")
+        existing_study = nmdc.Study(**study_doc)
     elif metadata_submission.get("nmdc_study_id"):
         # If no study_id is provided but the submission has a nmdc_study_id value, check if a study
         # with that ID exists in Mongo. If it exists, use that one. If it doesn't exist, raise an
         # error.
-        mdb = context.resources.mongo.db
-        existing_study = mdb.study_set.find_one(
-            {"id": metadata_submission["nmdc_study_id"]}
+        study_doc = mdb.study_set.find_one(
+            {"id": metadata_submission["nmdc_study_id"]}, {"_id": 0}
         )
-        if existing_study is None:
+        if study_doc is None:
             raise Exception(
                 f"Submission has nmdc_study_id '{metadata_submission['nmdc_study_id']}' but no Study with that ID exists in Mongo."
             )
+        existing_study = nmdc.Study(**study_doc)
 
     translator = SubmissionPortalTranslator(
         metadata_submission,
@@ -673,20 +675,47 @@ def translate_portal_submission_to_nmdc_schema_database(
 
 
 @op(required_resource_keys={"nmdc_portal_api_client"})
-def add_public_image_urls(
-    context: OpExecutionContext, database: nmdc.Database, submission_id: str
-) -> nmdc.Database:
+def finalize_submission(
+    context: OpExecutionContext,
+    run_summary: RunSummary,
+    database: nmdc.Database,
+    metadata_submission: Dict[str, Any],
+) -> None:
+    """Finalize a submission by calling the /api/metadata_submission/{submission_id}/finalize
+    endpoint and using the response to add public image URLs to the translated nmdc:Study.
+
+    Skip this step if:
+      - the preceding insert into MongoDB failed (as indicated by the run_summary.status not being
+        RunEventType.COMPLETE)
+      - the submission is already associated with an existing nmdc:Study (as indicated by having its
+        nmdc_study_id field populated)
+      - the provided nmdc:Database does not contain any nmdc:Study instances.
+    """
     client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
+    submission_id = metadata_submission["id"]
+
+    if run_summary.status != RunEventType.COMPLETE:
+        context.log.info(
+            f"MongoDB insert for submission '{submission_id}' did not complete successfully; skipping submission finalization step."
+        )
+        return
+
+    if metadata_submission.get("nmdc_study_id") is not None:
+        nmdc_study_id = metadata_submission["nmdc_study_id"]
+        context.log.info(
+            f"Submission '{submission_id}' is already associated with nmdc:Study '{nmdc_study_id}'; skipping submission finalization step."
+        )
+        return
 
     if database.study_set is None or len(database.study_set) == 0:
         context.log.info(
-            "No studies in nmdc.Database; skipping public image URL addition."
+            "No studies in nmdc.Database; skipping submission finalization step."
         )
-        return database
+        return
 
     if len(database.study_set) > 1:
         context.log.warning(
-            "Multiple studies in nmdc.Database; only adding public image URLs for the first study."
+            "Multiple studies in nmdc.Database; only finalizing the first study."
         )
 
     study_id = database.study_set[0].id
@@ -698,7 +727,31 @@ def add_public_image_urls(
         public_images.get("study_image_urls"),
     )
 
-    return database
+
+@op(required_resource_keys={"nmdc_portal_api_client"})
+def finalize_sample_set(
+    context: OpExecutionContext,
+    run_summary: RunSummary,
+    sample_set: Dict[str, Any],
+) -> None:
+    """Finalize a sample set by calling the /api/metadata_submission/sample_set/{sample_set_id}/status
+    endpoint to change the sample set's status to 'Released'.
+
+    Skip this step if the preceding insert into MongoDB failed (as indicated by the
+    run_summary.status not being RunEventType.COMPLETE).
+    """
+    client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
+    sample_set_id = sample_set["id"]
+
+    if run_summary.status != RunEventType.COMPLETE:
+        context.log.info(
+            f"MongoDB insert for sample set '{sample_set_id}' did not complete successfully; skipping sample set finalization step."
+        )
+        return
+
+    client.set_sample_set_status(
+        sample_set_id, status=SubmissionStatusEnum.Released.text
+    )
 
 
 @op

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -563,9 +563,9 @@ def nmdc_schema_database_from_gold_study(
 
 
 @op(
-    required_resource_keys={"mongo"},
     out={
         "submission_id": Out(),
+        "sample_set_id": Out(),
         "nucleotide_sequencing_mapping_file_url": Out(Optional[str]),
         "data_object_mapping_file_url": Out(Optional[str]),
         "biosample_extras_file_url": Out(Optional[str]),
@@ -576,21 +576,16 @@ def nmdc_schema_database_from_gold_study(
 def get_submission_portal_pipeline_inputs(
     context: OpExecutionContext,
     submission_id: str,
+    sample_set_id: str,
     nucleotide_sequencing_mapping_file_url: Optional[str],
     data_object_mapping_file_url: Optional[str],
     biosample_extras_file_url: Optional[str],
     biosample_extras_slot_mapping_file_url: Optional[str],
     study_id: Optional[str],
-) -> Tuple[str, str | None, str | None, str | None, str | None, str | None]:
-    # query for studies matching the ID to see if it eists
-    if study_id:
-        mdb = context.resources.mongo.db
-        result = mdb.study_set.find_one({"id": study_id})
-        if not result:
-            raise Exception(f"Study id: {study_id} does not exist in Mongo.")
-
+) -> Tuple[str, str, str | None, str | None, str | None, str | None, str | None]:
     return (
         submission_id,
+        sample_set_id,
         nucleotide_sequencing_mapping_file_url,
         data_object_mapping_file_url,
         biosample_extras_file_url,
@@ -609,10 +604,19 @@ def fetch_nmdc_portal_submission_by_id(
     return client.fetch_metadata_submission(submission_id)
 
 
-@op(required_resource_keys={"runtime_api_site_client"})
+@op(required_resource_keys={"nmdc_portal_api_client"})
+def fetch_nmdc_portal_submission_sample_set_by_id(
+    context: OpExecutionContext, sample_set_id: str
+) -> Dict[str, Any]:
+    client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
+    return client.fetch_sample_set(sample_set_id)
+
+
+@op(required_resource_keys={"mongo", "runtime_api_site_client"})
 def translate_portal_submission_to_nmdc_schema_database(
     context: OpExecutionContext,
     metadata_submission: Dict[str, Any],
+    sample_set: Dict[str, Any],
     nucleotide_sequencing_mapping: List,
     data_object_mapping: List,
     instrument_mapping: Dict[str, str],
@@ -623,13 +627,38 @@ def translate_portal_submission_to_nmdc_schema_database(
     study_id: Optional[str],
 ) -> nmdc.Database:
     client: RuntimeApiSiteClient = context.resources.runtime_api_site_client
+    mdb = context.resources.mongo.db
 
     def id_minter(*args, **kwargs):
         response = client.mint_id(*args, **kwargs)
         return response.json()
 
+    existing_study: Optional[nmdc.Study] = None
+    # Attempt to find an existing study in Mongo to reuse instead of creating a new one.
+    if study_id:
+        # If a study_id is provided, check that it exists in Mongo. If it exists, use that one. If
+        # it doesn't exist, raise an error.
+        mdb = context.resources.mongo.db
+        existing_study = mdb.study_set.find_one({"id": study_id})
+        if existing_study is None:
+            raise Exception(f"Study with ID '{study_id}' does not exist in Mongo.")
+    elif metadata_submission.get("nmdc_study_id"):
+        # If no study_id is provided but the submission has a nmdc_study_id value, check if a study
+        # with that ID exists in Mongo. If it exists, use that one. If it doesn't exist, raise an
+        # error.
+        mdb = context.resources.mongo.db
+        existing_study = mdb.study_set.find_one(
+            {"id": metadata_submission["nmdc_study_id"]}
+        )
+        if existing_study is None:
+            raise Exception(
+                f"Submission has nmdc_study_id '{metadata_submission['nmdc_study_id']}' but no Study with that ID exists in Mongo."
+            )
+
     translator = SubmissionPortalTranslator(
         metadata_submission,
+        sample_set,
+        existing_study=existing_study,
         nucleotide_sequencing_mapping=nucleotide_sequencing_mapping,
         data_object_mapping=data_object_mapping,
         id_minter=id_minter,
@@ -638,7 +667,6 @@ def translate_portal_submission_to_nmdc_schema_database(
         biosample_extras=biosample_extras,
         biosample_extras_slot_mapping=biosample_extras_slot_mapping,
         illumina_instrument_mapping=instrument_mapping,
-        study_id=study_id,
     )
     database = translator.get_database()
     return database

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -612,6 +612,47 @@ def fetch_nmdc_portal_submission_by_id(
     return client.fetch_metadata_submission(submission_id)
 
 
+@op
+def validate_submission_sample_set_id(
+    metadata_submission: Dict[str, Any], sample_set_id: str
+) -> str:
+    submission_id = metadata_submission.get("id")
+    sample_sets = metadata_submission.get("sample_sets")
+
+    if not isinstance(sample_sets, list):
+        raise Failure(
+            description=(
+                f"Submission '{submission_id}' response does not include a sample_sets list."
+            ),
+            metadata={
+                "submission_id": MetadataValue.text(str(submission_id)),
+                "sample_set_id": MetadataValue.text(sample_set_id),
+            },
+        )
+
+    submission_sample_set_ids = [
+        sample_set["id"]
+        for sample_set in sample_sets
+        if isinstance(sample_set, dict) and sample_set.get("id") is not None
+    ]
+
+    if sample_set_id not in submission_sample_set_ids:
+        raise Failure(
+            description=(
+                f"Sample set '{sample_set_id}' is not associated with submission '{submission_id}'."
+            ),
+            metadata={
+                "submission_id": MetadataValue.text(str(submission_id)),
+                "sample_set_id": MetadataValue.text(sample_set_id),
+                "submission_sample_set_ids": MetadataValue.json(
+                    submission_sample_set_ids
+                ),
+            },
+        )
+
+    return sample_set_id
+
+
 @op(required_resource_keys={"nmdc_portal_api_client"})
 def fetch_nmdc_portal_submission_sample_set_by_id(
     context: OpExecutionContext, sample_set_id: str

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 from collections import defaultdict
 from datetime import datetime, timezone
+from enum import Enum
 from importlib.metadata import version
 from io import BytesIO
 from pprint import pformat
@@ -115,6 +116,11 @@ from toolz import get_in, valfilter, identity
 
 # batch size for writing documents to alldocs
 BULK_WRITE_BATCH_SIZE = 2000
+
+
+class SubmissionFinalizeResult(str, Enum):
+    FINALIZED = "finalized"
+    ALREADY_LINKED = "already_linked"
 
 
 @op
@@ -674,7 +680,13 @@ def translate_portal_submission_to_nmdc_schema_database(
     return database
 
 
-@op(required_resource_keys={"nmdc_portal_api_client"}, out=Out(is_required=False))
+@op(
+    required_resource_keys={"nmdc_portal_api_client"},
+    out={
+        "finalized_study_database": Out(is_required=False),
+        "submission_finalize_result": Out(SubmissionFinalizeResult),
+    },
+)
 def finalize_submission(
     context: OpExecutionContext,
     run_summary: RunSummary,
@@ -684,7 +696,10 @@ def finalize_submission(
     """Finalize a submission by calling the /api/metadata_submission/{submission_id}/finalize
     endpoint and using the response to add public image URLs to the translated nmdc:Study. When
     image URLs are added, emit a minimal nmdc:Database containing only the updated nmdc:Study so
-    it can be persisted through /metadata/json:submit.
+    it can be persisted through /metadata/json:submit. Emit a finalize result only when the
+    submission is known to be finalized or was already linked to an nmdc:Study. Emitting a
+    finalize result allows downstream steps to finalize the sample set. The finalize result is
+    not emitted when finalizing the sample set should be skipped.
 
     Skip this step if:
       - the preceding insert into MongoDB failed (as indicated by the run_summary.status not being
@@ -707,6 +722,10 @@ def finalize_submission(
         context.log.info(
             f"Submission '{submission_id}' is already associated with nmdc:Study '{nmdc_study_id}'; skipping submission finalization step."
         )
+        yield Output(
+            SubmissionFinalizeResult.ALREADY_LINKED,
+            output_name="submission_finalize_result",
+        )
         return
 
     if database.study_set is None or len(database.study_set) == 0:
@@ -722,6 +741,9 @@ def finalize_submission(
 
     study_id = database.study_set[0].id
     public_images = client.finalize_submission(submission_id, study_id=study_id)
+    yield Output(
+        SubmissionFinalizeResult.FINALIZED, output_name="submission_finalize_result"
+    )
 
     if not any(
         public_images.get(image_field)
@@ -742,7 +764,10 @@ def finalize_submission(
         public_images.get("primary_study_image_url"),
         public_images.get("study_image_urls"),
     )
-    yield Output(nmdc.Database(study_set=[database.study_set[0]]))
+    yield Output(
+        nmdc.Database(study_set=[database.study_set[0]]),
+        output_name="finalized_study_database",
+    )
 
 
 @op(required_resource_keys={"nmdc_portal_api_client"})
@@ -750,14 +775,20 @@ def finalize_sample_set(
     context: OpExecutionContext,
     run_summary: RunSummary,
     sample_set: Dict[str, Any],
+    submission_finalize_result: SubmissionFinalizeResult,
 ) -> None:
     """Finalize a sample set by calling the /api/metadata_submission/sample_set/{sample_set_id}/status
     endpoint to change the sample set's status to 'Released'.
 
     Skip this step if the preceding insert into MongoDB failed (as indicated by the
-    run_summary.status not being RunEventType.COMPLETE).
+    run_summary.status not being RunEventType.COMPLETE). This step also depends on a submission
+    finalize result emitted only after the parent submission has been finalized or was already
+    linked to an nmdc:Study.
     """
     client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
+    context.log.info(
+        f"Submission finalize result satisfied: {submission_finalize_result}"
+    )
     sample_set_id = sample_set["id"]
 
     if run_summary.status != RunEventType.COMPLETE:

--- a/nmdc_runtime/site/ops.py
+++ b/nmdc_runtime/site/ops.py
@@ -118,7 +118,7 @@ from toolz import get_in, valfilter, identity
 BULK_WRITE_BATCH_SIZE = 2000
 
 
-class SubmissionFinalizeResult(str, Enum):
+class FinalizeSubmissionResult(str, Enum):
     FINALIZED = "finalized"
     ALREADY_LINKED = "already_linked"
 
@@ -591,6 +591,12 @@ def get_submission_portal_pipeline_inputs(
     biosample_extras_slot_mapping_file_url: Optional[str],
     study_id: Optional[str],
 ) -> Tuple[str, str, str | None, str | None, str | None, str | None, str | None]:
+    """Collect inputs required for translating a submission portal submission.
+
+    This op defines required and optional inputs for translating a submission portal submission into
+    NMDC schema records. The values are returned as a tuple. This is defined as an op so that
+    multiple Dagster graphs can use the same input definition.
+    """
     return (
         submission_id,
         sample_set_id,
@@ -616,6 +622,14 @@ def fetch_nmdc_portal_submission_by_id(
 def validate_submission_sample_set_id(
     metadata_submission: Dict[str, Any], sample_set_id: str
 ) -> str:
+    """Validate that the sample_set_id is associated with the metadata_submission.
+
+    Some Dagster graphs accept both a submission ID and a sample set ID as inputs. It is expected
+    that the sample set ID is associated with the submission. To prevent accidental mismatches (for
+    example, a Dagster user re-uses a previous run configuration and forgets to update one of the
+    IDs), this op checks that the sample set ID is included in the submission's sample sets. If it
+    is not, a Failure is raised. If it is, the sample set ID is returned.
+    """
     submission_id = metadata_submission.get("id")
     sample_sets = metadata_submission.get("sample_sets")
 
@@ -725,7 +739,7 @@ def translate_portal_submission_to_nmdc_schema_database(
     required_resource_keys={"nmdc_portal_api_client"},
     out={
         "finalized_study_database": Out(is_required=False),
-        "submission_finalize_result": Out(SubmissionFinalizeResult),
+        "finalize_submission_result": Out(FinalizeSubmissionResult),
     },
 )
 def finalize_submission(
@@ -764,28 +778,32 @@ def finalize_submission(
             f"Submission '{submission_id}' is already associated with nmdc:Study '{nmdc_study_id}'; skipping submission finalization step."
         )
         yield Output(
-            SubmissionFinalizeResult.ALREADY_LINKED,
-            output_name="submission_finalize_result",
+            FinalizeSubmissionResult.ALREADY_LINKED,
+            output_name="finalize_submission_result",
         )
         return
 
     if database.study_set is None or len(database.study_set) == 0:
         context.log.info(
-            "No studies in nmdc.Database; skipping submission finalization step."
+            "No studies in nmdc:Database; skipping submission finalization step."
         )
         return
 
     if len(database.study_set) > 1:
         context.log.warning(
-            "Multiple studies in nmdc.Database; only finalizing the first study."
+            "Multiple studies in nmdc:Database; only finalizing the first study."
         )
 
+    # Call the submission portal API to finalize the submission and yield a result indicating that
+    # the submission was finalized. The API call returns optional public image URLs (if any were
+    # uploaded for the submission). These will handled after the finalize result is yielded.
     study_id = database.study_set[0].id
     public_images = client.finalize_submission(submission_id, study_id=study_id)
     yield Output(
-        SubmissionFinalizeResult.FINALIZED, output_name="submission_finalize_result"
+        FinalizeSubmissionResult.FINALIZED, output_name="finalize_submission_result"
     )
 
+    # Check if any public image URLs were returned by the API call
     if not any(
         public_images.get(image_field)
         for image_field in (
@@ -794,11 +812,17 @@ def finalize_submission(
             "study_image_urls",
         )
     ):
+        # This is an expected case where the user did not upload any images for this submission. In
+        # this case there is no further work to do. Just log a message and return.
         context.log.info(
-            f"Submission '{submission_id}' finalization did not return public image URLs; skipping Study update submission."
+            f"Submission '{submission_id}' finalization did not return public image URLs;"
+            f"no updates to nmdc:Study '{study_id}' to make."
         )
         return
 
+    # If any public image URLs were returned by the API call, update the nmdc:Study and yield a
+    # minimal "finalized" nmdc:Database containing only the updated nmdc:Study so the image URLs can
+    # be persisted through /metadata/json:submit.
     SubmissionPortalTranslator.set_study_images(
         database.study_set[0],
         public_images.get("pi_image_url"),
@@ -816,7 +840,7 @@ def finalize_sample_set(
     context: OpExecutionContext,
     run_summary: RunSummary,
     sample_set: Dict[str, Any],
-    submission_finalize_result: SubmissionFinalizeResult,
+    finalize_submission_result: FinalizeSubmissionResult,
 ) -> None:
     """Finalize a sample set by calling the /api/metadata_submission/sample_set/{sample_set_id}/status
     endpoint to change the sample set's status to 'Released'.
@@ -828,7 +852,7 @@ def finalize_sample_set(
     """
     client: NmdcPortalApiClient = context.resources.nmdc_portal_api_client
     context.log.info(
-        f"Submission finalize result satisfied: {submission_finalize_result}"
+        f"Submission finalize result satisfied: {finalize_submission_result}"
     )
     sample_set_id = sample_set["id"]
 

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -508,10 +508,11 @@ def biosample_submission_ingest():
                     },
                 ),
                 "ops": {
-                    "export_json_to_drs": {"config": {"username": "..."}},
+                    "export_json_to_drs": {"config": {"username": ""}},
                     "get_submission_portal_pipeline_inputs": {
                         "inputs": {
                             "submission_id": "",
+                            "sample_set_id": "",
                             "nucleotide_sequencing_mapping_file_url": None,
                             "data_object_mapping_file_url": None,
                             "biosample_extras_file_url": None,
@@ -549,6 +550,7 @@ def biosample_submission_ingest():
                     "get_submission_portal_pipeline_inputs": {
                         "inputs": {
                             "submission_id": "",
+                            "sample_set_id": "",
                             "nucleotide_sequencing_mapping_file_url": None,
                             "data_object_mapping_file_url": None,
                             "biosample_extras_file_url": None,

--- a/nmdc_runtime/site/resources.py
+++ b/nmdc_runtime/site/resources.py
@@ -554,6 +554,15 @@ class NmdcPortalApiClient:
         response.raise_for_status()
         return response.json()
 
+    def set_sample_set_status(self, sample_set_id: str, status: str) -> Dict[str, Any]:
+        response = self._request(
+            "PATCH",
+            f"/api/metadata_submission/sample_set/{sample_set_id}/status",
+            json={"status": status},
+        )
+        response.raise_for_status()
+        return response.json()
+
 
 @resource(
     config_schema={

--- a/nmdc_runtime/site/resources.py
+++ b/nmdc_runtime/site/resources.py
@@ -536,6 +536,13 @@ class NmdcPortalApiClient:
         response.raise_for_status()
         return response.json()
 
+    def fetch_sample_set(self, sample_set_id: str) -> Dict[str, Any]:
+        response = self._request(
+            "GET", f"/api/metadata_submission/sample_set/{sample_set_id}"
+        )
+        response.raise_for_status()
+        return response.json()
+
     def finalize_submission(
         self, submission_id: str, *, study_id: str
     ) -> Dict[str, Any]:

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from collections import namedtuple
+from copy import deepcopy
 from decimal import Decimal
 from functools import lru_cache
 from importlib import resources
@@ -139,16 +140,22 @@ def split_strip(string: str | None, sep: str) -> list[str] | None:
 class SubmissionPortalTranslator(Translator):
     """A Translator subclass for handling submission portal entries
 
-    This translator is constructed with a metadata_submission object from the
-    submission portal. Since the submission schema is built by importing slots
-    from the nmdc:Biosample class this translator largely works by introspecting
-    the nmdc:Biosample class (via a SchemaView instance)
+    This translator is constructed with a metadata_submission object and a
+    sample set object from the submission portal. Since the submission schema
+    is built by importing slots from the nmdc:Biosample class this translator
+    largely works by introspecting the nmdc:Biosample class (via a SchemaView
+    instance)
     """
 
     def __init__(
         self,
         metadata_submission: Optional[JSON_OBJECT] = None,
+        sample_set: Optional[JSON_OBJECT] = None,
         *args,
+        # Optional existing Study instance indicating that new Biosamples should be associated
+        # with this Study instead of minting a new Study.
+        existing_study: Optional[nmdc.Study] = None,
+        # Mapping sidecar files for handling data files associated with submission portal entries.
         nucleotide_sequencing_mapping: Optional[list] = None,
         data_object_mapping: Optional[list] = None,
         illumina_instrument_mapping: Optional[dict[str, str]] = None,
@@ -156,7 +163,6 @@ class SubmissionPortalTranslator(Translator):
         # See: https://github.com/microbiomedata/submission-schema/issues/162
         study_category: Optional[str] = None,
         study_pi_image_url: Optional[str] = None,
-        study_id: Optional[str] = None,
         # Additional biosample-level metadata with optional column mapping information not captured
         # by the submission portal currently.
         # See: https://github.com/microbiomedata/submission-schema/issues/162
@@ -167,6 +173,9 @@ class SubmissionPortalTranslator(Translator):
         super().__init__(*args, **kwargs)
 
         self.metadata_submission: JSON_OBJECT = metadata_submission or {}
+        self.sample_set: JSON_OBJECT = sample_set or {}
+        self.existing_study = existing_study
+
         self.nucleotide_sequencing_mapping = nucleotide_sequencing_mapping
         self.data_object_mapping = data_object_mapping
         self.illumina_instrument_mapping: dict[str, str] = (
@@ -177,7 +186,6 @@ class SubmissionPortalTranslator(Translator):
             nmdc.StudyCategoryEnum(study_category) if study_category else None
         )
         self.study_pi_image_url = study_pi_image_url
-        self.study_id = study_id
 
         self.biosample_extras = group_dicts_by_key(
             BIOSAMPLE_UNIQUE_KEY_SLOT, biosample_extras
@@ -192,7 +200,7 @@ class SubmissionPortalTranslator(Translator):
             "MaterialProcessing", reflexive=False
         ):
             class_def = self.schema_view.get_class(class_name)
-            if not class_def.abstract:
+            if class_def is not None and not class_def.abstract:
                 self._material_processing_subclass_names.append(class_name)
 
     def _get_pi(
@@ -203,7 +211,7 @@ class SubmissionPortalTranslator(Translator):
         :param metadata_submission: submission portal entry
         :return: nmdc:PersonValue
         """
-        study_form = metadata_submission.get("studyForm")
+        study_form = metadata_submission.get("study_form")
         if not study_form:
             return None
 
@@ -223,7 +231,7 @@ class SubmissionPortalTranslator(Translator):
         :param metadata_submission: submission portal entry
         :return: nmdc.CreditAssociation list
         """
-        contributors = get_in(["studyForm", "contributors"], metadata_submission)
+        contributors = get_in(["study_form", "contributors"], metadata_submission)
         if not contributors:
             return None
 
@@ -248,7 +256,7 @@ class SubmissionPortalTranslator(Translator):
         :param metadata_submission: submission portal entry
         :return: GOLD CURIE
         """
-        gold_study_id = get_in(["studyForm", "GOLDStudyId"], metadata_submission)
+        gold_study_id = get_in(["study_form", "GOLDStudyId"], metadata_submission)
         if not gold_study_id:
             return None
 
@@ -260,7 +268,7 @@ class SubmissionPortalTranslator(Translator):
         """Construct a NCBI Bioproject CURIE from the study form data"""
 
         ncbi_bioproject_id = get_in(
-            ["studyForm", "NCBIBioProjectId"], metadata_submission
+            ["study_form", "NCBIBioProjectId"], metadata_submission
         )
         if not ncbi_bioproject_id:
             return None
@@ -268,28 +276,28 @@ class SubmissionPortalTranslator(Translator):
         return [self._ensure_curie(ncbi_bioproject_id, default_prefix="bioproject")]
 
     def _get_jgi_study_identifiers(
-        self, metadata_submission: JSON_OBJECT
+        self, sample_set: JSON_OBJECT
     ) -> Union[List[str], None]:
         """Construct a JGI proposal CURIE from the multiomics form data
 
-        :param metadata_submission: submission portal entry
+        :param sample_set: submission sample set object
         :return: JGI proposal CURIE
         """
-        jgi_study_id = get_in(["multiOmicsForm", "JGIStudyId"], metadata_submission)
+        jgi_study_id = get_in(["multi_omics_form", "JGIStudyId"], sample_set)
         if not jgi_study_id:
             return None
 
         return [self._ensure_curie(jgi_study_id, default_prefix="jgi.proposal")]
 
     def _get_emsl_project_identifiers(
-        self, metadata_submission: JSON_OBJECT
+        self, sample_set: JSON_OBJECT
     ) -> Union[List[str], None]:
         """Construct an EMSL project CURIE from the multiomics form data
 
-        :param metadata_submission: submission portal entry
+        :param sample_set: submission sample set object
         :return: EMSL project CURIE
         """
-        emsl_project_id = get_in(["multiOmicsForm", "studyNumber"], metadata_submission)
+        emsl_project_id = get_in(["multi_omics_form", "studyNumber"], sample_set)
         if not emsl_project_id:
             return None
 
@@ -444,20 +452,20 @@ class SubmissionPortalTranslator(Translator):
         except (ValueError, TypeError):
             return None
 
-    def _get_from(self, metadata_submission: JSON_OBJECT, field: Union[str, List[str]]):
+    def _get_from(self, json_object: JSON_OBJECT, field: Union[str, List[str]]):
         """Extract and sanitize a value from a nested dict
 
-        For field = [i0, i1, ..., iN] extract metadata_submission[i0][i1]...[iN]. This
-        value is then sanitized by trimming strings, replacing empty strings with None,
-        filtering Nones and empty strings from arrays.
+        For field = [i0, i1, ..., iN] extract json_object[i0][i1]...[iN]. This value is then
+        sanitized by trimming strings, replacing empty strings with None, filtering Nones and
+        empty strings from arrays.
 
-        :param metadata_submission: submission portal entry
+        :param json_object: submission portal form object
         :param field: list of nested fields to extract
         :return: sanitized value
         """
         if not isinstance(field, list):
             field = [field]
-        value = get_in(field, metadata_submission)
+        value = get_in(field, json_object)
 
         def sanitize(val):
             sanitized = val
@@ -477,7 +485,32 @@ class SubmissionPortalTranslator(Translator):
 
         return value
 
-    def _get_study_dois(self, metadata_submission) -> Union[List[nmdc.Doi], None]:
+    def _extend_list(
+        self, original: Optional[List], to_extend: Optional[List]
+    ) -> Optional[List]:
+        """Extend a list with another list, handling the case where one or both lists are None or empty.
+
+        :param original: original list
+        :param to_extend: list to extend with
+        :return: extended list or None
+        """
+        if original is None and to_extend is None:
+            return None
+
+        elif original is None:
+            extended = to_extend
+        elif to_extend is None:
+            extended = original
+        else:
+            extended = original + to_extend
+
+        if not extended:
+            return None
+        return extended
+
+    def _get_study_dois(
+        self, metadata_submission: JSON_OBJECT
+    ) -> Union[List[nmdc.Doi], None]:
         """Collect and translate DOI info from submission into nmdc-schema DOI instances
 
         If there were no DOIs, None is returned.
@@ -490,9 +523,8 @@ class SubmissionPortalTranslator(Translator):
         # `doi_category` slot in the nmdc:Doi object and field is the list of nested fields to
         # extract the DOI information from in the submission portal entry.
         doi_configs = [
-            ("dataset_doi", ["studyForm", "dataDois"]),
-            ("award_doi", ["multiOmicsForm", "awardDois"]),
-            ("publication_doi", ["studyForm", "publicationDois"]),
+            ("dataset_doi", ["study_form", "dataDois"]),
+            ("publication_doi", ["study_form", "publicationDois"]),
         ]
 
         study_dois = []
@@ -514,6 +546,33 @@ class SubmissionPortalTranslator(Translator):
                 )
 
         return study_dois if study_dois else None
+
+    def _get_sample_set_dois(
+        self, sample_set: JSON_OBJECT
+    ) -> Union[List[nmdc.Doi], None]:
+        """Collect and translate DOI info from sample set into nmdc-schema DOI instances
+
+        If there were no DOIs, None is returned.
+
+        :param sample_set: sample set object from submission portal
+        :return: list of nmdc:Doi objects
+        """
+
+        raw_dois = self._get_from(sample_set, ["multi_omics_form", "awardDois"])
+        if not raw_dois:
+            return None
+
+        sample_set_dois = [
+            nmdc.Doi(
+                doi_category="award_doi",
+                doi_provider=doi["provider"],
+                doi_value=self._ensure_curie(doi["value"], default_prefix="doi"),
+                type="nmdc:Doi",
+            )
+            for doi in raw_dois
+        ]
+
+        return sample_set_dois if sample_set_dois else None
 
     def _get_data_objects_from_fields(
         self,
@@ -610,17 +669,14 @@ class SubmissionPortalTranslator(Translator):
         """
         return nmdc.Study(
             alternative_names=self._get_from(
-                metadata_submission, ["studyForm", "alternativeNames"]
+                metadata_submission, ["study_form", "alternativeNames"]
             ),
             associated_dois=self._get_study_dois(metadata_submission),
             description=self._get_from(
-                metadata_submission, ["studyForm", "description"]
+                metadata_submission, ["study_form", "description"]
             ),
             funding_sources=self._get_from(
-                metadata_submission, ["studyForm", "fundingSources"]
-            ),
-            emsl_project_identifiers=self._get_emsl_project_identifiers(
-                metadata_submission
+                metadata_submission, ["study_form", "fundingSources"]
             ),
             gold_study_identifiers=self._get_gold_study_identifiers(
                 metadata_submission
@@ -632,18 +688,15 @@ class SubmissionPortalTranslator(Translator):
             insdc_bioproject_identifiers=self._get_ncbi_bioproject_identifiers(
                 metadata_submission
             ),
-            jgi_portal_study_identifiers=self._get_jgi_study_identifiers(
-                metadata_submission
-            ),
-            name=self._get_from(metadata_submission, ["studyForm", "studyName"]),
-            notes=self._get_from(metadata_submission, ["studyForm", "notes"]),
+            name=self._get_from(metadata_submission, ["study_form", "studyName"]),
+            notes=self._get_from(metadata_submission, ["study_form", "notes"]),
             principal_investigator=self._get_pi(metadata_submission),
             provenance_metadata=provenance_metadata,
             study_category=self.study_category,
-            title=self._get_from(metadata_submission, ["studyForm", "studyName"]),
+            title=self._get_from(metadata_submission, ["study_form", "studyName"]),
             type="nmdc:Study",
             websites=self._get_from(
-                metadata_submission, ["studyForm", "linkOutWebpage"]
+                metadata_submission, ["study_form", "linkOutWebpage"]
             ),
         )
 
@@ -900,29 +953,38 @@ class SubmissionPortalTranslator(Translator):
         """
         database = nmdc.Database()
         submission_id = self.metadata_submission.get("id")
-        metadata_submission_data = self.metadata_submission.get(
-            "metadata_submission", {}
-        )
         provenance_metadata = self._get_provenance_metadata(
             source_system_of_record=nmdc.SourceSystemEnum.NMDC_Submission_Portal.text,
             submission_portal_identifier=submission_id,
         )
-        # Generate one Study instance based on the metadata submission, if a study_id wasn't provided
-        if self.study_id:
-            nmdc_study_id = self.study_id
+        # Generate one Study instance based on the metadata submission if an existing study
+        # wasn't provided.
+        if self.existing_study:
+            nmdc_study_id = self.existing_study.id
+            nmdc_study = deepcopy(self.existing_study)
         else:
             nmdc_study_id = self._id_minter("nmdc:Study")[0]
-            database.study_set = [
-                self._translate_study(
-                    metadata_submission_data, nmdc_study_id, provenance_metadata
-                )
-            ]
+            nmdc_study = self._translate_study(
+                self.metadata_submission, nmdc_study_id, provenance_metadata
+            )
+
+        # Populate the Study fields that are derived from values on sample set forms.
+        nmdc_study.associated_dois = self._extend_list(
+            nmdc_study.associated_dois, self._get_sample_set_dois(self.sample_set)
+        )
+        nmdc_study.emsl_project_identifiers = self._extend_list(
+            nmdc_study.emsl_project_identifiers,
+            self._get_emsl_project_identifiers(self.sample_set),
+        )
+        nmdc_study.jgi_portal_study_identifiers = self._extend_list(
+            nmdc_study.jgi_portal_study_identifiers,
+            self._get_jgi_study_identifiers(self.sample_set),
+        )
+        database.study_set.append(nmdc_study)
 
         # Automatically populate the `env_package` field in the sample data based on which
         # environmental data tab the sample data came from.
-        sample_data = get_in(
-            ["sampleData", "data"], metadata_submission_data, default={}
-        )
+        sample_data = get_in(["sample_data", "data"], self.sample_set, default={})
         for key in sample_data.keys():
             data_field_info = DATA_FIELDS.get(key)
             if data_field_info is None:

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -5,7 +5,17 @@ from copy import deepcopy
 from decimal import Decimal
 from functools import lru_cache
 from importlib import resources
-from typing import Any, List, Optional, Union, Tuple, TypedDict, Literal
+from typing import (
+    Any,
+    Callable,
+    Hashable,
+    List,
+    Optional,
+    Union,
+    Tuple,
+    TypedDict,
+    Literal,
+)
 from urllib.parse import urlparse
 
 from linkml_runtime import SchemaView
@@ -485,28 +495,32 @@ class SubmissionPortalTranslator(Translator):
 
         return value
 
-    def _extend_list(
-        self, original: Optional[List], to_extend: Optional[List]
+    def _merge_list(
+        self,
+        target: Optional[List],
+        source: Optional[List],
+        *,
+        key: Callable[[Any], Hashable] = lambda item: item,
     ) -> Optional[List]:
-        """Extend a list with another list, handling the case where one or both lists are None or empty.
+        """Merge two lists while preserving order and removing duplicates.
 
-        :param original: original list
-        :param to_extend: list to extend with
-        :return: extended list or None
+        :param target: original list
+        :param source: list to merge into the target
+        :param key: function that returns a unique identifier for each list item
+        :return: merged list or None
         """
-        if original is None and to_extend is None:
-            return None
+        merged = []
+        seen = set()
+        for item in (target or []) + (source or []):
+            dedupe_key = key(item)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            merged.append(item)
 
-        elif original is None:
-            extended = to_extend
-        elif to_extend is None:
-            extended = original
-        else:
-            extended = original + to_extend
-
-        if not extended:
+        if not merged:
             return None
-        return extended
+        return merged
 
     def _get_study_dois(
         self, metadata_submission: JSON_OBJECT
@@ -969,14 +983,20 @@ class SubmissionPortalTranslator(Translator):
             )
 
         # Populate the Study fields that are derived from values on sample set forms.
-        nmdc_study.associated_dois = self._extend_list(
-            nmdc_study.associated_dois, self._get_sample_set_dois(self.sample_set)
+        nmdc_study.associated_dois = self._merge_list(
+            nmdc_study.associated_dois,
+            self._get_sample_set_dois(self.sample_set),
+            key=lambda doi: (
+                str(doi.doi_value),
+                str(doi.doi_provider),
+                str(doi.doi_category),
+            ),
         )
-        nmdc_study.emsl_project_identifiers = self._extend_list(
+        nmdc_study.emsl_project_identifiers = self._merge_list(
             nmdc_study.emsl_project_identifiers,
             self._get_emsl_project_identifiers(self.sample_set),
         )
-        nmdc_study.jgi_portal_study_identifiers = self._extend_list(
+        nmdc_study.jgi_portal_study_identifiers = self._merge_list(
             nmdc_study.jgi_portal_study_identifiers,
             self._get_jgi_study_identifiers(self.sample_set),
         )

--- a/nmdc_runtime/site/translation/submission_portal_translator.py
+++ b/nmdc_runtime/site/translation/submission_portal_translator.py
@@ -152,7 +152,7 @@ class SubmissionPortalTranslator(Translator):
 
     This translator is constructed with a metadata_submission object and a
     sample set object from the submission portal. Since the submission schema
-    is built by importing slots from the nmdc:Biosample class this translator
+    is built by importing slots from the nmdc:Biosample class, this translator
     largely works by introspecting the nmdc:Biosample class (via a SchemaView
     instance)
     """
@@ -465,9 +465,9 @@ class SubmissionPortalTranslator(Translator):
     def _get_from(self, json_object: JSON_OBJECT, field: Union[str, List[str]]):
         """Extract and sanitize a value from a nested dict
 
-        For field = [i0, i1, ..., iN] extract json_object[i0][i1]...[iN]. This value is then
-        sanitized by trimming strings, replacing empty strings with None, filtering Nones and
-        empty strings from arrays.
+        For field = [i0, i1, ..., iN], extract the value at json_object[i0][i1]...[iN]. This
+        value is then sanitized by trimming strings, replacing empty strings with None,
+        and filtering Nones and empty strings from arrays.
 
         :param json_object: submission portal form object
         :param field: list of nested fields to extract

--- a/tests/test_data/data/isolate_only_input.yaml
+++ b/tests/test_data/data/isolate_only_input.yaml
@@ -1,99 +1,21 @@
 metadata_submission:
-  metadata_submission:
-    sampleEnvironmentForm:
-      packageName:
-        - isolate
-      validation: []
-    senderShippingInfoForm:
-      shipper:
-        name: ""
-        email: ""
-        phone: ""
-        line1: ""
-        line2: ""
-        city: ""
-        state: ""
-        postalCode: ""
-        country: ""
-      expectedShippingDate: null
-      shippingConditions: ""
-      sample: ""
-      description: ""
-      experimentalGoals: ""
-      randomization: ""
-      usdaRegulated: null
-      permitNumber: ""
-      biosafetyLevel: ""
-      irbOrHipaa: null
-      comments: ""
-      validation: null
-    templates:
-      - isolate
-    studyForm:
-      studyName: Isolate Only
-      piName: ""
-      piEmail: tester@example.gov
-      piOrcid: ""
-      fundingSources: []
-      dataDois: []
-      publicationDois: []
-      linkOutWebpage: []
-      studyDate: null
-      description: ""
-      notes: ""
-      contributors: []
-      validation: []
-      alternativeNames: []
-      GOLDStudyId: ""
-      NCBIBioProjectId: ""
-    multiOmicsForm:
-      award: null
-      awardDois: []
-      dataGenerated: false
-      doe: false
-      facilities: []
-      facilityGenerated: null
-      JGIStudyId: ""
-      mgCompatible: null
-      mgInterleaved: null
-      mtCompatible: null
-      mtInterleaved: null
-      omicsProcessingTypes:
-        - isolate-genome
-        - isolate-transcriptome
-      otherAward: null
-      ship: null
-      studyNumber: ""
-      unknownDoi: null
-      mpProtocols: null
-      mbProtocols: null
-      mbGcProtocols: null
-      lipProtocols: null
-      nomProtocols: null
-      nomLcProtocols: null
-      validation: []
-    sampleData:
-      data:
-        isolate_data:
-          - ploidy: haploid
-            samp_name: "0001"
-            gc_content: 50
-            strain_name: Shewanella loihica PV-4
-            isolate_name: Bd21-3
-            analysis_type:
-              - isolate genome sequencing
-            classified_as: NCBITaxon:562
-            organism_genus: Shewanella
-            collection_date: 2013-03-25
-            organism_species: Shewanella loihica
-            isolate_single_colony: yes
-            isolate_known_contaminants: Bacillus subtilis ~5%
-      validation:
-        invalidCells:
-          isolate: {}
-        tabsValidated:
-          isolate: true
-  status: InProgress
+  study_form:
+    studyName: Isolate Only
+    piName: ""
+    piEmail: tester@example.gov
+    piOrcid: ""
+    fundingSources: []
+    dataDois: []
+    publicationDois: []
+    linkOutWebpage: []
+    studyDate: null
+    description: ""
+    notes: ""
+    contributors: []
+    validation: []
+    alternativeNames: []
+    GOLDStudyId: ""
+    NCBIBioProjectId: ""
   source_client: submission_portal
   is_test_submission: false
   id: 91213966-e36d-40b1-841d-4f6c10c1af21
@@ -104,11 +26,8 @@ metadata_submission:
     email: tester@example.gov
     is_admin: true
   study_name: Isolate Only
-  templates:
-    - isolate
   date_last_modified: 2026-06-18T00:03:42.507587
   created: 2026-06-18T00:03:07.804543
-  sample_count: 0
   reviewers: []
   contributors:
     - 0000-0000-0000-000X
@@ -121,3 +40,85 @@ metadata_submission:
   pi_image_url: null
   primary_study_image_url: null
   study_image_urls: []
+sample_set:
+  created: 2026-06-18T00:03:07.804543
+  date_last_modified: 2026-06-18T00:03:42.507587
+  id: e71d0b3c-00d7-4380-afed-a00934188ce9
+  multi_omics_form:
+    award: null
+    awardDois: []
+    dataGenerated: false
+    doe: false
+    facilities: []
+    facilityGenerated: null
+    JGIStudyId: ""
+    mgCompatible: null
+    mgInterleaved: null
+    mtCompatible: null
+    mtInterleaved: null
+    omicsProcessingTypes:
+      - isolate-genome
+      - isolate-transcriptome
+    otherAward: null
+    ship: null
+    studyNumber: ""
+    unknownDoi: null
+    mpProtocols: null
+    mbProtocols: null
+    mbGcProtocols: null
+    lipProtocols: null
+    nomProtocols: null
+    nomLcProtocols: null
+    validation: []
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      isolate_data:
+        - ploidy: haploid
+          samp_name: "0001"
+          gc_content: 50
+          strain_name: Shewanella loihica PV-4
+          isolate_name: Bd21-3
+          analysis_type:
+            - isolate genome sequencing
+          classified_as: NCBITaxon:562
+          organism_genus: Shewanella
+          collection_date: 2013-03-25
+          organism_species: Shewanella loihica
+          isolate_single_colony: yes
+          isolate_known_contaminants: Bacillus subtilis ~5%
+    validation:
+      invalidCells:
+        isolate: {}
+      tabsValidated:
+        isolate: true
+  sample_environment_form:
+    packageName:
+      - isolate
+    validation: []
+  sender_shipping_info_form:
+    shipper:
+      name: ""
+      email: ""
+      phone: ""
+      line1: ""
+      line2: ""
+      city: ""
+      state: ""
+      postalCode: ""
+      country: ""
+    expectedShippingDate: null
+    shippingConditions: ""
+    sample: ""
+    description: ""
+    experimentalGoals: ""
+    randomization: ""
+    usdaRegulated: null
+    permitNumber: ""
+    biosafetyLevel: ""
+    irbOrHipaa: null
+    comments: ""
+    validation: null
+  status: InProgress
+  templates:
+    - isolate

--- a/tests/test_data/data/isolate_soil_input.yaml
+++ b/tests/test_data/data/isolate_soil_input.yaml
@@ -1,118 +1,21 @@
 metadata_submission:
-  metadata_submission:
-    sampleEnvironmentForm:
-      packageName:
-        - isolate
-        - soil
-      validation: []
-    senderShippingInfoForm:
-      shipper:
-        name: ""
-        email: ""
-        phone: ""
-        line1: ""
-        line2: ""
-        city: ""
-        state: ""
-        postalCode: ""
-        country: ""
-      expectedShippingDate: null
-      shippingConditions: ""
-      sample: ""
-      description: ""
-      experimentalGoals: ""
-      randomization: ""
-      usdaRegulated: null
-      permitNumber: ""
-      biosafetyLevel: ""
-      irbOrHipaa: null
-      comments: ""
-      validation: null
-    templates:
-      - isolate
-      - soil
-    studyForm:
-      studyName: Isolate + Soil
-      piName: ""
-      piEmail: tester@example.gov
-      piOrcid: ""
-      fundingSources: []
-      dataDois: []
-      publicationDois: []
-      linkOutWebpage: []
-      studyDate: null
-      description: ""
-      notes: ""
-      contributors: []
-      validation: []
-      alternativeNames: []
-      GOLDStudyId: ""
-      NCBIBioProjectId: ""
-    multiOmicsForm:
-      award: null
-      awardDois: []
-      dataGenerated: false
-      doe: false
-      facilities: []
-      facilityGenerated: null
-      JGIStudyId: ""
-      mgCompatible: null
-      mgInterleaved: null
-      mtCompatible: null
-      mtInterleaved: null
-      omicsProcessingTypes:
-        - isolate-genome
-      otherAward: null
-      ship: null
-      studyNumber: ""
-      unknownDoi: null
-      mpProtocols: null
-      mbProtocols: null
-      mbGcProtocols: null
-      lipProtocols: null
-      nomProtocols: null
-      nomLcProtocols: null
-      validation: []
-    sampleData:
-      data:
-        soil_data:
-          - elev: 0
-            depth: 0 - 1
-            lat_lon: 0 0
-            samp_name: soil-001
-            env_medium: acidic soil [ENVO:01001185]
-            store_cond: frozen
-            geo_loc_name: "USA: Fake, Fake"
-            growth_facil: experimental_garden
-            analysis_type:
-              - metagenomics
-            collection_date: "2021"
-            env_broad_scale: alpine tundra biome [ENVO:01001505]
-            env_local_scale: active permafrost layer [ENVO:04000009]
-            samp_store_temp: 0
-        isolate_data:
-          - ploidy: triploid
-            samp_name: isolate-001
-            sample_link: soil-001
-            gc_content: 0
-            strain_name: Lorem ipsum dolor sit
-            isolate_name: Lorem ipsum dolor sit 0001
-            analysis_type:
-              - isolate genome sequencing
-            classified_as: NCBITaxon:0001
-            organism_genus: Lorem
-            collection_date: 2021-01-01
-            organism_species: Lorem ipsum
-            isolate_single_colony: yes
-            isolate_known_contaminants: Consectetur adipiscing 1%
-      validation:
-        invalidCells:
-          soil: {}
-          isolate: {}
-        tabsValidated:
-          soil: true
-          isolate: true
-  status: InProgress
+  study_form:
+    studyName: Isolate + Soil
+    piName: ""
+    piEmail: tester@example.gov
+    piOrcid: ""
+    fundingSources: []
+    dataDois: []
+    publicationDois: []
+    linkOutWebpage: []
+    studyDate: null
+    description: ""
+    notes: ""
+    contributors: []
+    validation: []
+    alternativeNames: []
+    GOLDStudyId: ""
+    NCBIBioProjectId: ""
   source_client: submission_portal
   is_test_submission: false
   id: ef59f345-8c89-4201-bcdc-28ca1f6919ca
@@ -123,12 +26,8 @@ metadata_submission:
     email: tester@example.gov
     is_admin: true
   study_name: Isolate + Soil
-  templates:
-    - isolate
-    - soil
   date_last_modified: 2026-06-18T18:19:43.435496
   created: 2026-06-18T18:19:19.301941
-  sample_count: 1
   reviewers: []
   contributors:
     - 0000-0000-0000-000X
@@ -141,3 +40,104 @@ metadata_submission:
   pi_image_url: null
   primary_study_image_url: null
   study_image_urls: []
+sample_set:
+  created: 2026-06-18T18:19:19.301941
+  date_last_modified: 2026-06-18T18:19:43.435496
+  id: 01964988-ff83-5e12-a95e-bf4c0c5c1baa
+  multi_omics_form:
+    award: null
+    awardDois: []
+    dataGenerated: false
+    doe: false
+    facilities: []
+    facilityGenerated: null
+    JGIStudyId: ""
+    mgCompatible: null
+    mgInterleaved: null
+    mtCompatible: null
+    mtInterleaved: null
+    omicsProcessingTypes:
+      - isolate-genome
+    otherAward: null
+    ship: null
+    studyNumber: ""
+    unknownDoi: null
+    mpProtocols: null
+    mbProtocols: null
+    mbGcProtocols: null
+    lipProtocols: null
+    nomProtocols: null
+    nomLcProtocols: null
+    validation: []
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      soil_data:
+        - elev: 0
+          depth: 0 - 1
+          lat_lon: 0 0
+          samp_name: soil-001
+          env_medium: acidic soil [ENVO:01001185]
+          store_cond: frozen
+          geo_loc_name: "USA: Fake, Fake"
+          growth_facil: experimental_garden
+          analysis_type:
+            - metagenomics
+          collection_date: "2021"
+          env_broad_scale: alpine tundra biome [ENVO:01001505]
+          env_local_scale: active permafrost layer [ENVO:04000009]
+          samp_store_temp: 0
+      isolate_data:
+        - ploidy: triploid
+          samp_name: isolate-001
+          sample_link: soil-001
+          gc_content: 0
+          strain_name: Lorem ipsum dolor sit
+          isolate_name: Lorem ipsum dolor sit 0001
+          analysis_type:
+            - isolate genome sequencing
+          classified_as: NCBITaxon:0001
+          organism_genus: Lorem
+          collection_date: 2021-01-01
+          organism_species: Lorem ipsum
+          isolate_single_colony: yes
+          isolate_known_contaminants: Consectetur adipiscing 1%
+    validation:
+      invalidCells:
+        soil: {}
+        isolate: {}
+      tabsValidated:
+        soil: true
+        isolate: true
+  sample_environment_form:
+    packageName:
+      - isolate
+      - soil
+    validation: []
+  sender_shipping_info_form:
+    shipper:
+      name: ""
+      email: ""
+      phone: ""
+      line1: ""
+      line2: ""
+      city: ""
+      state: ""
+      postalCode: ""
+      country: ""
+    expectedShippingDate: null
+    shippingConditions: ""
+    sample: ""
+    description: ""
+    experimentalGoals: ""
+    randomization: ""
+    usdaRegulated: null
+    permitNumber: ""
+    biosafetyLevel: ""
+    irbOrHipaa: null
+    comments: ""
+    validation: null
+  status: InProgress
+  templates:
+    - isolate
+    - soil

--- a/tests/test_data/data/isolate_soil_jgi_input.yaml
+++ b/tests/test_data/data/isolate_soil_jgi_input.yaml
@@ -1,143 +1,21 @@
 metadata_submission:
-  metadata_submission:
-    sampleEnvironmentForm:
-      packageName:
-        - isolate
-        - soil
-      validation: [ ]
-    senderShippingInfoForm:
-      shipper:
-        name: ""
-        email: ""
-        phone: ""
-        line1: ""
-        line2: ""
-        city: ""
-        state: ""
-        postalCode: ""
-        country: ""
-      expectedShippingDate: null
-      shippingConditions: ""
-      sample: ""
-      description: ""
-      experimentalGoals: ""
-      randomization: ""
-      usdaRegulated: null
-      permitNumber: ""
-      biosafetyLevel: ""
-      irbOrHipaa: null
-      comments: ""
-      validation: null
-    templates:
-      - isolate
-      - soil
-      - jgi_isolate_genome
-    studyForm:
-      studyName: Soil + Isolate + JGI
-      piName: ""
-      piEmail: tester@example.gov
-      piOrcid: ""
-      fundingSources: [ ]
-      dataDois: [ ]
-      publicationDois: [ ]
-      linkOutWebpage: [ ]
-      studyDate: null
-      description: ""
-      notes: ""
-      contributors: [ ]
-      validation: [ ]
-      alternativeNames: [ ]
-      GOLDStudyId: ""
-      NCBIBioProjectId: ""
-    multiOmicsForm:
-      award: CSP
-      awardDois:
-        - value: "10.123/abcd"
-          provider: "jgi"
-      dataGenerated: false
-      doe: true
-      facilities:
-        - JGI
-      facilityGenerated: null
-      JGIStudyId: "123456"
-      mgCompatible: null
-      mgInterleaved: null
-      mtCompatible: null
-      mtInterleaved: null
-      omicsProcessingTypes:
-        - isolate-genome-jgi
-      otherAward: ""
-      ship: null
-      studyNumber: ""
-      unknownDoi: false
-      mpProtocols: null
-      mbProtocols: null
-      mbGcProtocols: null
-      lipProtocols: null
-      nomProtocols: null
-      nomLcProtocols: null
-      validation: [ ]
-    sampleData:
-      data:
-        soil_data:
-          - elev: 0
-            depth: 0 - 1
-            lat_lon: 0 0
-            samp_name: soil-001
-            env_medium: acidic soil [ENVO:01001185]
-            store_cond: fresh
-            geo_loc_name: "USA: Test, Test"
-            growth_facil: experimental_garden
-            analysis_type:
-              - metagenomics
-            collection_date: "2021"
-            env_broad_scale: alpine tundra biome [ENVO:01001505]
-            env_local_scale: active permafrost layer [ENVO:04000009]
-            samp_store_temp: 0
-        isolate_data:
-          - ploidy: haploid
-            samp_name: isolate-001
-            gc_content: 0
-            sample_link: soil-001
-            strain_name: Lorem ipsum dolor sit
-            isolate_name: Lorem ipsum dolor sit 0001
-            analysis_type:
-              - isolate genome sequencing
-            classified_as: NCBITaxon:0001
-            organism_genus: Lorem
-            collection_date: 2021-01-01
-            organism_species: Lorem ipsum
-            isolate_single_colony: yes
-            isolate_known_contaminants: Consectetur adipiscing 1%
-        jgi_isolate_genome_data:
-          - dnase: no
-            cont_type: plate
-            cont_well: B1
-            samp_name: isolate-001
-            analysis_type:
-              - isolate genome sequencing
-            container_name: plate 1
-            estimated_size: 4.6
-            jgi_sample_name: JGI_pond_041618
-            replicate_group: SampleGroup1
-            dna_isolate_meth: phenol/chloroform extraction
-            nuc_acid_absorb1: 2.02
-            nuc_acid_absorb2: 2.02
-            biosafety_mat_cat: Alga
-            jgi_sample_format: Water
-            jgi_sample_volume: 25
-            sample_isolated_from: soil
-            nuc_acid_concentration: 100
-      validation:
-        invalidCells:
-          soil: { }
-          isolate: { }
-          jgi_isolate_genome: { }
-        tabsValidated:
-          soil: true
-          isolate: true
-          jgi_isolate_genome: true
-  status: InProgress
+  study_form:
+    studyName: Soil + Isolate + JGI
+    piName: ""
+    piEmail: tester@example.gov
+    piOrcid: ""
+    fundingSources: [ ]
+    dataDois: [ ]
+    publicationDois: [ ]
+    linkOutWebpage: [ ]
+    studyDate: null
+    description: ""
+    notes: ""
+    contributors: [ ]
+    validation: [ ]
+    alternativeNames: [ ]
+    GOLDStudyId: ""
+    NCBIBioProjectId: ""
   source_client: submission_portal
   is_test_submission: false
   id: ef59f345-8c89-4201-bcdc-28ca1f6919ca
@@ -148,12 +26,8 @@ metadata_submission:
     email: tester@example.gov
     is_admin: true
   study_name: Isolate + Soil
-  templates:
-    - isolate
-    - soil
   date_last_modified: 2026-06-18T18:19:43.435496
   created: 2026-06-18T18:19:19.301941
-  sample_count: 1
   reviewers: []
   contributors:
     - 0000-0000-0000-000X
@@ -166,3 +40,129 @@ metadata_submission:
   pi_image_url: null
   primary_study_image_url: null
   study_image_urls: []
+sample_set:
+  created: 2026-06-18T18:19:19.301941
+  date_last_modified: 2026-06-18T18:19:43.435496
+  id: ef849776-d196-5499-b83f-7ba26474694e
+  multi_omics_form:
+    award: CSP
+    awardDois:
+      - value: "10.123/abcd"
+        provider: "jgi"
+    dataGenerated: false
+    doe: true
+    facilities:
+      - JGI
+    facilityGenerated: null
+    JGIStudyId: "123456"
+    mgCompatible: null
+    mgInterleaved: null
+    mtCompatible: null
+    mtInterleaved: null
+    omicsProcessingTypes:
+      - isolate-genome-jgi
+    otherAward: ""
+    ship: null
+    studyNumber: ""
+    unknownDoi: false
+    mpProtocols: null
+    mbProtocols: null
+    mbGcProtocols: null
+    lipProtocols: null
+    nomProtocols: null
+    nomLcProtocols: null
+    validation: [ ]
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      soil_data:
+        - elev: 0
+          depth: 0 - 1
+          lat_lon: 0 0
+          samp_name: soil-001
+          env_medium: acidic soil [ENVO:01001185]
+          store_cond: fresh
+          geo_loc_name: "USA: Test, Test"
+          growth_facil: experimental_garden
+          analysis_type:
+            - metagenomics
+          collection_date: "2021"
+          env_broad_scale: alpine tundra biome [ENVO:01001505]
+          env_local_scale: active permafrost layer [ENVO:04000009]
+          samp_store_temp: 0
+      isolate_data:
+        - ploidy: haploid
+          samp_name: isolate-001
+          gc_content: 0
+          sample_link: soil-001
+          strain_name: Lorem ipsum dolor sit
+          isolate_name: Lorem ipsum dolor sit 0001
+          analysis_type:
+            - isolate genome sequencing
+          classified_as: NCBITaxon:0001
+          organism_genus: Lorem
+          collection_date: 2021-01-01
+          organism_species: Lorem ipsum
+          isolate_single_colony: yes
+          isolate_known_contaminants: Consectetur adipiscing 1%
+      jgi_isolate_genome_data:
+        - dnase: no
+          cont_type: plate
+          cont_well: B1
+          samp_name: isolate-001
+          analysis_type:
+            - isolate genome sequencing
+          container_name: plate 1
+          estimated_size: 4.6
+          jgi_sample_name: JGI_pond_041618
+          replicate_group: SampleGroup1
+          dna_isolate_meth: phenol/chloroform extraction
+          nuc_acid_absorb1: 2.02
+          nuc_acid_absorb2: 2.02
+          biosafety_mat_cat: Alga
+          jgi_sample_format: Water
+          jgi_sample_volume: 25
+          sample_isolated_from: soil
+          nuc_acid_concentration: 100
+    validation:
+      invalidCells:
+        soil: { }
+        isolate: { }
+        jgi_isolate_genome: { }
+      tabsValidated:
+        soil: true
+        isolate: true
+        jgi_isolate_genome: true
+  sample_environment_form:
+    packageName:
+      - isolate
+      - soil
+    validation: [ ]
+  sender_shipping_info_form:
+    shipper:
+      name: ""
+      email: ""
+      phone: ""
+      line1: ""
+      line2: ""
+      city: ""
+      state: ""
+      postalCode: ""
+      country: ""
+    expectedShippingDate: null
+    shippingConditions: ""
+    sample: ""
+    description: ""
+    experimentalGoals: ""
+    randomization: ""
+    usdaRegulated: null
+    permitNumber: ""
+    biosafetyLevel: ""
+    irbOrHipaa: null
+    comments: ""
+    validation: null
+  status: InProgress
+  templates:
+    - isolate
+    - soil
+    - jgi_isolate_genome

--- a/tests/test_data/data/nucleotide_sequencing_mapping_input.yaml
+++ b/tests/test_data/data/nucleotide_sequencing_mapping_input.yaml
@@ -1,54 +1,57 @@
 metadata_submission:
+  study_form:
+    GOLDStudyId: ''
+    alternativeNames: [ ]
+    NCBIBioProjectId: ''
+    contributors:
+      - name: Test Testerson
+        type: nmdc:PersonValue
+        orcid: 0000-0000-0000-0000
+        roles:
+          - Principal Investigator
+    description: This is a test submission
+    fundingSources:
+      - Some award ABC
+      - Some award XYZ
+    linkOutWebpage:
+      - http://www.example.com/submission-test
+    piEmail: test.testerson@example.com
+    piName: Test Testerson
+    piOrcid: 0000-0000-0000-0000
+    studyName: A test submission
   id: 00000000-0000-0000-0000-000000000000
-  metadata_submission:
+sample_set:
+  id: 7bc23571-6a34-5c42-998a-3fb41297ff5f
+  multi_omics_form:
+    JGIStudyId: ''
+    studyNumber: ''
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      plant_associated_data:
+        - analysis_type:
+            - metagenomics
+          collection_date: '2016-05-09'
+          depth: '0'
+          ecosystem: Environmental
+          ecosystem_category: Terrestrial
+          ecosystem_subtype: Leaf
+          ecosystem_type: Plant-associated
+          elev: '286'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          lat_lon: 42.39 -85.37
+          samp_name: G5R1_MAIN_09MAY2016
+          samp_store_temp: -80 Cel
+          source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
+          specific_ecosystem: Phyllosphere
+  sample_environment_form:
     packageName: plant-associated
-    sampleData:
-      data:
-        plant_associated_data:
-          - analysis_type:
-              - metagenomics
-            collection_date: '2016-05-09'
-            depth: '0'
-            ecosystem: Environmental
-            ecosystem_category: Terrestrial
-            ecosystem_subtype: Leaf
-            ecosystem_type: Plant-associated
-            elev: '286'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            lat_lon: 42.39 -85.37
-            samp_name: G5R1_MAIN_09MAY2016
-            samp_store_temp: -80 Cel
-            source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
-            specific_ecosystem: Phyllosphere
-    studyForm:
-      GOLDStudyId: ''
-      alternativeNames: [ ]
-      NCBIBioProjectId: ''
-      contributors:
-        - name: Test Testerson
-          type: nmdc:PersonValue
-          orcid: 0000-0000-0000-0000
-          roles:
-            - Principal Investigator
-      description: This is a test submission
-      fundingSources:
-        - Some award ABC
-        - Some award XYZ
-      linkOutWebpage:
-        - http://www.example.com/submission-test
-      piEmail: test.testerson@example.com
-      piName: Test Testerson
-      piOrcid: 0000-0000-0000-0000
-      studyName: A test submission
-    multiOmicsForm:
-      JGIStudyId: ''
-      studyNumber: ''
-    templates:
-      - plant-associated
+  templates:
+    - plant-associated
 nucleotide_sequencing_mapping:
   - __biosample_samp_name: G5R1_MAIN_09MAY2016
     processing_institution: JGI

--- a/tests/test_data/data/plant_air_jgi_input.yaml
+++ b/tests/test_data/data/plant_air_jgi_input.yaml
@@ -1,301 +1,56 @@
 metadata_submission:
-  metadata_submission:
-    packageName: [ 'plant-associated', 'air' ]
-    addressForm:
-      shipper:
-        name: ''
-        email: ''
-        phone: ''
-        line1: ''
-        line2: ''
-        city: ''
-        state: ''
-        postalCode: ''
-      expectedShippingDate:
-      shippingConditions: ''
-      sample: ''
-      description: ''
-      experimentalGoals: ''
-      randomization: ''
-      usdaRegulated:
-      permitNumber: ''
-      biosafetyLevel: ''
-      irbOrHipaa:
-      comments: ''
-    templates: [ 'plant-associated', 'air', 'jgi_mg' ]
-    studyForm:
-      studyName: Seasonal activities of the phyllosphere microbiome of perennial crops
-      piName: Ashley Shade
-      piEmail: shade.ashley@gmail.com
-      piOrcid: 0000-0002-7189-3067
-      linkOutWebpage:
-        - https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9950430/
-      studyDate:
-      description: Understanding the interactions between plants and microorganisms
-        can inform microbiome management to enhance crop productivity and resilience
-        to stress. Here, we apply a genome-centric approach to identify ecologically
-        important leaf microbiome members on replicated plots of field-grown switchgrass
-        and miscanthus, and to quantify their activities over two growing seasons for
-        switchgrass. We use metagenome and metatranscriptome sequencing and curate 40
-        medium- and high-quality metagenome-assembled-genomes (MAGs). We find that classes
-        represented by these MAGs (Actinomycetia, Alpha- and Gamma- Proteobacteria,
-        and Bacteroidota) are active in the late season, and upregulate transcripts
-        for short-chain dehydrogenase, molybdopterin oxidoreductase, and polyketide
-        cyclase. Stress-associated pathways are expressed for most MAGs, suggesting
-        engagement with the host environment. We also detect seasonally activated biosynthetic
-        pathways for terpenes and various non-ribosomal peptide pathways that are poorly
-        annotated. Our findings support that leaf-associated bacterial populations are
-        seasonally dynamic and responsive to host cues.
-      notes: ''
-      fundingSources:
-        - Some award ABC
-        - Some award XYZ
-      contributors:
-        - name: Adina Howe
-          type: nmdc:PersonValue
-          orcid: 0000-0002-7705-343X
-          roles:
-            - Writing review and editing
-            - Visualization
-            - Writing original draft
-            - Investigation
-            - Formal Analysis
-            - Data curation
-            - Conceptualization
-            - Validation
-            - Supervision
-            - Project administration
-            - Methodology
-            - Resources
-            - Software
-            - Principal Investigator
-            - Funding acquisition
-      alternativeNames:
-        - foo
-        - bar
-      GOLDStudyId: 'Gs0123456'
-      NCBIBioProjectId: 'PRJNA1234567'
-    multiOmicsForm:
-      JGIStudyId: '123456'
-      award:
-      dataGenerated: true
-      facilities: [ ]
-      facilityGenerated: true
-      omicsProcessingTypes:
-        - mg
-        - mt
-      otherAward: ''
-      studyNumber: '45678'
-    sampleData:
-      data:
-        plant_associated_data:
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R1_MAIN_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R2_MAIN_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:774bb4b9-5ebe-48d5-8236-1a60baa6af7a
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R3_MAIN_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:c0bb595b-9992-4475-8019-775189b5250a
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R4_MAIN_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:d74181a3-6fb9-406e-89f8-2d4861a4646c
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R1_NF_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:edfd5080-ccc2-495b-b17a-190ad6649291
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R2_NF_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:483921c0-7fa9-4a31-b281-e09565a0d6f9
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R3_NF_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:3b9aab19-0110-415b-8e29-849f0696de47
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G5R4_NF_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:579ec4b9-57c4-4431-8df9-432138233b0b
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G6R1_MAIN_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:69dd84ff-d777-4d1e-ac22-9cdac87074f5
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-          - elev: 286
-            depth: '0'
-            lat_lon: 42.39 -85.37
-            ecosystem: Environmental
-            samp_name: "G6R2_MAIN_09MAY2016"
-            env_medium: plant-associated biome [ENVO:01001001]
-            geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            source_mat_id: UUID:c0c4a2b5-0382-450a-8728-a176fa438efe
-            ecosystem_type: Plant-associated
-            collection_date: '2016-05-09'
-            env_broad_scale: agricultural biome [ENVO:01001442]
-            env_local_scale: phyllosphere biome [ENVO:01001442]
-            samp_store_temp: "-80 Cel"
-            ecosystem_subtype: Leaf
-            ecosystem_category: Terrestrial
-            specific_ecosystem: Phyllosphere
-        air_data:
-          - elev: 225
-            lat_lon: 50.586825 6.408977
-            samp_name: "wedw"
-            env_medium: abcd [ENVO:00001998]
-            geo_loc_name: "USA: Maryland, Bethesda"
-            analysis_type:
-              - metaproteomics
-            collection_date: 2021
-            env_broad_scale: ewdwed [ENVO:123]
-            env_local_scale: asdxasd [ENV:234]
-            samp_store_temp: "-80 Cel"
-        jgi_mg_data:
-          - samp_name: "G6R2_MAIN_09MAY2016"
-            analysis_type:
-              - metagenomics
-  status: in-progress
+  study_form:
+    studyName: Seasonal activities of the phyllosphere microbiome of perennial crops
+    piName: Ashley Shade
+    piEmail: shade.ashley@gmail.com
+    piOrcid: 0000-0002-7189-3067
+    linkOutWebpage:
+      - https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9950430/
+    studyDate:
+    description: Understanding the interactions between plants and microorganisms
+      can inform microbiome management to enhance crop productivity and resilience
+      to stress. Here, we apply a genome-centric approach to identify ecologically
+      important leaf microbiome members on replicated plots of field-grown switchgrass
+      and miscanthus, and to quantify their activities over two growing seasons for
+      switchgrass. We use metagenome and metatranscriptome sequencing and curate 40
+      medium- and high-quality metagenome-assembled-genomes (MAGs). We find that classes
+      represented by these MAGs (Actinomycetia, Alpha- and Gamma- Proteobacteria,
+      and Bacteroidota) are active in the late season, and upregulate transcripts
+      for short-chain dehydrogenase, molybdopterin oxidoreductase, and polyketide
+      cyclase. Stress-associated pathways are expressed for most MAGs, suggesting
+      engagement with the host environment. We also detect seasonally activated biosynthetic
+      pathways for terpenes and various non-ribosomal peptide pathways that are poorly
+      annotated. Our findings support that leaf-associated bacterial populations are
+      seasonally dynamic and responsive to host cues.
+    notes: ''
+    fundingSources:
+      - Some award ABC
+      - Some award XYZ
+    contributors:
+      - name: Adina Howe
+        type: nmdc:PersonValue
+        orcid: 0000-0002-7705-343X
+        roles:
+          - Writing review and editing
+          - Visualization
+          - Writing original draft
+          - Investigation
+          - Formal Analysis
+          - Data curation
+          - Conceptualization
+          - Validation
+          - Supervision
+          - Project administration
+          - Methodology
+          - Resources
+          - Software
+          - Principal Investigator
+          - Funding acquisition
+    alternativeNames:
+      - foo
+      - bar
+    GOLDStudyId: 'Gs0123456'
+    NCBIBioProjectId: 'PRJNA1234567'
   id: d32b5eb6-71e8-4c98-8a57-3e64d05718b4
   author_orcid: 0000-0002-7705-343X
   created: '2023-04-03T18:31:16.856377'
@@ -305,3 +60,252 @@ metadata_submission:
     name: Adina Howe
     is_admin: false
     type: nmdc:PersonValue
+sample_set:
+  created: '2023-04-03T18:31:16.856377'
+  id: fb8bf86e-49c9-5366-a1b9-1c5987cab967
+  multi_omics_form:
+    JGIStudyId: '123456'
+    award:
+    dataGenerated: true
+    facilities: [ ]
+    facilityGenerated: true
+    omicsProcessingTypes:
+      - mg
+      - mt
+    otherAward: ''
+    studyNumber: '45678'
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      plant_associated_data:
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R1_MAIN_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:e8ed34cc-32f4-4fc5-9b9f-c2699e43163c
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R2_MAIN_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:774bb4b9-5ebe-48d5-8236-1a60baa6af7a
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R3_MAIN_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:c0bb595b-9992-4475-8019-775189b5250a
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R4_MAIN_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:d74181a3-6fb9-406e-89f8-2d4861a4646c
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R1_NF_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:edfd5080-ccc2-495b-b17a-190ad6649291
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R2_NF_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:483921c0-7fa9-4a31-b281-e09565a0d6f9
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R3_NF_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:3b9aab19-0110-415b-8e29-849f0696de47
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G5R4_NF_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:579ec4b9-57c4-4431-8df9-432138233b0b
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G6R1_MAIN_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:69dd84ff-d777-4d1e-ac22-9cdac87074f5
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+        - elev: 286
+          depth: '0'
+          lat_lon: 42.39 -85.37
+          ecosystem: Environmental
+          samp_name: "G6R2_MAIN_09MAY2016"
+          env_medium: plant-associated biome [ENVO:01001001]
+          geo_loc_name: 'USA: Kellogg Biological Station, Michigan'
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          source_mat_id: UUID:c0c4a2b5-0382-450a-8728-a176fa438efe
+          ecosystem_type: Plant-associated
+          collection_date: '2016-05-09'
+          env_broad_scale: agricultural biome [ENVO:01001442]
+          env_local_scale: phyllosphere biome [ENVO:01001442]
+          samp_store_temp: "-80 Cel"
+          ecosystem_subtype: Leaf
+          ecosystem_category: Terrestrial
+          specific_ecosystem: Phyllosphere
+      air_data:
+        - elev: 225
+          lat_lon: 50.586825 6.408977
+          samp_name: "wedw"
+          env_medium: abcd [ENVO:00001998]
+          geo_loc_name: "USA: Maryland, Bethesda"
+          analysis_type:
+            - metaproteomics
+          collection_date: 2021
+          env_broad_scale: ewdwed [ENVO:123]
+          env_local_scale: asdxasd [ENV:234]
+          samp_store_temp: "-80 Cel"
+      jgi_mg_data:
+        - samp_name: "G6R2_MAIN_09MAY2016"
+          analysis_type:
+            - metagenomics
+  sample_environment_form:
+    packageName: [ 'plant-associated', 'air' ]
+  sender_shipping_info_form:
+    shipper:
+      name: ''
+      email: ''
+      phone: ''
+      line1: ''
+      line2: ''
+      city: ''
+      state: ''
+      postalCode: ''
+    expectedShippingDate:
+    shippingConditions: ''
+    sample: ''
+    description: ''
+    experimentalGoals: ''
+    randomization: ''
+    usdaRegulated:
+    permitNumber: ''
+    biosafetyLevel: ''
+    irbOrHipaa:
+    comments: ''
+  status: in-progress
+  templates: [ 'plant-associated', 'air', 'jgi_mg' ]

--- a/tests/test_data/data/sequencing_data_input.yaml
+++ b/tests/test_data/data/sequencing_data_input.yaml
@@ -1,166 +1,18 @@
 metadata_submission:
-  metadata_submission:
-    packageName:
-      - soil
-    addressForm:
-      shipper:
-        name: ""
-        email: ""
-        phone: ""
-        line1: ""
-        line2: ""
-        city: ""
-        state: ""
-        postalCode: ""
-        country: ""
-      expectedShippingDate: null
-      shippingConditions: ""
-      sample: ""
-      description: ""
-      experimentalGoals: ""
-      randomization: ""
-      usdaRegulated: null
-      permitNumber: ""
-      biosafetyLevel: ""
-      irbOrHipaa: null
-      comments: ""
-    templates:
-      - soil
-      - data_mg
-      - data_mt_interleaved
-    studyForm:
-      studyName: asdfasdf
-      piName: ""
-      piEmail: pkalita@lbl.gov
-      piOrcid: ""
-      fundingSources: []
-      linkOutWebpage: []
-      studyDate: null
-      description: ""
-      notes: ""
-      contributors: []
-      alternativeNames: []
-      GOLDStudyId: ""
-      NCBIBioProjectId: ""
-    multiOmicsForm:
-      award: ""
-      awardDois:
-        - ""
-        - ""
-      dataGenerated: true
-      doe: null
-      facilities: []
-      facilityGenerated: false
-      JGIStudyId: ""
-      mgCompatible: true
-      mgInterleaved: false
-      mtCompatible: true
-      mtInterleaved: true
-      omicsProcessingTypes:
-        - mg
-        - mt
-      otherAward: ""
-      ship: false
-      studyNumber: "12312"
-      unknownDoi: true
-    sampleData:
-      data:
-        soil_data:
-          - elev: 1325
-            depth: 0 - 1
-            lat_lon: 43 -120
-            samp_name: "001"
-            env_medium: bulk soil [ENVO:00005802]
-            store_cond: frozen
-            geo_loc_name: "USA: Fake, Fake"
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-            collection_date: 2025-01-01
-            env_broad_scale: mixed forest biome [ENVO:01000198]
-            env_local_scale: area of evergreen forest [ENVO:01000843]
-            samp_store_temp: -80 Cel
-            slope_gradient: 8%
-          - elev: 1325
-            depth: 0 - 1
-            lat_lon: 43 -120
-            samp_name: "002"
-            env_medium: bulk soil [ENVO:00005802]
-            store_cond: frozen
-            geo_loc_name: "USA: Fake, Fake"
-            growth_facil: field
-            analysis_type:
-              - metagenomics
-              - metatranscriptomics
-            collection_date: 2025-01-01
-            env_broad_scale: mixed forest biome [ENVO:01000198]
-            env_local_scale: area of evergreen forest [ENVO:01000843]
-            samp_store_temp: -80 Cel
-            slope_gradient: 0%
-          - elev: 1325
-            depth: 0 - 1
-            lat_lon: 43 -120
-            samp_name: "003"
-            env_medium: bulk soil [ENVO:00005802]
-            store_cond: frozen
-            geo_loc_name: "USA: Fake, Fake"
-            growth_facil: field
-            analysis_type:
-              - metatranscriptomics
-            collection_date: 2025-01-01
-            env_broad_scale: mixed forest biome [ENVO:01000198]
-            env_local_scale: area of evergreen forest [ENVO:01000843]
-            samp_store_temp: -80 Cel
-            slope_gradient: 0.5%
-        metagenome_sequencing_non_interleaved_data:
-          - model: hiseq_1500
-            samp_name: "001"
-            read_1_url: http://example.com/001-1.fastq.gz
-            read_2_url: http://example.com/001-2.fastq.gz
-            analysis_type:
-              - metagenomics
-            protocol_link: http://example.com
-            read_1_md5_checksum: b1946ac92492d2347c6235b4d2611184
-            read_2_md5_checksum: 94baaad4d1347ec6e15ae35c88ee8bc8
-            processing_institution: UCSD
-            insdc_bioproject_identifiers: bioproject:PRJNA366857
-            insdc_experiment_identifiers: insdc.sra:ERX000000
-          - model: hiseq_1500
-            samp_name: "002"
-            read_1_url: http://example.com/002-1.fastq.gz
-            read_2_url: http://example.com/002-2.fastq.gz
-            analysis_type:
-              - metagenomics
-              - metatranscriptomics
-            protocol_link: http://example.com
-            read_1_md5_checksum: 916f4c31aaa35d6b867dae9a7f54270d
-            read_2_md5_checksum: 764efa883dda1e11db47671c4a3bbd9e
-            processing_institution: UCSD
-            insdc_bioproject_identifiers: bioproject:PRJNA366857
-            insdc_experiment_identifiers: insdc.sra:ERX000000
-        metatranscriptome_sequencing_interleaved_data:
-        - model: nextseq
-          samp_name: "002"
-          analysis_type:
-            - metagenomics
-            - metatranscriptomics
-          protocol_link: http://example.org/protocol.html
-          interleaved_url: http://example.org/002-metat.fastq.gz
-          processing_institution: Battelle
-          interleaved_md5_checksum: 93ee47243d79217978cbed946c4e203a
-          insdc_bioproject_identifiers: bioproject:PRJNA366858
-          insdc_experiment_identifiers: insdc.sra:DRX000001
-        - model: nextseq
-          samp_name: "003"
-          analysis_type:
-            - metatranscriptomics
-          protocol_link: http://example.org/protocol.html
-          interleaved_url: http://example.org/003-metat-a.fastq.gz; http://example.org/003-metat-b.fastq.gz
-          processing_institution: Battelle
-          interleaved_md5_checksum: 8a7a02537074949bbef514cba5d669d8; 2dee554dd9bd8d2403e3b5430d19e3c3
-          insdc_bioproject_identifiers: bioproject:PRJNA366858
-          insdc_experiment_identifiers: insdc.sra:DRX000002
-  status: in-progress
+  study_form:
+    studyName: asdfasdf
+    piName: ""
+    piEmail: pkalita@lbl.gov
+    piOrcid: ""
+    fundingSources: []
+    linkOutWebpage: []
+    studyDate: null
+    description: ""
+    notes: ""
+    contributors: []
+    alternativeNames: []
+    GOLDStudyId: ""
+    NCBIBioProjectId: ""
   source_client: null
   is_test_submission: false
   id: e12d0754-c00c-4417-9a25-6eb372054182
@@ -172,10 +24,6 @@ metadata_submission:
     name: Patrick Kalita
     email: null
     is_admin: true
-  templates:
-    - soil
-    - data_mg
-    - data_mt_interleaved
   study_name: asdfasdf
   field_notes_metadata: null
   date_last_modified: 2025-03-31T21:32:16.065533
@@ -187,3 +35,156 @@ metadata_submission:
     email: null
     is_admin: true
   permission_level: owner
+sample_set:
+  created: 2025-03-28T17:03:50.955416
+  date_last_modified: 2025-03-31T21:32:16.065533
+  id: 657cd61b-97ca-597d-9ecb-dfe543f18adb
+  multi_omics_form:
+    award: ""
+    awardDois:
+      - ""
+      - ""
+    dataGenerated: true
+    doe: null
+    facilities: []
+    facilityGenerated: false
+    JGIStudyId: ""
+    mgCompatible: true
+    mgInterleaved: false
+    mtCompatible: true
+    mtInterleaved: true
+    omicsProcessingTypes:
+      - mg
+      - mt
+    otherAward: ""
+    ship: false
+    studyNumber: "12312"
+    unknownDoi: true
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      soil_data:
+        - elev: 1325
+          depth: 0 - 1
+          lat_lon: 43 -120
+          samp_name: "001"
+          env_medium: bulk soil [ENVO:00005802]
+          store_cond: frozen
+          geo_loc_name: "USA: Fake, Fake"
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+          collection_date: 2025-01-01
+          env_broad_scale: mixed forest biome [ENVO:01000198]
+          env_local_scale: area of evergreen forest [ENVO:01000843]
+          samp_store_temp: -80 Cel
+          slope_gradient: 8%
+        - elev: 1325
+          depth: 0 - 1
+          lat_lon: 43 -120
+          samp_name: "002"
+          env_medium: bulk soil [ENVO:00005802]
+          store_cond: frozen
+          geo_loc_name: "USA: Fake, Fake"
+          growth_facil: field
+          analysis_type:
+            - metagenomics
+            - metatranscriptomics
+          collection_date: 2025-01-01
+          env_broad_scale: mixed forest biome [ENVO:01000198]
+          env_local_scale: area of evergreen forest [ENVO:01000843]
+          samp_store_temp: -80 Cel
+          slope_gradient: 0%
+        - elev: 1325
+          depth: 0 - 1
+          lat_lon: 43 -120
+          samp_name: "003"
+          env_medium: bulk soil [ENVO:00005802]
+          store_cond: frozen
+          geo_loc_name: "USA: Fake, Fake"
+          growth_facil: field
+          analysis_type:
+            - metatranscriptomics
+          collection_date: 2025-01-01
+          env_broad_scale: mixed forest biome [ENVO:01000198]
+          env_local_scale: area of evergreen forest [ENVO:01000843]
+          samp_store_temp: -80 Cel
+          slope_gradient: 0.5%
+      metagenome_sequencing_non_interleaved_data:
+        - model: hiseq_1500
+          samp_name: "001"
+          read_1_url: http://example.com/001-1.fastq.gz
+          read_2_url: http://example.com/001-2.fastq.gz
+          analysis_type:
+            - metagenomics
+          protocol_link: http://example.com
+          read_1_md5_checksum: b1946ac92492d2347c6235b4d2611184
+          read_2_md5_checksum: 94baaad4d1347ec6e15ae35c88ee8bc8
+          processing_institution: UCSD
+          insdc_bioproject_identifiers: bioproject:PRJNA366857
+          insdc_experiment_identifiers: insdc.sra:ERX000000
+        - model: hiseq_1500
+          samp_name: "002"
+          read_1_url: http://example.com/002-1.fastq.gz
+          read_2_url: http://example.com/002-2.fastq.gz
+          analysis_type:
+            - metagenomics
+            - metatranscriptomics
+          protocol_link: http://example.com
+          read_1_md5_checksum: 916f4c31aaa35d6b867dae9a7f54270d
+          read_2_md5_checksum: 764efa883dda1e11db47671c4a3bbd9e
+          processing_institution: UCSD
+          insdc_bioproject_identifiers: bioproject:PRJNA366857
+          insdc_experiment_identifiers: insdc.sra:ERX000000
+      metatranscriptome_sequencing_interleaved_data:
+      - model: nextseq
+        samp_name: "002"
+        analysis_type:
+          - metagenomics
+          - metatranscriptomics
+        protocol_link: http://example.org/protocol.html
+        interleaved_url: http://example.org/002-metat.fastq.gz
+        processing_institution: Battelle
+        interleaved_md5_checksum: 93ee47243d79217978cbed946c4e203a
+        insdc_bioproject_identifiers: bioproject:PRJNA366858
+        insdc_experiment_identifiers: insdc.sra:DRX000001
+      - model: nextseq
+        samp_name: "003"
+        analysis_type:
+          - metatranscriptomics
+        protocol_link: http://example.org/protocol.html
+        interleaved_url: http://example.org/003-metat-a.fastq.gz; http://example.org/003-metat-b.fastq.gz
+        processing_institution: Battelle
+        interleaved_md5_checksum: 8a7a02537074949bbef514cba5d669d8; 2dee554dd9bd8d2403e3b5430d19e3c3
+        insdc_bioproject_identifiers: bioproject:PRJNA366858
+        insdc_experiment_identifiers: insdc.sra:DRX000002
+  sample_environment_form:
+    packageName:
+      - soil
+  sender_shipping_info_form:
+    shipper:
+      name: ""
+      email: ""
+      phone: ""
+      line1: ""
+      line2: ""
+      city: ""
+      state: ""
+      postalCode: ""
+      country: ""
+    expectedShippingDate: null
+    shippingConditions: ""
+    sample: ""
+    description: ""
+    experimentalGoals: ""
+    randomization: ""
+    usdaRegulated: null
+    permitNumber: ""
+    biosafetyLevel: ""
+    irbOrHipaa: null
+    comments: ""
+  status: in-progress
+  templates:
+    - soil
+    - data_mg
+    - data_mt_interleaved

--- a/tests/test_data/data/soil_sample_link_input.yaml
+++ b/tests/test_data/data/soil_sample_link_input.yaml
@@ -1,98 +1,18 @@
 metadata_submission:
-  metadata_submission:
-    packageName: [ 'soil' ]
-    addressForm:
-      shipper:
-        name: ''
-        email: ''
-        phone: ''
-        line1: ''
-        line2: ''
-        city: ''
-        state: ''
-        postalCode: ''
-      expectedShippingDate:
-      shippingConditions: ''
-      sample: ''
-      description: ''
-      experimentalGoals: ''
-      randomization: ''
-      usdaRegulated:
-      permitNumber: ''
-      biosafetyLevel: ''
-      irbOrHipaa:
-      comments: ''
-    templates: [ 'soil' ]
-    studyForm:
-      studyName: A test submission where sample_link is used to generate processed sample records
-      piName: Test Testerson
-      piEmail: test.testerson@example.com
-      piOrcid: 0000-0000-0000-000X
-      linkOutWebpage:
-      studyDate:
-      description:
-      notes:
-      fundingSources:
-      contributors:
-      alternativeNames:
-      GOLDStudyId:
-      NCBIBioProjectId:
-    multiOmicsForm:
-      JGIStudyId:
-      award:
-      dataGenerated: true
-      facilities: [ ]
-      facilityGenerated: true
-      omicsProcessingTypes:
-      otherAward:
-      studyNumber:
-    sampleData:
-      data:
-        soil_data:
-          - elev: 123
-            analysis_type:
-              - metagenomics
-            collection_date: '2022-01-15'
-            depth: "0 - 1"
-            env_broad_scale: 'urban biome [ENVO:01000249]'
-            env_local_scale: 'tunnel [ENVO:00000068]'
-            env_medium: 'bare soil [ENVO:01001616]'
-            geo_loc_name: 'USA: Nowhere, Oklahoma'
-            growth_facil: greenhouse
-            lat_lon: 35.211445 -98.464612
-            samp_name: "00001"
-            samp_store_temp: "-80 Cel"
-            store_cond: frozen
-          - elev: 123
-            analysis_type:
-              - metagenomics
-            collection_date: '2022-01-15'
-            depth: "0 - 1"
-            env_broad_scale: 'urban biome [ENVO:01000249]'
-            env_local_scale: 'tunnel [ENVO:00000068]'
-            env_medium: 'bare soil [ENVO:01001616]'
-            geo_loc_name: 'USA: Nowhere, Oklahoma'
-            growth_facil: greenhouse
-            lat_lon: 35.211445 -98.464612
-            samp_name: "00002"
-            samp_store_temp: "-80 Cel"
-            store_cond: frozen
-          - elev: 123
-            analysis_type:
-              - metagenomics
-            collection_date: '2022-01-15'
-            depth: "0 - 1"
-            env_broad_scale: 'urban biome [ENVO:01000249]'
-            env_local_scale: 'tunnel [ENVO:00000068]'
-            env_medium: 'bare soil [ENVO:01001616]'
-            geo_loc_name: 'USA: Nowhere, Oklahoma'
-            growth_facil: greenhouse
-            lat_lon: 35.211445 -98.464612
-            sample_link: "Pooling:00001,00002"
-            samp_name: "00003-POOLED"
-            samp_store_temp: "-80 Cel"
-            store_cond: frozen
-  status: in-progress
+  study_form:
+    studyName: A test submission where sample_link is used to generate processed sample records
+    piName: Test Testerson
+    piEmail: test.testerson@example.com
+    piOrcid: 0000-0000-0000-000X
+    linkOutWebpage:
+    studyDate:
+    description:
+    notes:
+    fundingSources:
+    contributors:
+    alternativeNames:
+    GOLDStudyId:
+    NCBIBioProjectId:
   id: 406e6ce5-ec5f-4617-badd-dc061358da24
   author_orcid: 0000-0000-0000-000X
   created: '2023-04-03T18:31:16.856377'
@@ -102,3 +22,87 @@ metadata_submission:
     name: Test Testerson
     is_admin: false
     type: nmdc:PersonValue
+sample_set:
+  created: '2023-04-03T18:31:16.856377'
+  id: 487875a4-e77d-56c5-a819-fb22c1550f8a
+  multi_omics_form:
+    JGIStudyId:
+    award:
+    dataGenerated: true
+    facilities: [ ]
+    facilityGenerated: true
+    omicsProcessingTypes:
+    otherAward:
+    studyNumber:
+  name: "Sample Set 1"
+  sample_data:
+    data:
+      soil_data:
+        - elev: 123
+          analysis_type:
+            - metagenomics
+          collection_date: '2022-01-15'
+          depth: "0 - 1"
+          env_broad_scale: 'urban biome [ENVO:01000249]'
+          env_local_scale: 'tunnel [ENVO:00000068]'
+          env_medium: 'bare soil [ENVO:01001616]'
+          geo_loc_name: 'USA: Nowhere, Oklahoma'
+          growth_facil: greenhouse
+          lat_lon: 35.211445 -98.464612
+          samp_name: "00001"
+          samp_store_temp: "-80 Cel"
+          store_cond: frozen
+        - elev: 123
+          analysis_type:
+            - metagenomics
+          collection_date: '2022-01-15'
+          depth: "0 - 1"
+          env_broad_scale: 'urban biome [ENVO:01000249]'
+          env_local_scale: 'tunnel [ENVO:00000068]'
+          env_medium: 'bare soil [ENVO:01001616]'
+          geo_loc_name: 'USA: Nowhere, Oklahoma'
+          growth_facil: greenhouse
+          lat_lon: 35.211445 -98.464612
+          samp_name: "00002"
+          samp_store_temp: "-80 Cel"
+          store_cond: frozen
+        - elev: 123
+          analysis_type:
+            - metagenomics
+          collection_date: '2022-01-15'
+          depth: "0 - 1"
+          env_broad_scale: 'urban biome [ENVO:01000249]'
+          env_local_scale: 'tunnel [ENVO:00000068]'
+          env_medium: 'bare soil [ENVO:01001616]'
+          geo_loc_name: 'USA: Nowhere, Oklahoma'
+          growth_facil: greenhouse
+          lat_lon: 35.211445 -98.464612
+          sample_link: "Pooling:00001,00002"
+          samp_name: "00003-POOLED"
+          samp_store_temp: "-80 Cel"
+          store_cond: frozen
+  sample_environment_form:
+    packageName: [ 'soil' ]
+  sender_shipping_info_form:
+    shipper:
+      name: ''
+      email: ''
+      phone: ''
+      line1: ''
+      line2: ''
+      city: ''
+      state: ''
+      postalCode: ''
+    expectedShippingDate:
+    shippingConditions: ''
+    sample: ''
+    description: ''
+    experimentalGoals: ''
+    randomization: ''
+    usdaRegulated:
+    permitNumber: ''
+    biosafetyLevel: ''
+    irbOrHipaa:
+    comments: ''
+  status: in-progress
+  templates: [ 'soil' ]

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -14,6 +14,7 @@ from nmdc_schema.nmdc import (
     FileTypeEnum,
     DoiProviderEnum,
     DoiCategoryEnum,
+    Doi,
     UnitEnum,
     Study,
 )
@@ -48,7 +49,7 @@ def test_get_pi():
     translator = SubmissionPortalTranslator()
     pi_person_value = translator._get_pi(
         {
-            "studyForm": {
+            "study_form": {
                 "piName": "Maria D. McDonald",
                 "piEmail": "MariaDMcDonald@example.edu",
                 "piOrcid": "",
@@ -67,7 +68,7 @@ def test_get_pi():
     )
     pi_person_value = translator._get_pi(
         {
-            "studyForm": {
+            "study_form": {
                 "piName": "Maria D. McDonald",
                 "piEmail": "MariaDMcDonald@example.edu",
                 "piOrcid": "0000-0000-0000-0001",
@@ -85,7 +86,7 @@ def test_get_study_dois():
     translator = SubmissionPortalTranslator()
     dois = translator._get_study_dois(
         {
-            "studyForm": {
+            "study_form": {
                 "dataDois": [
                     {
                         "provider": "emsl",
@@ -103,7 +104,35 @@ def test_get_study_dois():
                     }
                 ],
             },
-            "multiOmicsForm": {
+        }
+    )
+    assert dois is not None
+    assert len(dois) == 3
+
+    assert dois[0].doi_value == "doi:10.12345/6789"
+    assert dois[0].doi_provider == DoiProviderEnum("emsl")
+    assert dois[0].type == "nmdc:Doi"
+    assert dois[0].doi_category == DoiCategoryEnum("dataset_doi")
+
+    assert dois[1].doi_value == "doi:10.54321/9876"
+    assert dois[1].doi_provider is None
+    assert dois[1].type == "nmdc:Doi"
+    assert dois[1].doi_category == DoiCategoryEnum("publication_doi")
+
+    assert dois[2].doi_value == "doi:10.99999/abcd"
+    assert dois[2].doi_provider == DoiProviderEnum("zenodo")
+    assert dois[2].type == "nmdc:Doi"
+    assert dois[2].doi_category == DoiCategoryEnum("publication_doi")
+
+    empty_doi = translator._get_study_dois({})
+    assert empty_doi is None
+
+
+def test_get_sample_set_dois():
+    translator = SubmissionPortalTranslator()
+    sample_set_dois = translator._get_sample_set_dois(
+        {
+            "multi_omics_form": {
                 "awardDois": [
                     {
                         "provider": "jgi",
@@ -113,38 +142,23 @@ def test_get_study_dois():
             },
         }
     )
-    assert dois is not None
-    assert len(dois) == 4
+    assert sample_set_dois is not None
+    assert len(sample_set_dois) == 1
 
-    assert dois[0].doi_value == "doi:10.12345/6789"
-    assert dois[0].doi_provider == DoiProviderEnum("emsl")
-    assert dois[0].type == "nmdc:Doi"
-    assert dois[0].doi_category == DoiCategoryEnum("dataset_doi")
+    assert sample_set_dois[0].doi_value == "doi:10.11121314/15161718"
+    assert sample_set_dois[0].doi_provider == DoiProviderEnum("jgi")
+    assert sample_set_dois[0].type == "nmdc:Doi"
+    assert sample_set_dois[0].doi_category == DoiCategoryEnum("award_doi")
 
-    assert dois[1].doi_value == "doi:10.11121314/15161718"
-    assert dois[1].doi_provider == DoiProviderEnum("jgi")
-    assert dois[1].type == "nmdc:Doi"
-    assert dois[1].doi_category == DoiCategoryEnum("award_doi")
-
-    assert dois[2].doi_value == "doi:10.54321/9876"
-    assert dois[2].doi_provider is None
-    assert dois[2].type == "nmdc:Doi"
-    assert dois[2].doi_category == DoiCategoryEnum("publication_doi")
-
-    assert dois[3].doi_value == "doi:10.99999/abcd"
-    assert dois[3].doi_provider == DoiProviderEnum("zenodo")
-    assert dois[3].type == "nmdc:Doi"
-    assert dois[3].doi_category == DoiCategoryEnum("publication_doi")
-
-    empty_doi = translator._get_study_dois({})
-    assert empty_doi is None
+    empty_sample_set_doi = translator._get_sample_set_dois({})
+    assert empty_sample_set_doi is None
 
 
 def test_get_has_credit_associations():
     translator = SubmissionPortalTranslator()
     credit_associations = translator._get_has_credit_associations(
         {
-            "studyForm": {
+            "study_form": {
                 "contributors": [
                     {
                         "name": "Brenda Patterson",
@@ -264,14 +278,14 @@ def test_get_gold_study_identifiers():
     translator = SubmissionPortalTranslator()
 
     gold_ids = translator._get_gold_study_identifiers(
-        {"studyForm": {"GOLDStudyId": "Gs000000"}}
+        {"study_form": {"GOLDStudyId": "Gs000000"}}
     )
     assert gold_ids is not None
     assert len(gold_ids) == 1
     assert gold_ids[0] == "gold:Gs000000"
 
     gold_ids = translator._get_gold_study_identifiers(
-        {"studyForm": {"GOLDStudyId": ""}}
+        {"study_form": {"GOLDStudyId": ""}}
     )
     assert gold_ids is None
 
@@ -428,46 +442,47 @@ def test_instruments(test_minter):
     known_instruments = {
         "hiseq_2500": "nmdc:inst-14-nn4b6k72",
     }
-    metadata_submission = {
-        "metadata_submission": {
-            "packageName": ["soil"],
-            "templates": ["soil", "data_mg_interleaved"],
-            "studyForm": {
-                "studyName": "asdfasdf",
-                "piEmail": "fake@fake.com",
-            },
-            "sampleData": {
-                "data": {
-                    "soil_data": [
-                        _mock_soil_data("001"),
-                        _mock_soil_data("002"),
-                    ],
-                    "metagenome_sequencing_interleaved_data": [
-                        {
-                            "model": "hiseq_1500",
-                            "samp_name": "001",
-                            "interleaved_url": "http://example.com/001-1.fastq",
-                            "analysis_type": ["metagenomics"],
-                            "interleaved_checksum": "b1946ac92492d2347c6235b4d2611184",
-                        },
-                        {
-                            "model": "hiseq_2500",
-                            "samp_name": "002",
-                            "interleaved_url": "http://example.com/002-1.fastq",
-                            "analysis_type": [
-                                "metagenomics",
-                            ],
-                            "interleaved_checksum": "916f4c31aaa35d6b867dae9a7f54270d",
-                        },
-                    ],
-                },
+    submission = {
+        "packageName": ["soil"],
+        "templates": ["soil", "data_mg_interleaved"],
+        "study_form": {
+            "studyName": "asdfasdf",
+            "piEmail": "fake@fake.com",
+        },
+    }
+    sample_set = {
+        "sample_data": {
+            "data": {
+                "soil_data": [
+                    _mock_soil_data("001"),
+                    _mock_soil_data("002"),
+                ],
+                "metagenome_sequencing_interleaved_data": [
+                    {
+                        "model": "hiseq_1500",
+                        "samp_name": "001",
+                        "interleaved_url": "http://example.com/001-1.fastq",
+                        "analysis_type": ["metagenomics"],
+                        "interleaved_checksum": "b1946ac92492d2347c6235b4d2611184",
+                    },
+                    {
+                        "model": "hiseq_2500",
+                        "samp_name": "002",
+                        "interleaved_url": "http://example.com/002-1.fastq",
+                        "analysis_type": [
+                            "metagenomics",
+                        ],
+                        "interleaved_checksum": "916f4c31aaa35d6b867dae9a7f54270d",
+                    },
+                ],
             },
         },
     }
     translator = SubmissionPortalTranslator(
         id_minter=test_minter,
         illumina_instrument_mapping=known_instruments,
-        metadata_submission=metadata_submission,
+        metadata_submission=submission,
+        sample_set=sample_set,
         study_category="research_study",
     )
     database = translator.get_database()
@@ -487,6 +502,95 @@ def test_instruments(test_minter):
     assert len(database.data_generation_set) == 2
     instruments_used = {dg.instrument_used[0] for dg in database.data_generation_set}
     assert instruments_used == {minted_instrument_id, known_instrument_id}
+
+
+def test_existing_study_only_uses_sample_set_updates(test_minter):
+    existing_study = Study(
+        id="nmdc:sty-00-00000000",
+        type="nmdc:Study",
+        study_category="research_study",
+        name="Existing study name",
+        title="Existing study title",
+        description="Existing study description",
+        funding_sources=["Existing award"],
+        associated_dois=[
+            Doi(
+                doi_value="doi:10.0000/existing",
+                doi_provider=DoiProviderEnum("emsl"),
+                doi_category=DoiCategoryEnum("dataset_doi"),
+                type="nmdc:Doi",
+            ),
+        ],
+        emsl_project_identifiers=["emsl.project:existing"],
+        jgi_portal_study_identifiers=["jgi.proposal:existing"],
+    )
+    metadata_submission = {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "study_form": {
+            # In reality, the Submission Portal UI should prevent this form from being updated in
+            # the case where a new sample set is being added to an existing study. But if somehow
+            # the form is updated, the translator should ignore the updates.
+            "studyName": "Incoming study name",
+            "description": "Incoming study description",
+            "fundingSources": ["Incoming award"],
+            "dataDois": [
+                {
+                    "provider": "emsl",
+                    "value": "10.1111/from-study-form",
+                },
+            ],
+        },
+    }
+    sample_set = {
+        "multi_omics_form": {
+            "awardDois": [
+                {
+                    "provider": "jgi",
+                    "value": "10.2222/from-sample-set",
+                },
+            ],
+            "JGIStudyId": "123456",
+            "studyNumber": "78910",
+        },
+    }
+    translator = SubmissionPortalTranslator(
+        metadata_submission=metadata_submission,
+        sample_set=sample_set,
+        existing_study=existing_study,
+        id_minter=test_minter,
+        study_category="research_study",
+    )
+
+    database = translator.get_database()
+
+    assert len(database.study_set) == 1
+    study = database.study_set[0]
+
+    # Assert that the study-level information did not change.
+    assert study.id == existing_study.id
+    assert study.name == "Existing study name"
+    assert study.title == "Existing study title"
+    assert study.description == "Existing study description"
+    assert study.funding_sources == ["Existing award"]
+
+    # Assert that information from the sample set was added to the study.
+    assert study.associated_dois is not None
+    assert [doi.doi_value for doi in study.associated_dois] == [
+        "doi:10.0000/existing",
+        "doi:10.2222/from-sample-set",
+    ]
+    assert [doi.doi_category for doi in study.associated_dois] == [
+        DoiCategoryEnum("dataset_doi"),
+        DoiCategoryEnum("award_doi"),
+    ]
+    assert study.emsl_project_identifiers == [
+        "emsl.project:existing",
+        "emsl.project:78910",
+    ]
+    assert study.jgi_portal_study_identifiers == [
+        "jgi.proposal:existing",
+        "jgi.proposal:123456",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -552,10 +656,12 @@ def test_get_database(test_minter, monkeypatch, data_file_base):
     )
 
     expected = Database(**expected_output)
+    expected_as_dict = json_dumper.to_dict(expected)
     actual = translator.get_database()
-    assert actual == expected
+    actual_as_dict = json_dumper.to_dict(actual)
+    assert actual_as_dict == expected_as_dict
 
-    validation_result = validate_json(json_dumper.to_dict(actual), mongo_db)
+    validation_result = validate_json(actual_as_dict, mongo_db)
     assert validation_result == {"result": "All Okay!"}
 
 

--- a/tests/test_data/test_submission_portal_translator.py
+++ b/tests/test_data/test_submission_portal_translator.py
@@ -593,6 +593,59 @@ def test_existing_study_only_uses_sample_set_updates(test_minter):
     ]
 
 
+def test_existing_study_sample_set_updates_are_deduplicated(test_minter):
+    existing_study = Study(
+        id="nmdc:sty-00-00000000",
+        type="nmdc:Study",
+        study_category="research_study",
+        name="Existing study name",
+        title="Existing study title",
+        description="Existing study description",
+        associated_dois=[
+            Doi(
+                doi_value="doi:10.2222/from-sample-set",
+                doi_provider=DoiProviderEnum("jgi"),
+                doi_category=DoiCategoryEnum("award_doi"),
+                type="nmdc:Doi",
+            ),
+        ],
+        emsl_project_identifiers=["emsl.project:78910"],
+        jgi_portal_study_identifiers=["jgi.proposal:123456"],
+    )
+    metadata_submission = {
+        "id": "00000000-0000-0000-0000-000000000000",
+    }
+    sample_set = {
+        "multi_omics_form": {
+            "awardDois": [
+                {
+                    "provider": "jgi",
+                    "value": "10.2222/from-sample-set",
+                },
+            ],
+            "JGIStudyId": "123456",
+            "studyNumber": "78910",
+        },
+    }
+    translator = SubmissionPortalTranslator(
+        metadata_submission=metadata_submission,
+        sample_set=sample_set,
+        existing_study=existing_study,
+        id_minter=test_minter,
+        study_category="research_study",
+    )
+
+    database = translator.get_database()
+
+    study = database.study_set[0]
+    assert study.associated_dois is not None
+    assert [doi.doi_value for doi in study.associated_dois] == [
+        "doi:10.2222/from-sample-set",
+    ]
+    assert study.emsl_project_identifiers == ["emsl.project:78910"]
+    assert study.jgi_portal_study_identifiers == ["jgi.proposal:123456"]
+
+
 @pytest.mark.parametrize(
     "data_file_base",
     [


### PR DESCRIPTION
On this branch, I updated the submission translation process (the `SubmissionPortalTranslator` class itself and the Dagster ops that call it) to work with the new sample set architecture. 

### Details

The Submission Portal is restructuring how data is input and stored. Previously study- and sample-level information is stored in one unit (called a "submission"). With the sample set changes, the submission holds study-level information and has a one-to-many relationship with sample sets, which hold the sample-level information. 

These changes update the submission translation process to take the new structure into account. This means:

* The two Dagster jobs of interest (`ingest_metadata_submission` and `translate_metadata_submission_to_nmdc_schema_database`) now require both a submission ID and a sample set ID as inputs.
* If this is the first sample set being translated for a given submission, a new `nmdc:Study` records is created from the submission record and new `nmdc:Biosample` (and possibly other) records are created from the sample set record. 
* If this is not the first sample set being translated for a given submission, a new `nmdc:Study` records is not created. In this case the submission will already have a value populated in its `nmdc_study_id` field. This value is used to look up a record from the `study_set` collection. New `nmdc:Biosample` (and possibly other) records are created from the sample set record and associated with the existing `nmdc:Study` record. 
* After the MongoDB updates are finished, both the submission and the sample set need to be "finalized" -- meaning a few bits of information need to be sent back to the Submission Portal (i.e. this is where the submission's `nmdc_study_id` field is populated in the first place).

### Related issue(s)

Fixes #1496 

### Related subsystem(s)

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [x] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

- [x] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by

* Updating, extending, and running existing automated tests
* Manually running the relevant jobs in local Dagster talking to my local `nmdc-server` stack running the `feat-submission-sample-sets` branch

### Documentation

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [x] Other (explain below)

N/A

### Maintainability

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
