### PR TITLE
Implement `MongoCommandProcessor` class as replacement for 400-line `_run_mdb_cmd` function

### DIFF
--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -23,6 +23,7 @@ from nmdc_runtime.api.models.query import (
     DeleteCommand,
     DeleteCommandResponse,
     DeleteSpecs,
+    DeleteStatement,
 )
 from nmdc_runtime.util import get_allowed_references, nmdc_schema_view
 
@@ -144,50 +145,40 @@ class MongoCommandProcessor:
 
     def _identify_broken_references_deletion_would_leave_behind(
             self,
-            delete_command: DeleteCommand,
+            collection_name: str,
+            target_document_oids: list[ObjectId],
             stop_on_first: bool = False,
     ) -> list:
         """
-        Identify broken references that would be left behind if Mongo were to run the specified
-        "delete" command on the database in its current state.
+        Identify documents that would remain after the deletion, which contain references to any of
+        the documents that would be deleted. The `ObjectId`s of the documents that would be deleted
+        are passed to this function via the `target_document_oids` parameter.
         
-        If `stop_on_first` is `True`, the function will stop checking after it finds a single broken
-        reference that would be left behind (this will decrease response times since the function
-        won't have to continue looking for additional references).
-
-        Note: This function disregards the "limit" property, if any, of the "delete" specification.
-              We have no way of predicting _which_ document Mongo would delete, and so we behave as
-              though _all_ matching documents would be deleted.
-              TODO: Address the fact that this could create a false negative result when one of the
-                    referring documents happens to match the "delete" specification.
+        If `stop_on_first` is `True`, the function will stop checking after it finds a single such
+        document that would be left behind (this will decrease return times since the function won't
+        have to continue looking for additional such documents).
         """
-        collection = self.db.get_collection(delete_command.delete)
-        delete_specs: DeleteSpecs = derive_delete_specs(delete_command=delete_command)
+        collection = self.db.get_collection(collection_name)
 
         # Initialize a list of descriptors of the broken references that would be left behind.
         # Note: These descriptors will identify referring _documents_, but not referring _fields_.
         descriptors_of_broken_references: list = []
 
-        # Make a list of the documents that would be deleted.
+        # Get the `id` and `type` values of the documents that would be deleted.
         target_document_descriptors = list(
             collection.find(
-                filter={"$or": [spec["filter"] for spec in delete_specs]},
+                filter={"_id": {"$in": target_document_oids}},
                 projection={"_id": 1, "id": 1, "type": 1},
             )
         )
 
-        # Make a set of their `_id` values (i.e. their ObjectId values).
-        target_document_oids = set(
-            tdd["_id"] for tdd in target_document_descriptors
-        )
-
         # For each of those documents, check whether it is referenced by any documents that would
-        # not be deleted (if so, it means a broken reference would be left behind).
+        # _not_ be deleted (if so, it means a broken reference would be left behind).
         finder = Finder(database=self.db)
         for target_document_descriptor in target_document_descriptors:
             # If the document descriptor lacks an "id" field, we already know that no documents can
             # reference it (since they would have to _use_ that "id" value to do so). In that case,
-            # we won't bother trying to identify referring documents for it.
+            # we won't bother trying to identify documents that reference it.
             if "id" not in target_document_descriptor:
                 continue
 
@@ -200,7 +191,7 @@ class MongoCommandProcessor:
             )
 
             # If _any_ referring document is _not_ among those that would be deleted, it means that
-            # performing the deletion _would_ leave behind broken references.
+            # performing the deletion _would_ leave behind a referring document (i.e. a broken reference).
             for rdd in referring_document_descriptors:
                 source_document_oid = rdd["source_document_object_id"]
                 if source_document_oid not in target_document_oids:
@@ -262,27 +253,31 @@ class MongoCommandProcessor:
         raw_response = self.db.command(command=mongo_command_document)
         return CollStatsCommandResponse(**raw_response)
 
-    def _back_up_documents_before_deletion(self, delete_command: DeleteCommand) -> None:
+    def _back_up_documents_before_deletion(
+        self,
+        collection_name: str,
+        target_document_oids: list[ObjectId],
+    ) -> None:
         """Back up the documents identified by the specified "delete" command."""
 
-        collection = self.db.get_collection(delete_command.delete)
-        delete_specs: DeleteSpecs = derive_delete_specs(delete_command=delete_command)
-
         # Get a cursor referencing the documents that would be deleted.
+        collection = self.db.get_collection(collection_name)
         target_documents_cursor = collection.find(
-            filter={"$or": [spec["filter"] for spec in delete_specs]},
+            filter={"_id": {"$in": target_document_oids}},
         )
 
         # Insert each of those documents into the deletion archive database (e.g. "nmdc_deleted").
         deleted_at = now()  # they'll all have the same `deleted_at` timestamp.
         deletion_archive_db = self.db.client.get_database(self.DELETION_ARCHIVE_DATABASE_NAME)
-        deletion_archive_collection = deletion_archive_db.get_collection(delete_command.delete)
+        deletion_archive_collection = deletion_archive_db.get_collection(collection_name)
         documents_to_back_up = []
         for doc in target_documents_cursor:
             documents_to_back_up.append(dict(doc=doc, deleted_at=deleted_at))
         insert_many_result = deletion_archive_collection.insert_many(documents_to_back_up)
 
         # If we didn't back up all of the documents, raise an exception.
+        # TODO: Consider delegating the reporting that "no documents have been deleted" to the
+        #       caller, since the actual deletion is not one of this method's concerns.
         if len(insert_many_result.inserted_ids) != len(documents_to_back_up):
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -331,20 +326,27 @@ class MongoCommandProcessor:
                 detail=f"Collection '{collection_name}' is not described by the NMDC Schema",
             )
 
