### PR TITLE
Configure Dagster to limit `ensure_alldocs` to 45 mins and to skip launching new runs when already running

### DIFF
--- a/nmdc_runtime/site/dagster.yaml
+++ b/nmdc_runtime/site/dagster.yaml
@@ -10,6 +10,12 @@ run_launcher:
   module: dagster.core.launcher
   class: DefaultRunLauncher
 
+# Enable Dagster's "run monitoring" feature, so Dagster will enforce the `MAX_RUNTIME_SECONDS_TAG`
+# duration limits that we define at the job level (e.g. we define one for the `ensure_alldocs` job).
+# Docs: https://docs.dagster.io/deployment/execution/run-monitoring#general-run-timeouts
+run_monitoring:
+  enabled: true
+
 run_storage:
   module: dagster_postgres.run_storage
   class: PostgresRunStorage

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -159,7 +159,7 @@ ensure_alldocs_hourly = ScheduleDefinition(
             # durations exceed this limit. We enable Dagster's "run monitoring" feature
             # via `run_monitoring.enabled: true` in `nmdc_runtime/site/dagster.yaml`.
             MAX_RUNTIME_SECONDS_TAG: timedelta(minutes=45).total_seconds(),
-        }
+        },
     ),
 )
 
@@ -486,7 +486,7 @@ def repo():
                 # durations exceed this limit. We enable Dagster's "run monitoring" feature
                 # via `run_monitoring.enabled: true` in `nmdc_runtime/site/dagster.yaml`.
                 MAX_RUNTIME_SECONDS_TAG: timedelta(minutes=45).total_seconds(),