-        # Check how many documents containing broken references the deletion would leave behind.
-        # If there are any, log warnings or raise an exception, depending upon `allow_broken_refs`.
-        broken_refs = self._identify_broken_references_deletion_would_leave_behind(
-            delete_command=command,
+        # Get the `_id` values of the documents that would be deleted.
+        target_document_oids = self._get_oids_of_specified_documents(command)
+
+        # Determine whether any documents that reference those documents would be left behind
+        # if the deletion were to be performed.
+        referrers_left_behind = self._identify_broken_references_deletion_would_leave_behind(
+            collection_name=collection_name,
+            target_document_oids=target_document_oids,
             stop_on_first=True,
         )
-        if len(broken_refs) > 0:
+
+        # Check how many documents containing broken references the deletion would leave behind.
+        # If there are any, log warnings or raise an exception, depending upon `allow_broken_refs`.
+        if len(referrers_left_behind) > 0:
             if allow_broken_refs:
-                for ref in broken_refs:
+                for r in referrers_left_behind:
                     logger.warning(
-                        f"The document having 'id'='{ref['target_document_id']}' in "
-                        f"the collection '{ref['collection_name']}' is referenced by "
-                        f"the document having 'id'='{ref['source_document_id']}' in "
-                        f"the collection '{ref['source_collection_name']}'. "
+                        f"The document having 'id'='{r['target_document_id']}' in "
+                        f"the collection '{r['collection_name']}' is referenced by "
+                        f"the document having 'id'='{r['source_document_id']}' in "
+                        f"the collection '{r['source_collection_name']}'. "
                         f"Deleting the former will leave behind a broken reference."
                     )
             else:
@@ -356,26 +358,35 @@ class MongoCommandProcessor:
                 #       such references; but it would also take longer to compute and
                 #       would increase the response size (consider the case where the
                 #       user-specified filter matches many, many documents).
-                ref = broken_refs[0]
+                r = referrers_left_behind[0]
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail=(
                         f"The operation was not performed, because performing it would "
                         f"have left behind one or more broken references. For example: "
-                        f"The document having 'id'='{ref['target_document_id']}' in "
-                        f"the collection '{ref['collection_name']}' is referenced by "
-                        f"the document having 'id'='{ref['source_document_id']}' in "
-                        f"the collection '{ref['source_collection_name']}'. "
+                        f"The document having 'id'='{r['target_document_id']}' in "
+                        f"the collection '{r['collection_name']}' is referenced by "
+                        f"the document having 'id'='{r['source_document_id']}' in "
+                        f"the collection '{r['source_collection_name']}'. "
                         f"Deleting the former would leave behind a broken reference. "
                         f"Update or delete referring document(s) and try again."
                     ),
                 )
 
         # Back up the would-be deleted documents.
-        self._back_up_documents_before_deletion(delete_command=command)
+        self._back_up_documents_before_deletion(
+            collection_name=collection_name,
+            target_document_oids=target_document_oids,
+        )
 
         # Perform the deletion.
-        mongo_command_document = self._make_mongo_command_document(command)
+        delete_command = DeleteCommand(
+            delete=collection_name,
+            deletes=[
+                DeleteStatement(q={"_id": {"$in": target_document_oids}}, limit=0)
+            ],
+        )
+        mongo_command_document = self._make_mongo_command_document(delete_command)
         raw_response = self.db.command(command=mongo_command_document)
 
         # Handle `writeErrors`.

--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -173,10 +173,19 @@ class MongoCommandProcessor:
             )
         )
 
+        # Make a set, so existence searches are faster (than with a list).
+        target_document_oids_set: set = set(target_document_oids)
+
         # For each of those documents, check whether it is referenced by any documents that would
         # _not_ be deleted (if so, it means a broken reference would be left behind).
+        is_scan_aborted = False
         finder = Finder(database=self.db)
         for target_document_descriptor in target_document_descriptors:
+            # If the "is scan aborted" flag has been set, break out of this loop. This happens when
+            # the `stop_on_first` flag is set and we have already found our first violation.
+            if is_scan_aborted:
+                break
+
             # If the document descriptor lacks an "id" field, we already know that no documents can
             # reference it (since they would have to _use_ that "id" value to do so). In that case,
             # we won't bother trying to identify documents that reference it.
@@ -195,7 +204,11 @@ class MongoCommandProcessor:
             # performing the deletion _would_ leave behind a referring document (i.e. a broken reference).
             for rdd in referring_document_descriptors:
                 source_document_oid = rdd["source_document_object_id"]
-                if source_document_oid not in target_document_oids:
+                source_collection_name = rdd["source_collection_name"]
+                if not (
+                    source_collection_name == collection_name and
+                    source_document_oid in target_document_oids_set
+                ):
                     descriptor_of_broken_reference = dict(
                         source_collection_name=rdd["source_collection_name"],
                         source_class_name=rdd["source_class_name"],
@@ -210,6 +223,7 @@ class MongoCommandProcessor:
                     # If the caller opted to stop after identifying the first reference that would
                     # be broken, stop iterating now.
                     if stop_on_first:
+                        is_scan_aborted = True
                         break
 
         return descriptors_of_broken_references
@@ -265,6 +279,11 @@ class MongoCommandProcessor:
     ) -> None:
         """Back up the documents identified by the specified "delete" command."""
 
+        # If no `ObjectId`s were specified, return early.
+        if len(target_document_oids) == 0:
+            logger.debug("No documents were specified to be backed up.")
+            return None
+
         # Get a cursor referencing the documents that would be deleted.
         collection = self.db.get_collection(collection_name)
         target_documents_cursor = collection.find(
@@ -280,23 +299,31 @@ class MongoCommandProcessor:
             collection_name
         )
         documents_to_back_up = []
-        for doc in target_documents_cursor:
-            documents_to_back_up.append(dict(doc=doc, deleted_at=deleted_at))
-        insert_many_result = deletion_archive_collection.insert_many(
-            documents_to_back_up
-        )
+        for target_document in target_documents_cursor:
+            documents_to_back_up.append(dict(doc=target_document, deleted_at=deleted_at))
 