-            }
+            },
         ),
     ]
     schedules = [

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -16,6 +16,8 @@ from dagster import (
     RunStatusSensorContext,
     DefaultSensorStatus,
     MAX_RUNTIME_SECONDS_TAG,
+    RunsFilter,
+    ScheduleEvaluationContext,
 )
 from starlette import status
 from toolz import merge, get_in
@@ -115,11 +117,41 @@ housekeeping_weekly = ScheduleDefinition(
     job=housekeeping.to_job(**preset_normal),
 )
 
+
+def should_execute_ensure_alldocs(context: ScheduleEvaluationContext) -> bool:
+    """
+    Helper function that returns `True` if there are no running or queued runs of the
+    `ensure_alldocs` job; otherwise, returns `False`. This function was designed to be passed to
+    the `ScheduleDefinition` constructor via the latter's `should_execute` kwarg.
+    """
+    num_matching_runs = context.instance.get_runs_count(
+        filters=RunsFilter(
+            job_name=ensure_alldocs.name,
+            statuses=[
+                DagsterRunStatus.NOT_STARTED,
+                DagsterRunStatus.QUEUED,
+                DagsterRunStatus.STARTING,
+                DagsterRunStatus.STARTED,
+                DagsterRunStatus.CANCELING,
+                # We intentionally omitted the following statuses:
+                # - DagsterRunStatus.MANAGED (only relevant when using Dagster with Airflow)
+                # - DagsterRunStatus.SUCCESS (the run has succeeded)
+                # - DagsterRunStatus.FAILURE (the run has failed)
+                # - DagsterRunStatus.CANCELED (the run has stopped after being canceled)
+            ],
+        )
+    )
+    return num_matching_runs == 0
+
+
+# Docs: https://docs.dagster.io/api/dagster/schedules-sensors#dagster.schedule
 # Note: A cron schedule of `0 * * * *` means "every hour".
 ensure_alldocs_hourly = ScheduleDefinition(
     name="hourly_ensure_alldocs",
     cron_schedule="0 * * * *",
     execution_timezone="America/New_York",
+    # Configure Dagster to skip executing the job when there are already running or queued runs of it.
+    should_execute=should_execute_ensure_alldocs,
     job=ensure_alldocs.to_job(
         **preset_normal,
         run_tags={

--- a/nmdc_runtime/site/repository.py
+++ b/nmdc_runtime/site/repository.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from importlib.metadata import version
 import json
 
@@ -14,6 +15,7 @@ from dagster import (
     DagsterRunStatus,
     RunStatusSensorContext,
     DefaultSensorStatus,
+    MAX_RUNTIME_SECONDS_TAG,
 )
 from starlette import status
 from toolz import merge, get_in
@@ -118,7 +120,15 @@ ensure_alldocs_hourly = ScheduleDefinition(
     name="hourly_ensure_alldocs",
     cron_schedule="0 * * * *",
     execution_timezone="America/New_York",
-    job=ensure_alldocs.to_job(**preset_normal),
+    job=ensure_alldocs.to_job(
+        **preset_normal,
+        run_tags={
+            # Configure Dagster's "run monitoring" feature to "fail" runs of this job whose
+            # durations exceed this limit. We enable Dagster's "run monitoring" feature
+            # via `run_monitoring.enabled: true` in `nmdc_runtime/site/dagster.yaml`.
+            MAX_RUNTIME_SECONDS_TAG: timedelta(minutes=45).total_seconds(),
+        }
+    ),
 )
 
 
@@ -437,7 +447,15 @@ def repo():
         ensure_jobs.to_job(**preset_normal),
         apply_metadata_in.to_job(**preset_normal),
         export_study_biosamples_metadata.to_job(**preset_normal),
-        ensure_alldocs.to_job(**preset_normal),
+        ensure_alldocs.to_job(
+            **preset_normal,
+            run_tags={
+                # Configure Dagster's "run monitoring" feature to "fail" runs of this job whose
+                # durations exceed this limit. We enable Dagster's "run monitoring" feature
+                # via `run_monitoring.enabled: true` in `nmdc_runtime/site/dagster.yaml`.
+                MAX_RUNTIME_SECONDS_TAG: timedelta(minutes=45).total_seconds(),
+            }
+        ),
     ]
     schedules = [
         housekeeping_weekly,


### PR DESCRIPTION
<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I made changes to the way Dagster manages the `ensure_alldocs` job.

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

#### Limiting run duration

Previously, the job could run indefinitely (that is true about all Dagster jobs by default). Normally, that wasn't a problem, since this job normally takes about 20 minutes to run. During our monthly releases (and at other times where we shut down Dagster), this was leading to multiple runs of the job "clogging" the queue, preventing unrelated jobs from being run (such as those that apply changesheets). That phenomenon is documented in the [Dagster docs](https://docs.dagster.io/deployment/execution/run-monitoring#detecting-run-worker-crashes):

<img width="948" height="314" alt="image" src="https://github.com/user-attachments/assets/efda3129-0104-41b1-833b-1046d50a9246" />

On this branch, I enabled Dagster's "[run monitoring](https://docs.dagster.io/deployment/execution/run-monitoring)" feature and configured it to **"fail" any `ensure_alldocs` runs that don't finish within 45 minutes**. For reference, the runs of that job normally finish in 20 minutes.

#### Skipping if already running/queued

Also, previously, Dagster was configured to schedule a run of the `ensure_alldocs` jobs every hour, _even if_ there were other runs of the job still running or queued.

On this branch, I configured Dagster to only schedule a run of the hourly `ensure_alldocs` job **if there are no running or queued runs of it.** If there are already running or queued runs of it at the time, Dagster will skip the new run ~(and set its status to `SKIPPED`)~. Note that this does not apply to launching the `ensure_alldocs` job manually via the Dagster UI—it only applied to the hourly scheduled runs (although the "already running" instance can have been launched by either means).

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

Fixes #1356

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [x] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I tested these changes (explain below)
- [x] I did not test these changes

I will test these changes in dev.

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [x] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [x] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [x] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [x] I used `black` to format all the Python files I created/modified
- [x] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")