-        # If we didn't back up all of the documents, raise an exception.
-        # TODO: Consider delegating the reporting that "no documents have been deleted" to the
-        #       caller, since the actual deletion is not one of this method's concerns.
-        if len(insert_many_result.inserted_ids) != len(documents_to_back_up):
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=(
-                    "Deletion failed. We failed to back up the documents before starting deletion. "
-                    "The entire operation has been aborted. No documents have been deleted."
-                ),
+        if len(documents_to_back_up) < len(target_document_oids):
+            logger.warning(
+                f"We expected to back up {len(target_document_oids)} documents, "
+                f"but we found only {len(documents_to_back_up)} documents to back up."
             )
+
+        if len(documents_to_back_up) > 0:
+            insert_many_result = deletion_archive_collection.insert_many(documents_to_back_up)
+
+            # If we didn't back up all of the documents we found, raise an exception.
+            # TODO: Consider delegating the reporting that "no documents have been deleted" to the
+            #       caller, since the actual deletion is not one of this method's concerns.
+            if len(insert_many_result.inserted_ids) != len(documents_to_back_up):
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=(
+                        "We failed to back up some documents before starting the deletion. "
+                        "The entire operation has been aborted. No documents have been deleted."
+                    ),
+                )
+        else:
+            logger.debug("There are no documents to back up.")
 
     @staticmethod
     def _generate_user_facing_event_id() -> str:
@@ -357,7 +384,7 @@ class MongoCommandProcessor:
                 for r in referrers_left_behind:
                     logger.warning(
                         f"The document having 'id'='{r['target_document_id']}' in "
-                        f"the collection '{r['collection_name']}' is referenced by "
+                        f"the collection '{collection_name}' is referenced by "
                         f"the document having 'id'='{r['source_document_id']}' in "
                         f"the collection '{r['source_collection_name']}'. "
                         f"Deleting the former will leave behind a broken reference."
@@ -378,7 +405,7 @@ class MongoCommandProcessor:
                         f"The operation was not performed, because performing it would "
                         f"have left behind one or more broken references. For example: "
                         f"The document having 'id'='{r['target_document_id']}' in "
-                        f"the collection '{r['collection_name']}' is referenced by "
+                        f"the collection '{collection_name}' is referenced by "
                         f"the document having 'id'='{r['source_document_id']}' in "
                         f"the collection '{r['source_collection_name']}'. "
                         f"Deleting the former would leave behind a broken reference. "
@@ -396,11 +423,14 @@ class MongoCommandProcessor:
         delete_command = DeleteCommand(
             delete=collection_name,
             deletes=[
-                DeleteStatement(q={"_id": {"$in": target_document_oids}}, limit=0)
+                DeleteStatement(q={"_id": {"$in": target_document_oids}}, limit=0),
             ],
         )
         mongo_command_document = self._make_mongo_command_document(delete_command)
-        raw_response = self.db.command(command=mongo_command_document)
+        raw_response = self.db.command(
+            command=mongo_command_document,
+            comment="A deletion by MongoCommandProcessor within nmdc-runtime",
+        )
 
         # Handle `writeErrors`.
         response = DeleteCommandResponse(**raw_response)
@@ -420,9 +450,18 @@ class MongoCommandProcessor:
 
         return response
 
-    def process(self, command: MongoCommand) -> MongoCommandResponse:
+    def process(
+        self,
+        command: MongoCommand,
+        allow_broken_refs: bool = False,
+    ) -> MongoCommandResponse:
         """
         Submit the specified command to the configured Mongo database.
+
+        For "delete" commands, the `allow_broken_refs` parameter controls whether this processor
+        will still carry out the deletion, even if it would leave behind broken reference. This
+        is offered as an option because a "delete" command can only target a single collection;
+        meanwhile, it's possible for documents in two collections to reference one another.
         """
 
         # Initialize the response.
@@ -434,15 +473,20 @@ class MongoCommandProcessor:
         elif isinstance(command, CollStatsCommand):
             response = self._process_collstats_command(command)
         elif isinstance(command, DeleteCommand):
-            response = self._process_delete_command(command)
+            response = self._process_delete_command(command, allow_broken_refs=allow_broken_refs)
 
             # If no documents were deleted, the user might have made a mistake. In that case,
             # we return an error response as a courtesy.
             if response.n == 0:
                 raise HTTPException(
                     status_code=status.HTTP_418_IM_A_TEAPOT,
-                    detail="No documents were deleted. Check the syntax of your request.",
+                    detail="No documents were deleted. Check the syntax of your request."
                 )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported command: {command}"
+            )
 
         # Return the response.
         return response

--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -1,10 +1,17 @@
 from json import dumps
 from logging import getLogger
 from typing import Any
+import uuid
 
 from bson.json_util import loads
+from fastapi import HTTPException, status
 from pymongo.database import Database
+from refscan.lib.helpers import get_collection_names_from_schema
+from refscan.lib.Finder import Finder
+from refscan.scanner import identify_referring_documents
 
+from nmdc_runtime.api.core.util import now
+from nmdc_runtime.api.models.lib.helpers import derive_delete_specs
 from nmdc_runtime.api.models.query import (
     Cmd as MongoCommand,
     CommandResponse as MongoCommandResponse,
@@ -12,10 +19,15 @@ from nmdc_runtime.api.models.query import (
     CollStatsCommandResponse,
     CountCommand,
     CountCommandResponse,
+    DeleteCommand,
+    DeleteCommandResponse,
+    DeleteSpecs,
 )
+from nmdc_runtime.util import get_allowed_references, nmdc_schema_view
 
 
 logger = getLogger(__name__)
+
 
 class MongoCommandProcessor:
     """
@@ -26,9 +38,14 @@ class MongoCommandProcessor:
           us to work with over time.
     """
 
+    DELETION_ARCHIVE_DATABASE_NAME = "nmdc_deleted"
+
     def __init__(self, db: Database):
-        """Initialize this instance's Mongo database reference to be the specified one."""
+        """
+        Initialize this instance with a `SchemaView` instance and the specified database connection.
+        """
         self.db = db
+        self.schema_view = nmdc_schema_view()
 
     @staticmethod
     def _make_mongo_command_document(command: MongoCommand) -> dict[str, Any]:
@@ -69,6 +86,88 @@ class MongoCommandProcessor:
         True
         """
         return response.ok == 1
+
+    def _get_nmdc_schema_collection_names(self) -> list[str]:
+        """Returns the names of all collections described by the NMDC Schema."""
+        return get_collection_names_from_schema(schema_view=self.schema_view)
+
+    def _identify_broken_references_deletion_would_leave_behind(
+            self,
+            delete_command: DeleteCommand,
+            stop_on_first: bool = False,
+    ) -> list:
+        """
+        Identify broken references that would be left behind if Mongo were to run the specified
+        "delete" command on the database in its current state.
+        
+        If `stop_on_first` is `True`, the function will stop checking after it finds a single broken
+        reference that would be left behind (this will decrease response times since the function
+        won't have to continue looking for additional references).
+
+        Note: This function disregards the "limit" property, if any, of the "delete" specification.
+              We have no way of predicting _which_ document Mongo would delete, and so we behave as
+              though _all_ matching documents would be deleted.
+              TODO: Address the fact that this could create a false negative result when one of the
+                    referring documents happens to match the "delete" specification.
+        """
+        collection = self.db.get_collection(delete_command.delete)
+        delete_specs: DeleteSpecs = derive_delete_specs(delete_command=delete_command)
+
+        # Initialize a list of descriptors of the broken references that would be left behind.
+        # Note: These descriptors will identify referring _documents_, but not referring _fields_.
+        descriptors_of_broken_references: list = []
+
+        # Make a list of the documents that would be deleted.
+        target_document_descriptors = list(
+            collection.find(
+                filter={"$or": [spec["filter"] for spec in delete_specs]},
+                projection={"_id": 1, "id": 1, "type": 1},
+            )
+        )
+
+        # Make a set of their `_id` values (i.e. their ObjectId values).
+        target_document_oids = set(
+            tdd["_id"] for tdd in target_document_descriptors
+        )
+
+        # For each of those documents, check whether it is referenced by any documents that would
+        # not be deleted (if so, it means a broken reference would be left behind).
+        finder = Finder(database=self.db)
+        for target_document_descriptor in target_document_descriptors:
+            # If the document descriptor lacks an "id" field, we already know that no documents can
+            # reference it (since they would have to _use_ that "id" value to do so). In that case,
+            # we won't bother trying to identify referring documents for it.
+            if "id" not in target_document_descriptor:
+                continue
+
+            # Identify all documents that reference this target document.
+            referring_document_descriptors = identify_referring_documents(
+                document=target_document_descriptor,  # expects at least "id" and "type"
+                schema_view=nmdc_schema_view(),
+                references=get_allowed_references(),
+                finder=finder,
+            )
+
+            # If _any_ referring document is _not_ among those that would be deleted, it means that
+            # performing the deletion _would_ leave behind broken references.
+            for rdd in referring_document_descriptors:
+                source_document_oid = rdd["source_document_object_id"]
+                if source_document_oid not in target_document_oids:
+                    descriptor_of_broken_reference = dict(
+                        source_collection_name=rdd["source_collection_name"],
+                        source_class_name=rdd["source_class_name"],
+                        source_document_oid=source_document_oid,
+                        source_document_id=rdd["source_document_id"],
+                        target_document_id=target_document_descriptor["id"],
+                    )
+                    descriptors_of_broken_references.append(descriptor_of_broken_reference)
+
+                    # If the caller opted to stop after identifying the first reference that would
+                    # be broken, stop iterating now.
+                    if stop_on_first:
+                        break
+
+        return descriptors_of_broken_references
 
     def _process_count_command(self, command: CountCommand) -> CountCommandResponse:
         """
@@ -112,6 +211,138 @@ class MongoCommandProcessor:
         raw_response = self.db.command(command=mongo_command_document)
         return CollStatsCommandResponse(**raw_response)
 
+    def _back_up_documents_before_deletion(self, delete_command: DeleteCommand) -> None:
+        """Back up the documents identified by the specified "delete" command."""
+
+        collection = self.db.get_collection(delete_command.delete)
+        delete_specs: DeleteSpecs = derive_delete_specs(delete_command=delete_command)
+
+        # Get a cursor referencing the documents that would be deleted.
+        target_documents_cursor = collection.find(
+            filter={"$or": [spec["filter"] for spec in delete_specs]},
+        )
+
+        # Insert each of those documents into the deletion archive database (e.g. "nmdc_deleted").
+        deleted_at = now()  # they'll all have the same `deleted_at` timestamp.
+        deletion_archive_db = self.db.client.get_database(self.DELETION_ARCHIVE_DATABASE_NAME)
+        deletion_archive_collection = deletion_archive_db.get_collection(delete_command.delete)
+        documents_to_back_up = []
+        for doc in target_documents_cursor:
+            documents_to_back_up.append(dict(doc=doc, deleted_at=deleted_at))
+        insert_many_result = deletion_archive_collection.insert_many(documents_to_back_up)
+
+        # If we didn't back up all of the documents, raise an exception.
+        if len(insert_many_result.inserted_ids) != len(documents_to_back_up):
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    "Deletion failed. We failed to back up the documents before starting deletion. "
+                    "The entire operation has been aborted. No documents have been deleted."
+                ),
+            )
+
+    @staticmethod
+    def _generate_user_facing_event_id() -> str:
+        r"""
+        Get a unique identifier that can be used to correlate a user report with system logs.
+
+        Example: '20260721201139-7bbbc058-45a4-4926-a568-f7b532a4289c'
+
+        Docs: https://docs.python.org/3/library/uuid.html
+
+        >>> import re
+        >>> id_ = MongoCommandProcessor._generate_user_facing_event_id()
+        >>> re.compile(r"^[0-9]{14}-[0-9a-f\-]{36}$").match(id_) is not None
+        True
+        >>> id_.startswith("20")
+        True
+        """
+        timestamp: str = now().strftime('%Y%m%d%H%M%S')
+        uuid_ = str(uuid.uuid4())
+        return f"{timestamp}-{uuid_}"
+
+    def _process_delete_command(
+        self,
+        command: DeleteCommand,
+        allow_broken_refs: bool = False,
+    ) -> DeleteCommandResponse:
+        """
+        Process a MongoDB `delete` command.
+
+        Reference: https://www.mongodb.com/docs/manual/reference/command/delete/
+        """
+
+        # If the specified collection isn't described by the schema, raise an exception.
+        collection_name = command.delete
+        if collection_name not in self._get_nmdc_schema_collection_names():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Collection '{collection_name}' is not described by the NMDC Schema",
+            )
+
+        # Check how many documents containing broken references the deletion would leave behind.
+        # If there are any, log warnings or raise an exception, depending upon `allow_broken_refs`.
+        broken_refs = self._identify_broken_references_deletion_would_leave_behind(
+            delete_command=command,
+            stop_on_first=True,
+        )
+        if len(broken_refs) > 0:
+            if allow_broken_refs:
+                for ref in broken_refs:
+                    logger.warning(
+                        f"The document having 'id'='{ref['target_document_id']}' in "
+                        f"the collection '{ref['collection_name']}' is referenced by "
+                        f"the document having 'id'='{ref['source_document_id']}' in "
+                        f"the collection '{ref['source_collection_name']}'. "
+                        f"Deleting the former will leave behind a broken reference."
+                    )
+            else:
+                # Raise an exception about the first would-be-broken reference.
+                #
+                # TODO: Consider reporting _all_ would-be-broken references instead of
+                #       only the _first_ one we encounter. That would make the response
+                #       more informative to the user in cases where there are multiple
+                #       such references; but it would also take longer to compute and
+                #       would increase the response size (consider the case where the
+                #       user-specified filter matches many, many documents).
+                ref = broken_refs[0]
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail=(
+                        f"The operation was not performed, because performing it would "
+                        f"have left behind one or more broken references. For example: "
+                        f"The document having 'id'='{ref['target_document_id']}' in "
+                        f"the collection '{ref['collection_name']}' is referenced by "
+                        f"the document having 'id'='{ref['source_document_id']}' in "
+                        f"the collection '{ref['source_collection_name']}'. "
+                        f"Deleting the former would leave behind a broken reference. "
+                        f"Update or delete referring document(s) and try again."
+                    ),
+                )
+
+        # Back up the would-be deleted documents.
+        self._back_up_documents_before_deletion(delete_command=command)
+
+        # Perform the deletion.
+        mongo_command_document = self._make_mongo_command_document(command)
+        raw_response = self.db.command(command=mongo_command_document)
+
+        # Handle `writeErrors`.
+        response = DeleteCommandResponse(**raw_response)
+        if isinstance(response.writeErrors, list) and len(response.writeErrors) > 0:
+            event_id = self._generate_user_facing_event_id()
+            logger.error(f"An error(s) occurred while deleting documents. Event ID: {event_id}")
+            logger.error(response.writeErrors)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    "An error occurred while deleting the specified documents. Please contact "
+                    f"an administrator of this application, referencing system event '{event_id}'. "
+                ),
+            )
+    
+        return response
+
     def process(self, command: MongoCommand) -> MongoCommandResponse:
         """
         Submit the specified command to the configured Mongo database.
@@ -125,6 +356,16 @@ class MongoCommandProcessor:
             response = self._process_count_command(command)
         elif isinstance(command, CollStatsCommand):
             response = self._process_collstats_command(command)
+        elif isinstance(command, DeleteCommand):
+            response = self._process_delete_command(command)
+
+            # If no documents were deleted, the user might have made a mistake. In that case,
+            # we return an error response as a courtesy.
+            if response.n == 0:
+                raise HTTPException(
+                    status_code=status.HTTP_418_IM_A_TEAPOT,
+                    detail="No documents were deleted. Check the syntax of your request."
+                )
 
         # Return the response.
         return response

--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -1,0 +1,130 @@
+from json import dumps
+from logging import getLogger
+from typing import Any
+
+from bson.json_util import loads
+from pymongo.database import Database
+
+from nmdc_runtime.api.models.query import (
+    Cmd as MongoCommand,
+    CommandResponse as MongoCommandResponse,
+    CollStatsCommand,
+    CollStatsCommandResponse,
+    CountCommand,
+    CountCommandResponse,
+)
+
+
+logger = getLogger(__name__)
+
+class MongoCommandProcessor:
+    """
+    Note: This class was created as a replacement for the `_run_mdb_cmd` function defined in the
+          `nmdc_runtime/api/endpoints/queries.py` file. That function had grown over time to be
+          over 400 lines, to have multiple responsibilities, and to accumulate caveats/TODOs.
+          This class, initially, shares some of those traits, but we think it'll be easier for
+          us to work with over time.
+    """
+
+    def __init__(self, db: Database):
+        """Initialize this instance's Mongo database reference to be the specified one."""
+        self.db = db
+
+    @staticmethod
+    def _make_mongo_command_document(command: MongoCommand) -> dict[str, Any]:
+        """
+        Get a MongoDB document representing the specified command.
+
+        References:
+        - https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
+        - https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
+
+        Note: The implementation of this function was copied from the `_run_mdb_cmd` function
+              in the `nmdc_runtime/api/endpoints/queries.py` file.
+
+        >>> from bson import ObjectId
+        >>> query = {"_id": ObjectId("000011112222333344445555")}
+        >>> command = CountCommand(count="study_set", query=query)
+        >>> MongoCommandProcessor._make_mongo_command_document(command)
+        {'count': 'study_set', 'query': {'_id': ObjectId('000011112222333344445555')}}
+        """
+
+        # Note: `command.model_dump()` converts `ObjectId("...")` into `{"$oid": "..."}`,
+        #       so we'll subsequently convert it back (via `bson.json_util.loads` below).
+        json_dict: dict = command.model_dump(exclude_unset=True)
+        json_string: str = dumps(json_dict)
+        mongo_command_document: dict = loads(json_string)
+        return mongo_command_document
+
+    @staticmethod
+    def _is_response_ok(response: MongoCommandResponse) -> bool:
+        """
+        Returns `True` if `response.ok` is 1; otherwise, returns `False`.
+
+        >>> response = MongoCommandResponse(ok=0)
+        >>> MongoCommandProcessor._is_response_ok(response)
+        False
+        >>> response = MongoCommandResponse(ok=1)
+        >>> MongoCommandProcessor._is_response_ok(response)
+        True
+        """
+        return response.ok == 1
+
+    def _process_count_command(self, command: CountCommand) -> CountCommandResponse:
+        """
+        Process a MongoDB `count` command.
+
+        >>> from unittest.mock import MagicMock
+        >>> mock_db = MagicMock(spec=Database)
+        >>> mock_db.command.return_value = {"ok": 1, "n": 123}
+        >>> processor = MongoCommandProcessor(mock_db)
+        >>> response = processor._process_count_command(CountCommand(count="study_set"))
+        >>> response.model_dump()
+        {'ok': 1, 'n': 123}
+        >>> mock_db.command.assert_called_once_with(command={"count": "study_set"})
+        """
+        mongo_command_document = self._make_mongo_command_document(command)
+        raw_response = self.db.command(command=mongo_command_document)
+        return CountCommandResponse(**raw_response)
+
+    def _process_collstats_command(self, command: CollStatsCommand) -> CollStatsCommandResponse:
+        """
+        Process a MongoDB `collStats` command.
+
+        Note: The `collStats` command has been deprecated since MongoDB 6.2.
+              Reference: https://www.mongodb.com/docs/manual/reference/command/collStats/
+
+        >>> from unittest.mock import MagicMock
+        >>> mock_db = MagicMock(spec=Database)
+        >>> mock_db.command.return_value = {"ok": 1, "ns": "non_existent_collection", "size": 0, "count": 0, "storageSize": 0, "totalIndexSize": 0, "totalSize": 0, "scaleFactor": 1}
+        >>> processor = MongoCommandProcessor(mock_db)
+        >>> response = processor._process_collstats_command(CollStatsCommand(collStats="non_existent_collection"))
+        >>> dumped_response = response.model_dump()
+        >>> dumped_response["ok"]
+        1
+        >>> dumped_response["ns"]
+        'non_existent_collection'
+        >>> dumped_response["count"]
+        0.0
+        >>> mock_db.command.assert_called_once_with(command={"collStats": "non_existent_collection"})
+        """
+        mongo_command_document = self._make_mongo_command_document(command)
+        raw_response = self.db.command(command=mongo_command_document)
+        return CollStatsCommandResponse(**raw_response)
+
+    def process(self, command: MongoCommand) -> MongoCommandResponse:
+        """
+        Submit the specified command to the configured Mongo database.
+        """
+
+        # Initialize the response.
+        response = MongoCommandResponse(ok=0)
+
+        # Invoke the appropriate method based upon the kind of command.
+        if isinstance(command, CountCommand):
+            response = self._process_count_command(command)
+        elif isinstance(command, CollStatsCommand):
+            response = self._process_collstats_command(command)
+
+        # Return the response.
+        return response

--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -27,7 +27,6 @@ from nmdc_runtime.api.models.query import (
 )
 from nmdc_runtime.util import get_allowed_references, nmdc_schema_view
 
-
 logger = getLogger(__name__)
 
 
@@ -93,7 +92,9 @@ class MongoCommandProcessor:
         """Returns the names of all collections described by the NMDC Schema."""
         return get_collection_names_from_schema(schema_view=self.schema_view)
 
-    def _get_oids_of_specified_documents(self, delete_command: DeleteCommand) -> List[ObjectId]:
+    def _get_oids_of_specified_documents(
+        self, delete_command: DeleteCommand
+    ) -> List[ObjectId]:
         """
         Returns a sorted list of the `ObjectId`s (i.e. `_id` values) of the documents matching a
         given command, considering all of the command's constituent specifications.
@@ -144,16 +145,16 @@ class MongoCommandProcessor:
         return sorted(oids, key=str)
 
     def _identify_broken_references_deletion_would_leave_behind(
-            self,
-            collection_name: str,
-            target_document_oids: list[ObjectId],
-            stop_on_first: bool = False,
+        self,
+        collection_name: str,
+        target_document_oids: list[ObjectId],
+        stop_on_first: bool = False,
     ) -> list:
         """
         Identify documents that would remain after the deletion, which contain references to any of
         the documents that would be deleted. The `ObjectId`s of the documents that would be deleted
         are passed to this function via the `target_document_oids` parameter.
-        
+
         If `stop_on_first` is `True`, the function will stop checking after it finds a single such
         document that would be left behind (this will decrease return times since the function won't
         have to continue looking for additional such documents).
@@ -202,7 +203,9 @@ class MongoCommandProcessor:
                         source_document_id=rdd["source_document_id"],
                         target_document_id=target_document_descriptor["id"],
                     )
-                    descriptors_of_broken_references.append(descriptor_of_broken_reference)
+                    descriptors_of_broken_references.append(
+                        descriptor_of_broken_reference
+                    )
 
                     # If the caller opted to stop after identifying the first reference that would
                     # be broken, stop iterating now.
@@ -228,7 +231,9 @@ class MongoCommandProcessor:
         raw_response = self.db.command(command=mongo_command_document)
         return CountCommandResponse(**raw_response)
 
-    def _process_collstats_command(self, command: CollStatsCommand) -> CollStatsCommandResponse:
+    def _process_collstats_command(
+        self, command: CollStatsCommand
+    ) -> CollStatsCommandResponse:
         """
         Process a MongoDB `collStats` command.
 
@@ -268,12 +273,18 @@ class MongoCommandProcessor:
 
         # Insert each of those documents into the deletion archive database (e.g. "nmdc_deleted").
         deleted_at = now()  # they'll all have the same `deleted_at` timestamp.
-        deletion_archive_db = self.db.client.get_database(self.DELETION_ARCHIVE_DATABASE_NAME)
-        deletion_archive_collection = deletion_archive_db.get_collection(collection_name)
+        deletion_archive_db = self.db.client.get_database(
+            self.DELETION_ARCHIVE_DATABASE_NAME
+        )
+        deletion_archive_collection = deletion_archive_db.get_collection(
+            collection_name
+        )
         documents_to_back_up = []
         for doc in target_documents_cursor:
             documents_to_back_up.append(dict(doc=doc, deleted_at=deleted_at))
-        insert_many_result = deletion_archive_collection.insert_many(documents_to_back_up)
+        insert_many_result = deletion_archive_collection.insert_many(
+            documents_to_back_up
+        )
 
         # If we didn't back up all of the documents, raise an exception.
         # TODO: Consider delegating the reporting that "no documents have been deleted" to the
@@ -303,7 +314,7 @@ class MongoCommandProcessor:
         >>> id_.startswith("20")
         True
         """
-        timestamp: str = now().strftime('%Y%m%d%H%M%S')
+        timestamp: str = now().strftime("%Y%m%d%H%M%S")
         uuid_ = str(uuid.uuid4())
         return f"{timestamp}-{uuid_}"
 
@@ -331,10 +342,12 @@ class MongoCommandProcessor:
 
         # Determine whether any documents that reference those documents would be left behind
         # if the deletion were to be performed.
-        referrers_left_behind = self._identify_broken_references_deletion_would_leave_behind(
-            collection_name=collection_name,
-            target_document_oids=target_document_oids,
-            stop_on_first=True,
+        referrers_left_behind = (
+            self._identify_broken_references_deletion_would_leave_behind(
+                collection_name=collection_name,
+                target_document_oids=target_document_oids,
+                stop_on_first=True,
+            )
         )
 
         # Check how many documents containing broken references the deletion would leave behind.
@@ -393,7 +406,9 @@ class MongoCommandProcessor:
         response = DeleteCommandResponse(**raw_response)
         if isinstance(response.writeErrors, list) and len(response.writeErrors) > 0:
             event_id = self._generate_user_facing_event_id()
-            logger.error(f"An error(s) occurred while deleting documents. Event ID: {event_id}")
+            logger.error(
+                f"An error(s) occurred while deleting documents. Event ID: {event_id}"
+            )
             logger.error(response.writeErrors)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -402,7 +417,7 @@ class MongoCommandProcessor:
                     f"an administrator of this application, referencing system event '{event_id}'. "
                 ),
             )
-    
+
         return response
 
     def process(self, command: MongoCommand) -> MongoCommandResponse:
@@ -426,7 +441,7 @@ class MongoCommandProcessor:
             if response.n == 0:
                 raise HTTPException(
                     status_code=status.HTTP_418_IM_A_TEAPOT,
-                    detail="No documents were deleted. Check the syntax of your request."
+                    detail="No documents were deleted. Check the syntax of your request.",
                 )
 
         # Return the response.

--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -206,8 +206,8 @@ class MongoCommandProcessor:
                 source_document_oid = rdd["source_document_object_id"]
                 source_collection_name = rdd["source_collection_name"]
                 if not (
-                    source_collection_name == collection_name and
-                    source_document_oid in target_document_oids_set
+                    source_collection_name == collection_name
+                    and source_document_oid in target_document_oids_set
                 ):
                     descriptor_of_broken_reference = dict(
                         source_collection_name=rdd["source_collection_name"],
@@ -300,7 +300,9 @@ class MongoCommandProcessor:
         )
         documents_to_back_up = []
         for target_document in target_documents_cursor:
-            documents_to_back_up.append(dict(doc=target_document, deleted_at=deleted_at))
+            documents_to_back_up.append(
+                dict(doc=target_document, deleted_at=deleted_at)
+            )
 
         if len(documents_to_back_up) < len(target_document_oids):
             logger.warning(
@@ -309,7 +311,9 @@ class MongoCommandProcessor:
             )
 
         if len(documents_to_back_up) > 0:
-            insert_many_result = deletion_archive_collection.insert_many(documents_to_back_up)
+            insert_many_result = deletion_archive_collection.insert_many(
+                documents_to_back_up
+            )
 
             # If we didn't back up all of the documents we found, raise an exception.
             # TODO: Consider delegating the reporting that "no documents have been deleted" to the
@@ -473,19 +477,21 @@ class MongoCommandProcessor:
         elif isinstance(command, CollStatsCommand):
             response = self._process_collstats_command(command)
         elif isinstance(command, DeleteCommand):
-            response = self._process_delete_command(command, allow_broken_refs=allow_broken_refs)
+            response = self._process_delete_command(
+                command, allow_broken_refs=allow_broken_refs
+            )
 
             # If no documents were deleted, the user might have made a mistake. In that case,
             # we return an error response as a courtesy.
             if response.n == 0:
                 raise HTTPException(
                     status_code=status.HTTP_418_IM_A_TEAPOT,
-                    detail="No documents were deleted. Check the syntax of your request."
+                    detail="No documents were deleted. Check the syntax of your request.",
                 )
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unsupported command: {command}"
+                detail=f"Unsupported command: {command}",
             )
 
         # Return the response.

--- a/nmdc_runtime/lib/mongo_command_processor.py
+++ b/nmdc_runtime/lib/mongo_command_processor.py
@@ -1,8 +1,9 @@
 from json import dumps
 from logging import getLogger
-from typing import Any
+from typing import Any, List
 import uuid
 
+from bson import ObjectId
 from bson.json_util import loads
 from fastapi import HTTPException, status
 from pymongo.database import Database
@@ -90,6 +91,56 @@ class MongoCommandProcessor:
     def _get_nmdc_schema_collection_names(self) -> list[str]:
         """Returns the names of all collections described by the NMDC Schema."""
         return get_collection_names_from_schema(schema_view=self.schema_view)
+
+    def _get_oids_of_specified_documents(self, delete_command: DeleteCommand) -> List[ObjectId]:
+        """
+        Returns a sorted list of the `ObjectId`s (i.e. `_id` values) of the documents matching a
+        given command, considering all of the command's constituent specifications.
+
+        Note: For commands that contain more than one specification, we process each specification
+              against the _same_ source data; instead of trying to simulate the effects of executing
+              the command with its earlier specifications (such as deletions or specifications that
+              contain a "limit") before executing it with its later specifications.
+
+        >>> # Seed the mock database:
+        >>> from mongomock import MongoClient
+        >>> db = MongoClient().nmdc
+        >>> _ = db.food_set.insert_many([
+        ...     {"_id": ObjectId("000000000000000000000001"), "name": "apple"},
+        ...     {"_id": ObjectId("000000000000000000000002"), "name": "banana"},
+        ...     {"_id": ObjectId("000000000000000000000003"), "name": "carrot"},
+        ...     {"_id": ObjectId("000000000000000000000004"), "name": "daikon"},
+        ... ])
+
+        1. The result is de-duplicated.
+        >>> command = DeleteCommand(delete="food_set", deletes=[
+        ...     {"q": {"name": {"$in": ["apple", "banana"]}}, "limit": 0},  # 1 and 2
+        ...     {"q": {"name": "apple"}, "limit": 0},                       # 1 again
+        ...     {"q": {"name": "daikon"}, "limit": 0},                      # 4
+        ... ])
+        >>> MongoCommandProcessor(db)._get_oids_of_specified_documents(command)
+        [ObjectId('000000000000000000000001'), ObjectId('000000000000000000000002'), ObjectId('000000000000000000000004')]
+
+        2. The "limit" gets applied, but we don't know which document Mongo will pick.
+        >>> command = DeleteCommand(delete="food_set", deletes=[
+        ...     {"q": {"name": {"$in": ["apple", "banana"]}}, "limit": 1},  # 1 or 2, we don't know
+        ... ])
+        >>> oids = MongoCommandProcessor(db)._get_oids_of_specified_documents(command)
+        >>> len(oids)
+        1
+        >>> any([ObjectId('000000000000000000000001') in oids, ObjectId('000000000000000000000002') in oids])
+        True
+        """
+        oids: set[ObjectId] = set()
+
+        collection = self.db.get_collection(delete_command.delete)
+        delete_specs: DeleteSpecs = derive_delete_specs(delete_command=delete_command)
+        for spec in delete_specs:
+            options = {**spec, "projection": {"_id": 1}}
+            oids_from_spec = [doc["_id"] for doc in collection.find(**options)]
+            oids.update(oids_from_spec)
+
+        return sorted(oids, key=str)
 
     def _identify_broken_references_deletion_would_leave_behind(
             self,


### PR DESCRIPTION
> [!NOTE]
> This PR is under construction.

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 1. Summary (required)                                                   │
    │                                                                         │
    │ Summarize the changes you made on this branch. This is typically a more │
    │ detailed restatement of the PR title.                                   │
    │                                                                         │
    │ Example: "On this branch, I updated the `/studies/{study_id}` endpoint  │
    │           so it returns an HTTP 404 response when the specified study   │
    │           does not exist."                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

On this branch, I...

### Details

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 2. Details (optional)                                                   │
    │                                                                         │
    │ Provide additional information you think readers will find useful.      │
    │ Readers include PR reviewers, release note authors, app debuggers, and  │
    │ your future self. Additional information might include motivation,      │
    │ rationale, and a description of how things used to be.                  │
    │                                                                         │
    │ Example: "It previously returned an HTTP 404 response and an empty      │
    │           JSON object."                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

...

### Related issue(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 3. Related issue(s) (optional)                                          │
    │                                                                         │
    │ Link to any GitHub issue(s) this branch was designed to resolve.        │
    │                                                                         │
    │ Example: "Fixes #12345"                                                 │
    └─────────────────────────────────────────────────────────────────────────┘-->

...

### Related subsystem(s)

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 4. Related subsystem(s) (required)                                      │
    │                                                                         │
    │ Mark the checkbox next to each subsystem related to the changes in this │
    │ branch. This information might influence who you request reviews from.  │
    │                                                                         │
    │ Example: If you modified the `/studies/{study_id}` API endpoint,        │
    │          mark the checkbox next to "Runtime API (except the Minter)".   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Runtime API (except the Minter)
- [ ] Minter
- [ ] Dagster
- [ ] Project documentation (in the `docs` directory)
- [ ] Translators (metadata ingest pipelines)
- [ ] MongoDB migrations
- [ ] Other

### Testing

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 5. Testing (required)                                                   │
    │                                                                         │
    │ Indicate whether you have already tested the changes this branch        │
    │ contains; and, if so, how someone other than you can test them. That    │
    │ may involve attaching example files or ad hoc test instructions.        │
    │                                                                         │
    │ Example: "I tested these changes by adding a pytest test that ensures   │
    │           the database does not contain a Study whose ID is `foo`,      │
    │           then submits an HTTP request to `/studies/foo` and confirms   │
    │           the response status is 404."                                  │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I tested these changes (explain below)
- [ ] I did not test these changes

I tested these changes by...

### Documentation

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 6. Documentation (required)                                             │
    │                                                                         │
    │ Indicate whether, in this branch, you have updated all documentation    │
    │ that would otherwise become inaccurate if this branch were to be        │
    │ merged in.                                                              │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] I **have not checked** for relevant documentation yet (e.g. in the `docs` directory)
- [ ] I have **updated** all relevant documentation so it will remain accurate
- [ ] Other (explain below)

### Maintainability

<!--┌─────────────────────────────────────────────────────────────────────────┐
    │ 7. Maintainability (required)                                           │
    │                                                                         │
    │ Indicate whether you have done each of these things that can make code  │
    │ easier to maintain, whether by your teammates or by your future self.   │
    └─────────────────────────────────────────────────────────────────────────┘-->

- [ ] Every Python function I defined includes a docstring _(test functions are exempt from this)_
- [ ] Every Python function parameter I introduced includes a type hint (e.g. `study_id: str`)
- [ ] All "to do" or "fix me" Python comments I added begin with either `# TODO` or `# FIXME`
- [ ] I used `black` to format all the Python files I created/modified
- [ ] The PR title is in the imperative mood (e.g. "Do X") and not the declarative mood (e.g. "Does X" or "Did X")
